### PR TITLE
add fixes for README and setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ While in the `gatekeeper` directory, run the setup script:
 
     $ sudo ./setup.sh
 
-This script compiles DPDK and loads the needed kernel modules.
+This script compiles DPDK and loads the needed kernel modules. It also sets two environmental variables: `RTE_SDK` and `RTE_TARGET`. They must be set before `gatekeeper` will compile. After running the setup script, you may want to save the environmental variables in your shell's preferences file. For example, in Bash, you can do:
 
-Once DPDK is compiled, `gatekeeper` can be compiled:
+    $ echo "export RTE_SDK=${RTE_SDK}" >> ${HOME}/.profile
+    $ echo "export RTE_TARGET=${RTE_TARGET}" >> ${HOME}/.profile
+
+Otherwise, each time you login you will need to set these environmental variables again.
+
+Once DPDK is compiled and the variables are set, `gatekeeper` can be compiled:
 
     $ make
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Once DPDK is compiled, `gatekeeper` can be compiled:
 
 ### Configure Network Adapters
 
-Before `gatekeeper` can be used, the network adapters must be bound to DPDK. For this, you can use the script `dpdk/tools/dpdk_nic_bind.py`. For example:
+Before `gatekeeper` can be used, the network adapters must be bound to DPDK. For this, you can use the script `dpdk/tools/dpdk-devbind.py`. For example:
 
     $ sudo dpdk/tools/dpdk-devbind.py --bind=uio_pci_generic enp131s0f0
 

--- a/setup.sh
+++ b/setup.sh
@@ -41,3 +41,5 @@ sudo echo "igb_uio" | sudo tee -a /etc/modules
 ln -s ${RTE_SDK}/build ${RTE_SDK}/${RTE_TARGET}
 
 cd ..
+
+echo "Environmental variables RTE_SDK and RTE_TARGET have been set, but not saved for future logins. You should save them to your shell's preferences file or set them after every login."


### PR DESCRIPTION
These patches update a file name and give more information about how to set the environmental variables that are required for compiling DPDK applications.