### PR TITLE
add skeleton code for Gatekeeper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dpdk"]
+	path = dpdk
+	url = https://github.com/cjdoucette/dpdk

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ $(error "Please define RTE_SDK environment variable.")
 endif
 
 RTE_TARGET ?= x86_64-native-linuxapp-gcc
+GATEKEEPER := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 include $(RTE_SDK)/mk/rte.vars.mk
 
@@ -15,7 +16,21 @@ APP = gatekeeper
 
 SRCS-y := main/main.c
 
-CFLAGS += $(WERROR_FLAGS)
+# Functional blocks.
+SRCS-y += arp/main.c
+SRCS-y += bp/main.c
+SRCS-y += catcher/main.c
+SRCS-y += config/static.c config/dynamic.c
+SRCS-y += cps/main.c
+SRCS-y += ggu/main.c
+SRCS-y += gk/main.c
+SRCS-y += gt/main.c
+SRCS-y += rt/main.c
+
+# Libraries.
+SRCS-y += lib/mailbox.c
+
+CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include
 EXTRA_CFLAGS += -O3 -g -Wfatal-errors
 
 include $(RTE_SDK)/mk/rte.extapp.mk

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# XXX This Makefile (in combination with the DPDK Makefiles) does
+# not recognize when a file has changed and re-compilation is
+# needed -- you need to explicitly do `make clean`. We probably
+# need to add a directive to look in the subdirectories.
+
+ifeq ($(RTE_SDK),)
+$(error "Please define RTE_SDK environment variable.")
+endif
+
+RTE_TARGET ?= x86_64-native-linuxapp-gcc
+
+include $(RTE_SDK)/mk/rte.vars.mk
+
+APP = gatekeeper
+
+SRCS-y := main/main.c
+
+CFLAGS += $(WERROR_FLAGS)
+EXTRA_CFLAGS += -O3 -g -Wfatal-errors
+
+include $(RTE_SDK)/mk/rte.extapp.mk

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Gatekeeper
+
+## How to Set Up
+
+### Install and Configure Dependencies
+
+Install the following software dependencies:
+
+    $ sudo apt-get update
+    $ sudo apt-get -y -q install git clang doxygen hugepages build-essential linux-headers-`uname -r`
+
+To use DPDK, make sure you have all of the environmental requirements: <http://dpdk.org/doc/guides/linux_gsg/sys_reqs.html#running-dpdk-applications>.
+
+Note that DPDK requires the use of hugepages; instructions for mounting hugepages are available in the link above.
+
+Once the software dependencies have been installed and the hugepages have been configured, you are ready to build `gatekeeper`.
+
+### Obtain Source
+
+Upon cloning the `gatekeeper` repository, change directory to the `dpdk` submodule and initialize it:
+
+    $ cd dpdk
+    $ git submodule init
+    $ git submodule update
+
+(Note: these initialization steps are not needed if you clone the `gatekeeper` repository using `git clone --recursive ...`.)
+
+### Compile
+
+While in the `gatekeeper` directory, run the setup script:
+
+    $ sudo ./setup.sh
+
+This script compiles DPDK and loads the needed kernel modules.
+
+Once DPDK is compiled, `gatekeeper` can be compiled:
+
+    $ make
+
+### Configure Network Adapters
+
+Before `gatekeeper` can be used, the network adapters must be bound to DPDK. For this, you can use the script `dpdk/tools/dpdk_nic_bind.py`. For example:
+
+    $ dpdk/tools/dpdk_nic_bind.py --bind=uio_pci_generic enp131s0f0
+
+This command binds the interface `enp131s0f0` to the `uio_pci_generic` driver so that frames can be passed directly to DPDK instead of the kernel.
+
+## How to Run
+
+Once `gatekeeper` is compiled and the environment is configured correctly, run:
+
+    $ sudo ./build/gatekeeper

--- a/arp/main.c
+++ b/arp/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_arp.h"
+
+int
+run_arp(void)
+{
+	/* TODO Initialize and run ARP functional block. */
+	return 0;
+}

--- a/bp/main.c
+++ b/bp/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_bp.h"
+
+int
+run_bp(void)
+{
+	/* TODO Initialize and run BP functional block. */
+	return 0;
+}

--- a/catcher/main.c
+++ b/catcher/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_catcher.h"
+
+int
+run_catcher(void)
+{
+	/* TODO Initialize and run Catcher functional block. */
+	return 0;
+}

--- a/config/dynamic.c
+++ b/config/dynamic.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_config.h"
+
+int
+run_dynamic_config(void)
+{
+	/* TODO Initialize and run Dynamic Config functional block. */
+	return 0;
+}

--- a/config/static.c
+++ b/config/static.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_config.h"
+
+int
+get_static_config(void)
+{
+	/* TODO Read in and report static configuration files. */
+	return 0;
+}

--- a/cps/main.c
+++ b/cps/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_cps.h"
+
+int
+run_cps(void)
+{
+	/* TODO Initialize and run Control Plane Support functional block. */
+	return 0;
+}

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_ggu.h"
+
+int
+run_ggu(void)
+{
+	/* TODO Initialize and run GK-GT Unit functional block. */
+	return 0;
+}

--- a/gk/main.c
+++ b/gk/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_gk.h"
+
+int
+run_gk(void)
+{
+	/* TODO Initialize and run GK functional block. */
+	return 0;
+}

--- a/gt/main.c
+++ b/gt/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_gt.h"
+
+int
+run_gt(void)
+{
+	/* TODO Initialize and run GT functional block. */
+	return 0;
+}

--- a/include/gatekeeper_arp.h
+++ b/include/gatekeeper_arp.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_ARP_H_
+#define _GATEKEEPER_ARP_H_
+
+int run_arp(void);
+
+#endif /* _GATEKEEPER_ARP_H_ */

--- a/include/gatekeeper_bp.h
+++ b/include/gatekeeper_bp.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_BP_H_
+#define _GATEKEEPER_BP_H_
+
+int run_bp(void);
+
+#endif /* _GATEKEEPER_BP_H_ */

--- a/include/gatekeeper_catcher.h
+++ b/include/gatekeeper_catcher.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_CATCHER_H_
+#define _GATEKEEPER_CATCHER_H_
+
+int run_catcher(void);
+
+#endif /* _GATEKEEPER_CATCHER_H_ */

--- a/include/gatekeeper_config.h
+++ b/include/gatekeeper_config.h
@@ -1,0 +1,8 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_CONFIG_H_
+#define _GATEKEEPER_CONFIG_H_
+
+int get_static_config(void);
+int run_dynamic_config(void);
+
+#endif /* _GATEKEEPER_CONFIG_H_ */

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_CPS_H_
+#define _GATEKEEPER_CPS_H_
+
+int run_cps(void);
+
+#endif /* _GATEKEEPER_CPS_H_ */

--- a/include/gatekeeper_ggu.h
+++ b/include/gatekeeper_ggu.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_GGU_H_
+#define _GATEKEEPER_GGU_H_
+
+int run_ggu(void);
+
+#endif /* _GATEKEEPER_GGU_H_ */

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_GK_H_
+#define _GATEKEEPER_GK_H_
+
+int run_gk(void);
+
+#endif /* _GATEKEEPER_GK_H_ */

--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_GT_H_
+#define _GATEKEEPER_GT_H_
+
+int run_gt(void);
+
+#endif /* _GATEKEEPER_GT_H_ */

--- a/include/gatekeeper_mailbox.h
+++ b/include/gatekeeper_mailbox.h
@@ -1,0 +1,15 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_MAILBOX_H_
+#define _GATEKEEPER_MAILBOX_H_
+
+/*
+ * TODO Remove this preprocessing directive when there are
+ * are calls to these functions; for now, the mailbox is
+ * just an example of how to set up a library.
+ */
+#if 0
+void create_mailbox(void);
+void destroy_mailbox(void);
+#endif
+
+#endif /* _GATEKEEPER_MAILBOX_H_ */

--- a/include/gatekeeper_rt.h
+++ b/include/gatekeeper_rt.h
@@ -1,0 +1,7 @@
+/* XXX Which license should be placed here? */
+#ifndef _GATEKEEPER_RT_H_
+#define _GATEKEEPER_RT_H_
+
+int run_rt(void);
+
+#endif /* _GATEKEEPER_RT_H_ */

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -1,0 +1,24 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_mailbox.h"
+
+/*
+ * TODO Remove this preprocessing directive when there are
+ * are calls to these functions; for now, the mailbox is
+ * just an example of how to set up a library.
+ */
+#if 0
+void
+create_mailbox(void)
+{
+	/* TODO Write mailbox creation function. */
+	return;
+}
+
+void
+destroy_mailbox(void)
+{
+	/* TODO Write mailbox destroy function. */
+	return;
+}
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -4,10 +4,134 @@
 
 #include <rte_eal.h>
 
+#include "gatekeeper_arp.h"
+#include "gatekeeper_bp.h"
+#include "gatekeeper_catcher.h"
+#include "gatekeeper_config.h"
+#include "gatekeeper_cps.h"
+#include "gatekeeper_ggu.h"
+#include "gatekeeper_gk.h"
+#include "gatekeeper_gt.h"
+#include "gatekeeper_rt.h"
+
+#include "gatekeeper_mailbox.h"
+
 int
 main(int argc, char **argv)
 {
 	int ret = rte_eal_init(argc, argv);
 	printf("EAL initialization: %d\n", ret);
-	return 0;
+
+	/*
+	 * TODO Add configuration state that can be written by this
+	 * function, so its information can be used to call the
+	 * functional blocks below.
+	 */
+	ret = get_static_config();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Set up shared state (such as mailboxes) and figure out
+	 * how to pass that information to the functional blocks that
+	 * need it.
+	 */
+
+	/*
+	 * TODO Decide whether this instance of the application is
+	 * running GK or GT and adjust which functional blocks are
+	 * invoked accordingly.
+	 */
+
+	/*
+	 * TODO Each of the calls below to a functional block should
+	 * be spun out of its own lcore (or set of lcores).
+	 */
+
+	/*
+	 * TODO Decide which lcore will be assigned to ARP and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_arp();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to BP and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_bp();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore will be assigned to Catcher and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_catcher();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore will be assigned to Dynamic Config and
+	 * decide what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_dynamic_config();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore will be assigned to Control Plane Support
+	 * and decide what other configuration information should be passed
+	 * to this functional block.
+	 */
+	ret = run_cps();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore will be assigned to GK-GT Unit and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_ggu();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to GK and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_gk();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to GT and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_gt();
+	if (ret < 0)
+		goto out;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to RT and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_rt();
+
+out:
+	/*
+	 * TODO Perform any needed state destruction, stop lcores if one
+	 * of the functions returned with an error, etc.
+	 */
+
+	return ret;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,13 @@
+/* XXX Which license should be placed here? */
+
+#include <stdio.h>
+
+#include <rte_eal.h>
+
+int
+main(int argc, char **argv)
+{
+	int ret = rte_eal_init(argc, argv);
+	printf("EAL initialization: %d\n", ret);
+	return 0;
+}

--- a/rt/main.c
+++ b/rt/main.c
@@ -1,0 +1,10 @@
+/* XXX Which license should be placed here? */
+
+#include "gatekeeper_rt.h"
+
+int
+run_rt(void)
+{
+	/* TODO Initialize and run RT functional block. */
+	return 0;
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,25 @@
+cd dpdk
+
+# Path to the build directory.
+export RTE_SDK=`pwd`
+
+# Target of build process.
+export RTE_TARGET=x86_64-native-linuxapp-gcc
+
+# Configure and build.
+make config T=${RTE_TARGET}
+make
+
+# Install kernel modules.
+sudo modprobe uio
+sudo modprobe uio_pci_generic
+sudo insmod ${RTE_SDK}/build/kmod/igb_uio.ko
+
+# Make modules persist across reboots.
+sudo ln -s ${RTE_SDK}/build/kmod/igb_uio.ko /lib/modules/`uname -r`
+sudo depmod -a
+sudo echo "uio" | sudo tee -a /etc/modules
+sudo echo "uio_pci_generic" | sudo tee -a /etc/modules
+sudo echo "igb_uio" | sudo tee -a /etc/modules
+
+ln -s ${RTE_SDK}/build ${RTE_SDK}/${RTE_TARGET}


### PR DESCRIPTION
These patches add the setup script and Makefile for Gatekeeper so that it is compiled with the DPDK libraries. It also adds a directory structure for the project -- one directory for each functional block, along with lib and include directories.

The entry point to the Gatekeeper program, in main/main.c, for now simply initializes the EAL to show interoperation with DPDK, and also invokes each functional block, which are at this point empty.

There are some other TODO tags added, such as to read in any configuration, set up shared state such as mailboxes, and figure out whether the instance of the program is running the Gatekeeper or Grantor algorithm. More specific TODOs should be added in future patches.

This is also a good time to change the directory structure, naming, etc.