### PR TITLE
add support for initializing the NICs, and a simple GK block example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ SRCS-y += gt/main.c
 SRCS-y += rt/main.c
 
 # Libraries.
-SRCS-y += lib/mailbox.c
+SRCS-y += lib/mailbox.c lib/net.c
 
 CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include
 EXTRA_CFLAGS += -O3 -g -Wfatal-errors

--- a/gk/main.c
+++ b/gk/main.c
@@ -16,11 +16,82 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <rte_log.h>
+#include <rte_lcore.h>
+#include <rte_ethdev.h>
+
 #include "gatekeeper_gk.h"
+#include "gatekeeper_main.h"
+#include "gatekeeper_config.h"
+
+/*
+ * Define the custom log type for GK functional block,
+ * which is used to generate logs for GK block.
+ */
+#define RTE_LOGTYPE_GK RTE_LOGTYPE_USER1
+
+#define GATEKEEPER_MAX_PKT_BURST (32)
+
+static int
+gk_proc(__attribute__((unused)) void *arg)
+{
+	/* TODO Implement the basic algorithm of a GK block. */
+
+	uint32_t lcore = rte_lcore_id();
+
+	RTE_LOG(NOTICE, GK, "The GK block is running at lcore = %u\n", lcore);
+
+	while (likely(!exiting)) {
+		/* 
+		 * XXX Sample setting for test only.
+		 * 
+		 * Here, just use two ports (0, 1) and 1 queue (0) for test.
+		 *
+		 * Port and queue identifiers should be changed 
+		 * according to configuration.
+		 */
+
+		/* Get burst of RX packets, from first port of pair. */
+		uint16_t num_rx;
+		uint16_t num_tx;
+		struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
+
+		num_rx = rte_eth_rx_burst(0, 0, bufs, GATEKEEPER_MAX_PKT_BURST);
+
+		if (unlikely(num_rx == 0))
+			continue;
+
+		/* Send burst of TX packets, to second port of pair. */
+		num_tx = rte_eth_tx_burst(1, 0, bufs, num_rx);
+
+		/* Free any unsent packets. */
+		if (unlikely(num_tx < num_rx)) {
+			int i;
+			for (i = num_tx; i < num_rx; i++)
+				rte_pktmbuf_free(bufs[i]);
+		}
+	}
+
+	RTE_LOG(NOTICE, GK, "The GK block at lcore = %u is exiting\n", lcore);
+
+	return 0;
+}
 
 int
 run_gk(void)
 {
 	/* TODO Initialize and run GK functional block. */
+
+	int i;
+	/*
+	 * XXX Sample configuration for test only.
+	 * The real configuration should come from the configuration step.
+	 */
+	const int lcore_start_id = 1;
+	const int lcore_end_id = 1;
+
+	for (i = lcore_start_id; i <= lcore_end_id; i++)
+		rte_eal_remote_launch(gk_proc, NULL, i);
+
 	return 0;
 }

--- a/include/gatekeeper_config.h
+++ b/include/gatekeeper_config.h
@@ -19,6 +19,65 @@
 #ifndef _GATEKEEPER_CONFIG_H_
 #define _GATEKEEPER_CONFIG_H_
 
+/* 
+ * XXX Sample parameters for test only. 
+ * They should be configured in the configuration step.
+ */
+#define GATEKEEPER_MAX_PORTS	(2)
+#define GATEKEEPER_MAX_QUEUES	(4)
+#define GATEKEEPER_MAX_NUMA_NODES (2)
+
+/*
+ * XXX Sample parameters for test only.
+ * They should be analyzed or tested further to find optimal values.
+ *
+ * Larger queue size can mitigate bursty behavior, but can also increase 
+ * pressure on cache and lead to lower performance.
+ */
+#define GATEKEEPER_NUM_RX_DESC	(128)
+#define GATEKEEPER_NUM_TX_DESC	(512)
+
+/* 
+ * XXX Sample parameter for the number of elements in the mbuf pool.
+ * This should be analyzed or tested further to find optimal value.
+ *
+ * The optimum size (in terms of memory usage) for a mempool is when it is a 
+ * power of two minus one.
+ *
+ * Need to provision enough memory for the worst case,
+ * since each queue needs at least
+ * GATEKEEPER_NUM_RX_DESC + GATEKEEPER_NUM_TX_DESC + GATEKEEPER_MAX_PKT_BURST
+ * descriptors. i.e., GATEKEEPER_DESC_PER_QUEUE =
+ * (GATEKEEPER_NUM_RX_DESC + GATEKEEPER_NUM_TX_DESC \
+ *		+ GATEKEEPER_MAX_PKT_BURST (let's say 32)) = 672.
+ *
+ * So, the pool size should be at least the maximum number of queues * 
+ *		number of descriptors per queue, i.e., 
+ * (GATEKEEPER_MAX_PORTS * GATEKEEPER_MAX_QUEUES * \
+ *              GATEKEEPER_DESC_PER_QUEUE - 1) = 5376.
+ */
+#define GATEKEEPER_MBUF_SIZE (8191)
+
+/* 
+ * XXX Sample parameter for the size of the per-core object cache, 
+ * i.e., number of struct rte_mbuf elements in the per-core object cache.
+ * this should be analyzed or tested further to find optimal value.
+ *
+ * Each core deals with at most GATEKEEPER_MAX_PORTS queues, so the cache size
+ * should be at least (number of ports * number of descriptors per queue), i.e.,
+ * (GATEKEEPER_MAX_PORTS * GATEKEEPER_DESC_PER_QUEUE).
+ * 
+ * Notice that, this argument must be lower or equal to 
+ * CONFIG_RTE_MEMPOOL_CACHE_MAX_SIZE and n / 1.5. 
+ * It is advised to choose cache_size to have "n modulo cache_size == 0": 
+ * if this is not the case, some elements will always stay in the pool 
+ * and will never be used. Here, n is GATEKEEPER_MBUF_SIZE.
+ *
+ * The maximum cache size can be adjusted in DPDK's .config file: 
+ * CONFIG_RTE_MEMPOOL_CACHE_MAX_SIZE.
+ */
+#define GATEKEEPER_CACHE_SIZE	(512)
+
 int get_static_config(void);
 int run_dynamic_config(void);
 

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -1,0 +1,24 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_MAIN_H_
+#define _GATEKEEPER_MAIN_H_
+
+extern volatile int exiting;
+
+#endif /* _GATEKEEPER_MAIN_H_ */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -1,0 +1,26 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_NET_H_
+#define _GATEKEEPER_NET_H_
+
+int gatekeeper_init_network(void);
+
+void gatekeeper_free_network(void);
+
+#endif /* _GATEKEEPER_NET_H_ */

--- a/lib/net.c
+++ b/lib/net.c
@@ -1,0 +1,205 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+#include <rte_mbuf.h>
+#include <rte_errno.h>
+#include <rte_lcore.h>
+#include <rte_debug.h>
+#include <rte_ethdev.h>
+
+#include "gatekeeper_net.h"
+#include "gatekeeper_config.h"
+
+/* 
+ * Parameters will be detected automatically. 
+ */
+static uint32_t num_ports;
+
+static struct rte_mempool *gatekeeper_pktmbuf_pool[GATEKEEPER_MAX_NUMA_NODES];
+
+/* TODO Implement the configuration for Flow Director, RSS, and Filters. */
+static struct rte_eth_conf gatekeeper_port_conf = {
+	.rxmode = { .max_rx_pkt_len = ETHER_MAX_LEN, },
+};
+
+static int
+find_num_numa_nodes(void)
+{
+	int i;
+	int nb_numa_nodes = 0;
+	int nb_lcores = rte_lcore_count();
+
+	for (i = 0; i < nb_lcores; i++) {
+		uint32_t socket_id;
+		socket_id = rte_lcore_to_socket_id(i);
+		if ((uint32_t)nb_numa_nodes <= socket_id)
+			nb_numa_nodes = socket_id + 1;
+	}
+	
+	return nb_numa_nodes;
+}
+
+static void
+close_num_ports(uint8_t nb_ports)
+{
+	uint8_t port_id;
+
+	for (port_id = 0; port_id < nb_ports; port_id++) {
+		rte_eth_dev_stop(port_id);
+		rte_eth_dev_close(port_id);
+	}
+}
+
+/* Initialize the network. */
+int
+gatekeeper_init_network(void)
+{
+	int i;
+	int ret = -1;
+	uint8_t port_id;
+	int num_numa_nodes = 0;
+	uint8_t num_succ_ports = 0;
+	uint32_t num_lcores = 0;
+
+	/* 
+ 	 * XXX Sample parameters for test only. 
+ 	 */
+	const uint32_t num_rx_queues = 1;
+	const uint32_t num_tx_queues = 1;
+
+	num_lcores = rte_lcore_count();
+	
+	RTE_ASSERT(num_rx_queues <= GATEKEEPER_MAX_QUEUES);
+	RTE_ASSERT(num_tx_queues <= GATEKEEPER_MAX_QUEUES);
+
+	num_numa_nodes = find_num_numa_nodes();
+	RTE_ASSERT(num_numa_nodes <= GATEKEEPER_MAX_NUMA_NODES);
+
+	/* Initialize pktmbuf on each numa node. */
+	for (i = 0; i < num_numa_nodes; i++) {
+		char pool_name[64];
+
+		if (gatekeeper_pktmbuf_pool[i] != NULL)
+			continue;
+
+		RTE_ASSERT(snprintf(pool_name, sizeof(pool_name), "pktmbuf_pool_%u", i) < sizeof(pool_name));
+		gatekeeper_pktmbuf_pool[i] = rte_pktmbuf_pool_create(pool_name,
+                		GATEKEEPER_MBUF_SIZE, GATEKEEPER_CACHE_SIZE, 0,
+                		RTE_MBUF_DEFAULT_BUF_SIZE, (unsigned)i);
+
+		/* No cleanup for this step, since DPDK doesn't offer a way to deallocate pools. */
+		if (gatekeeper_pktmbuf_pool[i] == NULL) {
+			RTE_LOG(ERR, MEMPOOL, "Failed to allocate mbuf for numa node %u!\n", i);
+
+			if (rte_errno == E_RTE_NO_CONFIG) RTE_LOG(ERR, MEMPOOL, "Function could not get pointer to rte_config structure!\n");
+			else if (rte_errno == E_RTE_SECONDARY) RTE_LOG(ERR, MEMPOOL, "Function was called from a secondary process instance!\n");
+			else if (rte_errno == EINVAL) RTE_LOG(ERR, MEMPOOL, "Cache size provided is too large!\n");
+			else if (rte_errno == ENOSPC) RTE_LOG(ERR, MEMPOOL, "The maximum number of memzones has already been allocated!\n");
+			else if (rte_errno == EEXIST) RTE_LOG(ERR, MEMPOOL, "A memzone with the same name already exists!\n");
+			else if (rte_errno == ENOMEM) RTE_LOG(ERR, MEMPOOL, "No appropriate memory area found in which to create memzone!\n");
+			else RTE_LOG(ERR, MEMPOOL, "Unknown error!\n");
+
+			ret = -1;
+			goto out;
+		}
+	}
+
+	/* Check port limits. */
+	num_ports = rte_eth_dev_count();
+	RTE_ASSERT(num_ports != 0 && num_ports <= GATEKEEPER_MAX_PORTS);
+
+	/* Initialize ports. */
+	for (port_id = 0; port_id < num_ports; port_id++) {
+		uint32_t lcore;
+		struct rte_eth_link link;
+		
+		ret = rte_eth_dev_configure(port_id, num_rx_queues, num_tx_queues, 
+				&gatekeeper_port_conf);
+		if (ret < 0) {
+			RTE_LOG(ERR, PORT, "Failed to configure port %hhu (err=%d)!\n", port_id, ret);
+			goto port;
+		}
+
+		for (lcore = 0; lcore < num_lcores; lcore++) {
+			size_t numa_node;
+			
+			/* XXX Map queue = lcore, if necessary, change the queues mapping. */
+			uint16_t queue = (uint16_t)lcore;
+
+			/* XXX In case the number of lcores is greater than number of queues. */
+			if (lcore >= num_rx_queues || lcore >= num_tx_queues)
+				break;
+
+			numa_node = rte_lcore_to_socket_id(lcore);
+
+			ret = rte_eth_rx_queue_setup(port_id, queue, GATEKEEPER_NUM_RX_DESC, 
+					(unsigned int)numa_node, NULL, 
+					gatekeeper_pktmbuf_pool[numa_node]);
+			if (ret < 0) {
+				RTE_LOG(ERR, PORT, "Failed to configure port %hhu rx_queue %hu (err=%d)!\n",\
+					 port_id, queue, ret);
+				goto port;
+			}
+
+			ret = rte_eth_tx_queue_setup(port_id, queue, GATEKEEPER_NUM_TX_DESC, 
+					numa_node, NULL);
+			if (ret < 0) {
+				RTE_LOG(ERR, PORT, "Failed to configure port %hhu tx_queue %hu (err=%d)!\n",\
+					 port_id, queue, ret);
+				goto port;
+			}
+		}
+
+		/* Start device. */
+		ret = rte_eth_dev_start(port_id);
+		if (ret < 0) {
+			RTE_LOG(ERR, PORT, "Failed to start port %hhu (err=%d)!\n", port_id, ret);
+			goto port;
+		}
+		num_succ_ports++;
+		
+		/*
+		 * The following code ensures that the device is ready for full speed RX/TX.
+		 * When the initialization is done without this, the initial packet 
+		 * transmission may be blocked.
+		 */
+		rte_eth_link_get(port_id, &link);
+		if (!link.link_status) {
+			RTE_LOG(ERR, PORT, "Querying port %hhu, and link is down!\n", port_id);
+			ret = -1;
+			goto port;
+		}
+	}
+
+	/* TODO Configure the Flow Director, RSS, and Filters. */
+
+	goto out;
+
+port:
+	close_num_ports(num_succ_ports);
+out:
+	return ret;
+}
+
+void
+gatekeeper_free_network(void)
+{
+	close_num_ports(num_ports);
+}


### PR DESCRIPTION
These patches add the initialization of the ports, and they support for multiple numa nodes. Based on these patches, we can add new functional blocks, and test them using network traffic.

In addition, the patches add the skeleton of the static configuration. The basic idea is that we need to define different configuration data structures and functions for different functional blocks according to the configuration files. To map the functional blocks to lcores, and then queues, we may need to find a smarter way. Currently, the mapping is simply kept in the configuration data structure.

In the GK block example, the patches simply receive a batch of packets and then transmit them into the corresponding TX queues.