### PR TITLE
improve setup and flesh out configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ APP = gatekeeper
 SRCS-y := main/main.c
 
 # Functional blocks.
-SRCS-y += arp/main.c
 SRCS-y += bp/main.c
 SRCS-y += catcher/main.c
 SRCS-y += config/static.c config/dynamic.c
@@ -41,6 +40,7 @@ SRCS-y += cps/main.c
 SRCS-y += ggu/main.c
 SRCS-y += gk/main.c
 SRCS-y += gt/main.c
+SRCS-y += lls/main.c
 SRCS-y += rt/main.c
 
 # Libraries.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Upon cloning the `gatekeeper` repository, change directory to the `dpdk` submodu
 
 While in the `gatekeeper` directory, run the setup script:
 
-    $ sudo ./setup.sh
+    $ ./setup.sh
 
 This script compiles DPDK and loads the needed kernel modules. It also sets two environmental variables: `RTE_SDK` and `RTE_TARGET`. They must be set before `gatekeeper` will compile. After running the setup script, you may want to save the environmental variables in your shell's preferences file. For example, in Bash, you can do:
 

--- a/bp/main.c
+++ b/bp/main.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_bp.h"
 
 int
-run_bp(void)
+run_bp(__attribute__((unused)) const struct bp_config *bp_conf)
 {
 	/* TODO Initialize and run BP functional block. */
 	return 0;

--- a/catcher/main.c
+++ b/catcher/main.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_catcher.h"
 
 int
-run_catcher(void)
+run_catcher(__attribute__((unused)) const struct catcher_config *catcher_conf)
 {
 	/* TODO Initialize and run Catcher functional block. */
 	return 0;

--- a/config/dynamic.c
+++ b/config/dynamic.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_config.h"
 
 int
-run_dynamic_config(void)
+run_dynamic_config(__attribute__((unused)) const struct dynamic_config *dy_conf)
 {
 	/* TODO Initialize and run Dynamic Config functional block. */
 	return 0;

--- a/config/static.c
+++ b/config/static.c
@@ -16,11 +16,113 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "gatekeeper_bp.h"
+#include "gatekeeper_catcher.h"
 #include "gatekeeper_config.h"
+#include "gatekeeper_cps.h"
+#include "gatekeeper_ggu.h"
+#include "gatekeeper_gk.h"
+#include "gatekeeper_gt.h"
+#include "gatekeeper_lls.h"
+#include "gatekeeper_rt.h"
 
 int
-get_static_config(void)
+config_and_launch(void)
 {
-	/* TODO Read in and report static configuration files. */
-	return 0;
+	struct bp_config bp_conf;
+	struct catcher_config catcher_conf;
+	struct dynamic_config dy_conf;
+	struct cps_config cps_conf;
+	struct ggu_config ggu_conf;
+	struct gk_config gk_conf;
+	struct gt_config gt_conf;
+	struct rt_config rt_conf;
+	int ret;
+
+	/*
+	 * TODO Read in configuration file(s) using Lua and create
+	 * config structs for each functional block. Then launch
+	 * all functional blocks (with their config struct) that
+	 * are needed with their own lcore(s).
+	 */
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to BP and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_bp(&bp_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore will be assigned to Catcher and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_catcher(&catcher_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore will be assigned to Dynamic Config and
+	 * decide what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_dynamic_config(&dy_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore will be assigned to Control Plane Support
+	 * and decide what other configuration information should be passed
+	 * to this functional block.
+	 */
+	ret = run_cps(&cps_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore will be assigned to GK-GT Unit and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_ggu(&ggu_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to GK and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_gk(&gk_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to GT and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_gt(&gt_conf);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore will be assigned to LLS and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_lls();
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * TODO Decide which lcore*s* will be assigned to RT and decide
+	 * what other configuration information should be passed to
+	 * this functional block.
+	 */
+	ret = run_rt(&rt_conf);
+	return ret;
 }

--- a/cps/main.c
+++ b/cps/main.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_cps.h"
 
 int
-run_cps(void)
+run_cps(__attribute__((unused)) const struct cps_config *cps_conf)
 {
 	/* TODO Initialize and run Control Plane Support functional block. */
 	return 0;

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_ggu.h"
 
 int
-run_ggu(void)
+run_ggu(__attribute__((unused)) const struct ggu_config *ggu_conf)
 {
 	/* TODO Initialize and run GK-GT Unit functional block. */
 	return 0;

--- a/gk/main.c
+++ b/gk/main.c
@@ -78,20 +78,19 @@ gk_proc(__attribute__((unused)) void *arg)
 }
 
 int
-run_gk(void)
+run_gk(const struct gk_config *gk_conf)
 {
 	/* TODO Initialize and run GK functional block. */
 
-	int i;
-	/*
-	 * XXX Sample configuration for test only.
-	 * The real configuration should come from the configuration step.
-	 */
-	const int lcore_start_id = 1;
-	const int lcore_end_id = 1;
-
-	for (i = lcore_start_id; i <= lcore_end_id; i++)
-		rte_eal_remote_launch(gk_proc, NULL, i);
+	unsigned int i;
+	int ret;
+	for (i = gk_conf->lcore_start_id; i <= gk_conf->lcore_end_id; i++) {
+		ret = rte_eal_remote_launch(gk_proc, NULL, i);
+		if (ret) {
+			RTE_LOG(ERR, EAL, "lcore %u failed to launch GK\n", i);
+			return ret;
+		}
+	}
 
 	return 0;
 }

--- a/gt/main.c
+++ b/gt/main.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_gt.h"
 
 int
-run_gt(void)
+run_gt(__attribute__((unused)) const struct gt_config *gt_conf)
 {
 	/* TODO Initialize and run GT functional block. */
 	return 0;

--- a/include/gatekeeper_bp.h
+++ b/include/gatekeeper_bp.h
@@ -19,6 +19,12 @@
 #ifndef _GATEKEEPER_BP_H_
 #define _GATEKEEPER_BP_H_
 
-int run_bp(void);
+/* Configuration for the BP functional block. */
+struct bp_config {
+	unsigned int	lcore_start_id;
+	unsigned int	lcore_end_id;
+};
+
+int run_bp(const struct bp_config *bp_conf);
 
 #endif /* _GATEKEEPER_BP_H_ */

--- a/include/gatekeeper_catcher.h
+++ b/include/gatekeeper_catcher.h
@@ -19,6 +19,11 @@
 #ifndef _GATEKEEPER_CATCHER_H_
 #define _GATEKEEPER_CATCHER_H_
 
-int run_catcher(void);
+/* Configuration for the Catcher functional block. */
+struct catcher_config {
+	unsigned int	lcore_id;
+};
+
+int run_catcher(const struct catcher_config *catcher_conf);
 
 #endif /* _GATEKEEPER_CATCHER_H_ */

--- a/include/gatekeeper_config.h
+++ b/include/gatekeeper_config.h
@@ -78,7 +78,12 @@
  */
 #define GATEKEEPER_CACHE_SIZE	(512)
 
-int get_static_config(void);
-int run_dynamic_config(void);
+/* Configuration for the Dynamic Config functional block. */
+struct dynamic_config {
+	unsigned int	lcore_id;
+};
+
+int config_and_launch(void);
+int run_dynamic_config(const struct dynamic_config *dy_conf);
 
 #endif /* _GATEKEEPER_CONFIG_H_ */

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -19,6 +19,11 @@
 #ifndef _GATEKEEPER_CPS_H_
 #define _GATEKEEPER_CPS_H_
 
-int run_cps(void);
+/* Configuration for the Control Plane Support functional block. */
+struct cps_config {
+	unsigned int	lcore_id;
+};
+
+int run_cps(const struct cps_config *cps_conf);
 
 #endif /* _GATEKEEPER_CPS_H_ */

--- a/include/gatekeeper_ggu.h
+++ b/include/gatekeeper_ggu.h
@@ -19,6 +19,11 @@
 #ifndef _GATEKEEPER_GGU_H_
 #define _GATEKEEPER_GGU_H_
 
-int run_ggu(void);
+/* Configuration for the GK-GT Unit functional block. */
+struct ggu_config {
+	unsigned int	lcore_id;
+};
+
+int run_ggu(const struct ggu_config *ggu_conf);
 
 #endif /* _GATEKEEPER_GGU_H_ */

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -19,6 +19,12 @@
 #ifndef _GATEKEEPER_GK_H_
 #define _GATEKEEPER_GK_H_
 
-int run_gk(void);
+/* Configuration for the GK functional block. */
+struct gk_config {
+	unsigned int	lcore_start_id;
+	unsigned int	lcore_end_id;
+};
+
+int run_gk(const struct gk_config *gk_conf);
 
 #endif /* _GATEKEEPER_GK_H_ */

--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -19,6 +19,12 @@
 #ifndef _GATEKEEPER_GT_H_
 #define _GATEKEEPER_GT_H_
 
-int run_gt(void);
+/* Configuration for the GT functional block. */
+struct gt_config {
+	unsigned int	lcore_start_id;
+	unsigned int	lcore_end_id;
+};
+
+int run_gt(const struct gt_config *gt_conf);
 
 #endif /* _GATEKEEPER_GT_H_ */

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _GATEKEEPER_ARP_H_
-#define _GATEKEEPER_ARP_H_
+#ifndef _GATEKEEPER_LLS_H_
+#define _GATEKEEPER_LLS_H_
 
-int run_arp(void);
+int run_lls(void);
 
-#endif /* _GATEKEEPER_ARP_H_ */
+#endif /* _GATEKEEPER_LLS_H_ */

--- a/include/gatekeeper_rt.h
+++ b/include/gatekeeper_rt.h
@@ -19,6 +19,12 @@
 #ifndef _GATEKEEPER_RT_H_
 #define _GATEKEEPER_RT_H_
 
-int run_rt(void);
+/* Configuration for the RT functional block. */
+struct rt_config {
+	unsigned int	lcore_start_id;
+	unsigned int	lcore_end_id;
+};
+
+int run_rt(const struct rt_config *rt_conf);
 
 #endif /* _GATEKEEPER_RT_H_ */

--- a/lls/main.c
+++ b/lls/main.c
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "gatekeeper_arp.h"
+#include "gatekeeper_lls.h"
 
 int
-run_arp(void)
+run_lls(void)
 {
-	/* TODO Initialize and run ARP functional block. */
+	/* TODO Initialize and run Link Layer Support functional block. */
 	return 0;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -96,15 +96,6 @@ main(int argc, char **argv)
 	if (ret < 0)
 		goto out;
 
-	/*
-	 * TODO Add configuration state that can be written by this
-	 * function, so its information can be used to call the
-	 * functional blocks below.
-	 */
-	ret = get_static_config();
-	if (ret < 0)
-		goto out;
-
 	ret = gatekeeper_init_network();
 	if (ret < 0)
 		goto out;
@@ -115,104 +106,16 @@ main(int argc, char **argv)
 	 * need it.
 	 */
 
-	/*
-	 * TODO Decide whether this instance of the application is
-	 * running GK or GT and adjust which functional blocks are
-	 * invoked accordingly.
-	 */
-
-	/*
-	 * TODO Each of the calls below to a functional block should
-	 * be spun out of its own lcore (or set of lcores).
-	 */
-
-	/*
-	 * TODO Decide which lcore will be assigned to LLS and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_lls();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore*s* will be assigned to BP and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_bp();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore will be assigned to Catcher and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_catcher();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore will be assigned to Dynamic Config and
-	 * decide what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_dynamic_config();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore will be assigned to Control Plane Support
-	 * and decide what other configuration information should be passed
-	 * to this functional block.
-	 */
-	ret = run_cps();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore will be assigned to GK-GT Unit and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_ggu();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore*s* will be assigned to GK and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_gk();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore*s* will be assigned to GT and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_gt();
-	if (ret < 0)
-		goto net;
-
-	/*
-	 * TODO Decide which lcore*s* will be assigned to RT and decide
-	 * what other configuration information should be passed to
-	 * this functional block.
-	 */
-	ret = run_rt();
+	ret = config_and_launch();
+	if (ret < 0) {
+		/* Stop all lcores. */
+		exiting = true;
+	}
 
 	rte_eal_mp_wait_lcore();
 
-	/*
-	 * TODO Perform any needed state destruction, stop lcores if one
-	 * of the functions returned with an error, etc.
-	 */
+	/* TODO Perform any needed state destruction. */
 
-net:
 	gatekeeper_free_network();
 out:
 	return ret;

--- a/main/main.c
+++ b/main/main.c
@@ -25,7 +25,6 @@
 #include <rte_common.h>
 #include <rte_launch.h>
 
-#include "gatekeeper_arp.h"
 #include "gatekeeper_bp.h"
 #include "gatekeeper_catcher.h"
 #include "gatekeeper_config.h"
@@ -33,6 +32,7 @@
 #include "gatekeeper_ggu.h"
 #include "gatekeeper_gk.h"
 #include "gatekeeper_gt.h"
+#include "gatekeeper_lls.h"
 #include "gatekeeper_rt.h"
 #include "gatekeeper_main.h"
 
@@ -127,11 +127,11 @@ main(int argc, char **argv)
 	 */
 
 	/*
-	 * TODO Decide which lcore will be assigned to ARP and decide
+	 * TODO Decide which lcore will be assigned to LLS and decide
 	 * what other configuration information should be passed to
 	 * this functional block.
 	 */
-	ret = run_arp();
+	ret = run_lls();
 	if (ret < 0)
 		goto net;
 

--- a/rt/main.c
+++ b/rt/main.c
@@ -19,7 +19,7 @@
 #include "gatekeeper_rt.h"
 
 int
-run_rt(void)
+run_rt(__attribute__((unused)) const struct rt_config *rt_conf)
 {
 	/* TODO Initialize and run RT functional block. */
 	return 0;

--- a/setup.sh
+++ b/setup.sh
@@ -31,12 +31,20 @@ sudo modprobe uio
 sudo modprobe uio_pci_generic
 sudo insmod ${RTE_SDK}/build/kmod/igb_uio.ko
 
-# Make modules persist across reboots.
+# Make modules persist across reboots. Since multiple
+# users can run this script, don't re-add these modules
+# if someone else already made them persistent.
 sudo ln -s ${RTE_SDK}/build/kmod/igb_uio.ko /lib/modules/`uname -r`
 sudo depmod -a
-sudo echo "uio" | sudo tee -a /etc/modules
-sudo echo "uio_pci_generic" | sudo tee -a /etc/modules
-sudo echo "igb_uio" | sudo tee -a /etc/modules
+if ! grep -q "uio" /etc/modules; then
+  sudo echo "uio" | sudo tee -a /etc/modules
+fi
+if ! grep -q "uio_pci_generic" /etc/modules; then
+  sudo echo "uio_pci_generic" | sudo tee -a /etc/modules
+fi
+if ! grep -q "igb_uio" /etc/modules; then
+  sudo echo "igb_uio" | sudo tee -a /etc/modules
+fi
 
 ln -s ${RTE_SDK}/build ${RTE_SDK}/${RTE_TARGET}
 


### PR DESCRIPTION
The first two commits are improvements on the setup process.

The third commit is to reflect the fact that Gatekeeper has multiple link layer responsibilities: ARP, ND, LACP, etc. Therefore, the ARP functional block is renamed to Link Layer Support.

The config commits take steps toward reading in and using a configuration file. "ensure enough lcores are present" helps set up whether enough lcores have been used to run the program. "add basics for block and lcore config" adds configuration files for every block so that the configuration can assign lcores, enable functional blocks, and run them.