### PR TITLE
add interface abstraction and queue mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ While in the `gatekeeper` directory, run the setup script:
     $ ./setup.sh
 
 This script compiles DPDK and LuaJIT, and loads the needed kernel modules.
+Additionally, it saves the interface names and their respective PCI addresses
+in the file `lua/if_map.lua`, so that interface names can be used in
+the Gatekeeper configuration files.
 It also sets two environmental variables: `RTE_SDK` and `RTE_TARGET`.
 They must be set before `gatekeeper` will compile.
 After running the setup script, you may want to save

--- a/config/static.c
+++ b/config/static.c
@@ -25,8 +25,7 @@
 #include <rte_debug.h>
 
 #include "gatekeeper_config.h"
-
-#define RTE_LOGTYPE_CONFIG RTE_LOGTYPE_USER2
+#include "gatekeeper_main.h"
 
 /* TODO Get the install-path via Makefile. */
 #define LUA_BASE_DIR               "./lua"
@@ -66,7 +65,8 @@ config_and_launch(void)
 
 	lua_state = luaL_newstate();
 	if (!lua_state) {
-		RTE_LOG(ERR, CONFIG, "Fail to create new Lua state!\n");
+		RTE_LOG(ERR, GATEKEEPER,
+			"config: failed to create new Lua state!\n");
 		return -1;
 	}
 
@@ -74,7 +74,8 @@ config_and_launch(void)
 	set_lua_path(lua_state, LUA_BASE_DIR);
 	ret = luaL_loadfile(lua_state, lua_entry_path);
 	if (ret != 0) {
-		RTE_LOG(ERR, CONFIG, "%s!\n", lua_tostring(lua_state, -1));
+		RTE_LOG(ERR, GATEKEEPER,
+			"config: %s!\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
 	}
@@ -91,7 +92,8 @@ config_and_launch(void)
 	 */
 	ret = lua_pcall(lua_state, 0, 0, 0);
 	if (ret != 0) {
-		RTE_LOG(ERR, CONFIG, "%s!\n", lua_tostring(lua_state, -1));
+		RTE_LOG(ERR, GATEKEEPER,
+			"config: %s!\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
 	}
@@ -100,14 +102,16 @@ config_and_launch(void)
 	lua_getglobal(lua_state, "gatekeeper_init");
 	ret = lua_pcall(lua_state, 0, 1, 0);
 	if (ret != 0) {
-		RTE_LOG(ERR, CONFIG, "%s!\n", lua_tostring(lua_state, -1));
+		RTE_LOG(ERR, GATEKEEPER,
+			"config: %s!\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
 	}
 
 	ret = luaL_checkinteger(lua_state, -1);
 	if (ret < 0)
-		RTE_LOG(ERR, CONFIG, "gatekeeper_init() return value is %d!\n",
+		RTE_LOG(ERR, GATEKEEPER,
+			"config: gatekeeper_init() return value is %d!\n",
 			ret);
 
 out:

--- a/generate_if_map.c
+++ b/generate_if_map.c
@@ -1,0 +1,100 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define GATEKEEPER_IF_MAP	"./lua/if_map.lua"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <ifaddrs.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <linux/ethtool.h> 
+#include <linux/sockios.h>
+
+int
+main(void)
+{
+	FILE *f;
+	struct ifaddrs *addrs, *iter;
+	int sock;
+	int ret;
+
+	f = fopen(GATEKEEPER_IF_MAP, "w");
+	if (f == NULL) {
+		perror("fopen");
+		return -1;
+	}
+
+	ret = getifaddrs(&addrs);
+	if (ret == -1) {
+		perror("getifaddrs");
+		goto file;
+	}
+
+	sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock == -1) {
+		perror("socket");
+		goto addrs;
+	}
+
+	fprintf(f, "return {\n");
+
+	iter = addrs;
+	while (iter != NULL) {
+		struct ifreq ifr;
+		struct ethtool_cmd cmd;
+		struct ethtool_drvinfo drvinfo;
+
+		/*
+		 * Use AF_PACKET to only get each interface once,
+		 * and skip the loopback interface.
+		 */
+		if (iter->ifa_addr == NULL ||
+				iter->ifa_addr->sa_family != AF_PACKET ||
+				strcmp(iter->ifa_name, "lo") == 0)
+			goto next;
+
+		memset(&ifr, 0, sizeof(ifr));
+		memset(&cmd, 0, sizeof(cmd));
+		memset(&drvinfo, 0, sizeof(drvinfo));
+		strcpy(ifr.ifr_name, iter->ifa_name);
+
+		ifr.ifr_data = (void *)&drvinfo;
+		drvinfo.cmd = ETHTOOL_GDRVINFO;
+
+		if (ioctl(sock, SIOCETHTOOL, &ifr) < 0) {
+			perror("ioctl");
+			goto next;
+		}
+
+		fprintf(f, "\t[\"%s\"] = \"%s\",\n", iter->ifa_name,
+			drvinfo.bus_info);
+next:
+		iter = iter->ifa_next;
+	}
+
+	fprintf(f, "}\n");
+
+	close(sock);
+addrs:
+	freeifaddrs(addrs);
+file:
+	fclose(f);
+	return ret;
+}

--- a/gk/main.c
+++ b/gk/main.c
@@ -23,12 +23,6 @@
 #include "gatekeeper_gk.h"
 #include "gatekeeper_main.h"
 
-/*
- * Define the custom log type for GK functional block,
- * which is used to generate logs for GK block.
- */
-#define RTE_LOGTYPE_GK RTE_LOGTYPE_USER1
-
 #define GATEKEEPER_MAX_PKT_BURST (32)
 
 static int
@@ -39,7 +33,8 @@ gk_proc(void *arg)
 	uint32_t lcore = rte_lcore_id();
 	struct gk_config *gk_conf = (struct gk_config *)arg;
 
-	RTE_LOG(NOTICE, GK, "The GK block is running at lcore = %u\n", lcore);
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"gk: the GK block is running at lcore = %u\n", lcore);
 	
 	rte_atomic32_inc(&gk_conf->ref_cnt);
 
@@ -74,7 +69,8 @@ gk_proc(void *arg)
 		}
 	}
 
-	RTE_LOG(NOTICE, GK, "The GK block at lcore = %u is exiting\n", lcore);
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"gk: the GK block at lcore = %u is exiting\n", lcore);
 
 	return cleanup_gk(gk_conf);
 }

--- a/gk/main.c
+++ b/gk/main.c
@@ -21,6 +21,7 @@
 
 #include "gatekeeper_gk.h"
 #include "gatekeeper_main.h"
+#include "gatekeeper_net.h"
 
 #define GATEKEEPER_MAX_PKT_BURST (32)
 
@@ -32,18 +33,21 @@ gk_proc(void *arg)
 	uint32_t lcore = rte_lcore_id();
 	struct gk_config *gk_conf = (struct gk_config *)arg;
 
+	uint8_t port_in = get_net_conf()->front.id;
+	uint8_t port_out = get_net_conf()->back.id;
+
 	RTE_LOG(NOTICE, GATEKEEPER,
 		"gk: the GK block is running at lcore = %u\n", lcore);
-	
+
 	rte_atomic32_inc(&gk_conf->ref_cnt);
 
 	while (likely(!exiting)) {
 		/* 
 		 * XXX Sample setting for test only.
 		 * 
-		 * Here, just use two ports (0, 1) and 1 queue (0) for test.
+		 * Here, just use one queue (0) for test.
 		 *
-		 * Port and queue identifiers should be changed 
+		 * Queue identifiers should be changed 
 		 * according to configuration.
 		 */
 
@@ -52,13 +56,14 @@ gk_proc(void *arg)
 		uint16_t num_tx;
 		struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
 
-		num_rx = rte_eth_rx_burst(0, 0, bufs, GATEKEEPER_MAX_PKT_BURST);
+		num_rx = rte_eth_rx_burst(port_in, 0, bufs,
+			GATEKEEPER_MAX_PKT_BURST);
 
 		if (unlikely(num_rx == 0))
 			continue;
 
 		/* Send burst of TX packets, to second port of pair. */
-		num_tx = rte_eth_tx_burst(1, 0, bufs, num_rx);
+		num_tx = rte_eth_tx_burst(port_out, 0, bufs, num_rx);
 
 		/* Free any unsent packets. */
 		if (unlikely(num_tx < num_rx)) {

--- a/gk/main.c
+++ b/gk/main.c
@@ -16,9 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <rte_log.h>
-#include <rte_lcore.h>
 #include <rte_ethdev.h>
+#include <rte_malloc.h>
 
 #include "gatekeeper_gk.h"
 #include "gatekeeper_main.h"
@@ -78,7 +77,7 @@ gk_proc(void *arg)
 struct gk_config *
 alloc_gk_conf(void)
 {
-	return calloc(1, sizeof(struct gk_config));
+	return rte_calloc("gk_config", 1, sizeof(struct gk_config), 0);
 }
 
 int
@@ -111,7 +110,7 @@ cleanup_gk(struct gk_config *gk_conf)
 	 * if the result is 0, or false in all other cases.
 	 */
 	if (rte_atomic32_dec_and_test(&gk_conf->ref_cnt)) {
-		free(gk_conf);
+		rte_free(gk_conf);
 	}
 
 	return 0;

--- a/include/gatekeeper_config.h
+++ b/include/gatekeeper_config.h
@@ -23,7 +23,7 @@
  * XXX Sample parameters for test only. 
  * They should be configured in the configuration step.
  */
-#define GATEKEEPER_MAX_PORTS	(2)
+#define GATEKEEPER_MAX_PORTS	(4)
 #define GATEKEEPER_MAX_QUEUES	(4)
 
 /*

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -19,6 +19,13 @@
 #ifndef _GATEKEEPER_MAIN_H_
 #define _GATEKEEPER_MAIN_H_
 
+/*
+ * Custom log type for Gatekeeper-related log entries.
+ * When using this logtype, the log string should include
+ * the name of the relevant functional block, library, etc.
+ */
+#define RTE_LOGTYPE_GATEKEEPER RTE_LOGTYPE_USER1
+
 extern volatile int exiting;
 
 #endif /* _GATEKEEPER_MAIN_H_ */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -21,10 +21,47 @@
 
 #include <stdint.h>
 
+/*
+ * A Gatekeeper interface is specified by a set of PCI addresses
+ * that map to DPDK port numbers. If multiple ports are specified,
+ * then the ports are bonded.
+ */
+struct gatekeeper_if {
+	/* The ports (in PCI address format) that compose this interface. */
+	char		**pci_addrs;
+
+	/* The number of ports that in this interface (length of @pci_addrs). */
+	uint8_t		num_ports;
+
+	/* Name of the interface. Needed for setting/getting bonded port. */
+	char		*name;
+
+	/*
+	 * The fields below are for internal use.
+	 * Configuration files should not refer to them.
+	 */
+
+	/* DPDK port IDs corresponding to each address in @pci_addrs. */
+	uint8_t		*ports;
+
+	/*
+	 * The DPDK port ID for this interface.
+	 *
+	 * If @ports only has one element, then @id is that port.
+	 * If @ports has multiple elements, then @id is the DPDK
+	 * *bonded* port ID representing all of those ports.
+	 */
+	uint8_t         id;
+};
+
 /* Configuration for the Network. */
 struct net_config {
 	uint16_t		num_rx_queues;
 	uint16_t		num_tx_queues;
+
+	struct gatekeeper_if	front;
+	struct gatekeeper_if	back;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
@@ -34,10 +71,12 @@ struct net_config {
 	struct rte_mempool 	**gatekeeper_pktmbuf_pool;
 };
 
+int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
+	const char **pci_addrs, uint8_t num_pci_addrs);
+void lua_free_iface(struct gatekeeper_if *iface);
+
 struct net_config *get_net_conf(void);
-
 int gatekeeper_init_network(struct net_config *net_conf);
-
 void gatekeeper_free_network(void);
 
 #endif /* _GATEKEEPER_NET_H_ */

--- a/lib/net.c
+++ b/lib/net.c
@@ -19,6 +19,7 @@
 #include <rte_mbuf.h>
 #include <rte_errno.h>
 #include <rte_ethdev.h>
+#include <rte_eth_bond.h>
 #include <rte_malloc.h>
 
 #include "gatekeeper_net.h"
@@ -47,15 +48,107 @@ find_num_numa_nodes(void)
 	return nb_numa_nodes;
 }
 
-static void
-close_num_ports(uint8_t nb_ports)
+int
+lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
+	const char **pci_addrs, uint8_t num_pci_addrs)
 {
-	uint8_t port_id;
+	uint8_t i, j;
 
-	for (port_id = 0; port_id < nb_ports; port_id++) {
-		rte_eth_dev_stop(port_id);
-		rte_eth_dev_close(port_id);
+	iface->num_ports = num_pci_addrs;
+
+	iface->name = rte_malloc("iface_name", strlen(iface_name) + 1, 0);
+	if (iface->name == NULL) {
+		RTE_LOG(ERR, MALLOC, "%s: Out of memory for iface name\n",
+			__func__);
+		return -1;
 	}
+	strcpy(iface->name, iface_name);
+
+	iface->pci_addrs = rte_calloc("pci_addrs", num_pci_addrs,
+		sizeof(*pci_addrs), 0);
+	if (iface->pci_addrs == NULL) {
+		RTE_LOG(ERR, MALLOC, "%s: Out of memory for PCI array\n",
+			__func__);
+		goto name;
+	}
+
+	for (i = 0; i < num_pci_addrs; i++) {
+		iface->pci_addrs[i] = rte_malloc(NULL,
+			strlen(pci_addrs[i]) + 1, 0);
+		if (iface->pci_addrs[i] == NULL) {
+			RTE_LOG(ERR, MALLOC,
+				"%s: Out of memory for PCI address %s\n",
+				__func__, pci_addrs[i]);
+			for (j = 0; j < i; j++)
+				rte_free(iface->pci_addrs[j]);
+			rte_free(iface->pci_addrs);
+			iface->pci_addrs = NULL;
+			goto name;
+		}
+		strcpy(iface->pci_addrs[i], pci_addrs[i]);
+	}
+
+	return 0;
+
+name:
+	rte_free(iface->name);
+	iface->name = NULL;
+	return -1;
+}
+
+static void
+free_pci_addrs(struct gatekeeper_if *iface)
+{
+	uint8_t i;
+	for (i = 0; i < iface->num_ports; i++)
+		rte_free(iface->pci_addrs[i]);
+	rte_free(iface->pci_addrs);
+	iface->pci_addrs = NULL;
+}
+
+void
+lua_free_iface(struct gatekeeper_if *iface)
+{
+	free_pci_addrs(iface);
+	rte_free(iface->name);
+	iface->name = NULL;
+}
+
+static void
+close_iface_id(struct gatekeeper_if *iface, uint8_t nb_slave_ports)
+{
+	uint8_t i;
+
+	/* If there's only one port, there's no bonded port. */
+	if (iface->num_ports == 1)
+		return;
+
+	for (i = 0; i < nb_slave_ports; i++)
+		rte_eth_bond_slave_remove(iface->id, iface->ports[i]);
+
+	rte_eth_bond_free(iface->name);
+}
+
+static void
+close_iface_ports(struct gatekeeper_if *iface, uint8_t nb_ports)
+{
+	uint8_t i;
+	for (i = 0; i < nb_ports; i++) {
+		rte_eth_dev_stop(iface->ports[i]);
+		rte_eth_dev_close(iface->ports[i]);
+	}
+}
+
+static void
+close_iface(struct gatekeeper_if *iface)
+{
+	close_iface_id(iface, iface->num_ports);
+	close_iface_ports(iface, iface->num_ports);
+	rte_free(iface->ports);
+	iface->ports = NULL;
+	free_pci_addrs(iface);
+	rte_free(iface->name);
+	iface->name = NULL;
 }
 
 struct net_config *
@@ -64,15 +157,173 @@ get_net_conf(void)
 	return &config;
 }
 
+static int
+init_port(struct net_config *net_conf, uint8_t port_id, uint8_t *num_succ_ports)
+{
+	unsigned int lcore;
+	struct rte_eth_link link;
+	int ret = rte_eth_dev_configure(port_id,
+		net_conf->num_rx_queues, net_conf->num_tx_queues,
+		&gatekeeper_port_conf);
+	if (ret < 0) {
+		RTE_LOG(ERR, PORT,
+			"Failed to configure port %hhu (err=%d)!\n",
+			port_id, ret);
+		return ret;
+	}
+
+	/*
+	 * TODO This initialization assumes that every block wants
+	 * to use the same queue identifier for both RX and TX on
+	 * both interfaces. This is not the case, and should be
+	 * changed in future patches.
+	 */
+	RTE_LCORE_FOREACH_SLAVE(lcore) {
+		unsigned int numa_node = rte_lcore_to_socket_id(lcore);
+		struct rte_mempool *mp = net_conf->
+			gatekeeper_pktmbuf_pool[numa_node];
+		uint16_t queue = (uint16_t)(lcore - 1);
+
+		if (queue < net_conf->num_rx_queues) {
+			ret = rte_eth_rx_queue_setup(port_id, queue,
+				GATEKEEPER_NUM_RX_DESC,
+				numa_node, NULL, mp);
+			if (ret < 0) {
+				RTE_LOG(ERR, PORT, "Failed to configure port %hhu rx_queue %hu (err=%d)!\n",
+					port_id, queue, ret);
+				return ret;
+			}
+		}
+
+		if (queue < net_conf->num_tx_queues) {
+			ret = rte_eth_tx_queue_setup(port_id, queue,
+				GATEKEEPER_NUM_TX_DESC, numa_node, NULL);
+			if (ret < 0) {
+				RTE_LOG(ERR, PORT, "Failed to configure port %hhu tx_queue %hu (err=%d)!\n",
+					port_id, queue, ret);
+				return ret;
+			}
+		}
+	}
+
+	/* Start device. */
+	ret = rte_eth_dev_start(port_id);
+	if (ret < 0) {
+		RTE_LOG(ERR, PORT, "Failed to start port %hhu (err=%d)!\n",
+			port_id, ret);
+		return ret;
+	}
+	if (num_succ_ports != NULL)
+		num_succ_ports++;
+
+	/*
+	 * The following code ensures that the device is ready for
+	 * full speed RX/TX.
+	 * When the initialization is done without this,
+	 * the initial packet transmission may be blocked.
+	 */
+	rte_eth_link_get(port_id, &link);
+	if (!link.link_status) {
+		RTE_LOG(ERR, PORT, "Querying port %hhu, and link is down!\n",
+			port_id);
+		ret = -1;
+		return ret;
+	}
+
+	/* TODO Configure the Flow Director and RSS. */
+
+	return 0;
+}
+
+static int
+init_iface(struct net_config *net_conf, struct gatekeeper_if *iface)
+{
+	int ret = 0;
+	uint8_t i;
+	uint8_t num_succ_ports = 0;
+	uint8_t num_slaves_added = 0;
+
+	iface->ports = rte_calloc("ports", iface->num_ports,
+		sizeof(*iface->ports), 0);
+	if (iface->ports == NULL) {
+		RTE_LOG(ERR, MALLOC, "%s: Out of memory for %s ports\n",
+			__func__, iface->name);
+		return -1;
+	}
+
+	for (i = 0; i < iface->num_ports; i++) {
+		struct rte_pci_addr pci_addr;
+		uint8_t port_id;
+
+		int ret = eal_parse_pci_DomBDF(iface->pci_addrs[i], &pci_addr);
+		if (ret < 0) {
+			RTE_LOG(ERR, PORT,
+				"Failed to parse PCI %s (err=%d)!\n",
+				iface->pci_addrs[i], ret);
+			goto close_ports;
+		}
+
+		ret = rte_eth_dev_get_port_by_addr(&pci_addr, &port_id);
+		if (ret < 0) {
+			RTE_LOG(ERR, PORT,
+				"Failed to map PCI %s to a port (err=%d)!\n",
+				iface->pci_addrs[i], ret);
+			goto close_ports;
+		}
+		iface->ports[i] = port_id;
+
+		ret = init_port(net_conf, port_id, &num_succ_ports);
+		if (ret < 0)
+			goto close_ports;
+	}
+
+	/* Initialize bonded port, if needed. */
+	if (iface->num_ports == 1) {
+		iface->id = iface->ports[0];
+		return 0;
+	}
+
+	/* TODO Also allow LACP to be used. */
+	ret = rte_eth_bond_create(iface->name, BONDING_MODE_ROUND_ROBIN, 0);
+	if (ret < 0) {
+		RTE_LOG(ERR, PORT, "Failed to create bonded port (err=%d)!\n",
+			ret);
+		goto close_ports;
+	}
+
+	iface->id = (uint8_t)ret;
+
+	ret = init_port(net_conf, iface->id, NULL);
+	if (ret < 0)
+		goto close_id;
+
+	for (i = 0; i < iface->num_ports; i++) {
+		ret = rte_eth_bond_slave_add(iface->id, iface->ports[i]);
+		if (ret < 0) {
+			RTE_LOG(ERR, PORT, "Failed to add slave port %hhu to bonded port %hhu (err=%d)!\n",
+				iface->ports[i], iface->id, ret);
+			goto close_id;
+		}
+		num_slaves_added++;
+	}
+
+	return 0;
+
+close_id:
+	close_iface_id(iface, num_slaves_added);
+close_ports:
+	close_iface_ports(iface, num_succ_ports);
+	rte_free(iface->ports);
+	iface->ports = NULL;
+	return ret;
+}
+
 /* Initialize the network. */
 int
 gatekeeper_init_network(struct net_config *net_conf)
 {
 	int i;
 	int ret = -1;
-	uint8_t port_id;
-	uint8_t num_succ_ports = 0;
-	uint32_t num_lcores = 0;
 
 	if (!net_conf)
 		return -1;
@@ -88,8 +339,6 @@ gatekeeper_init_network(struct net_config *net_conf)
 		}
 	}
 
-	num_lcores = rte_lcore_count();
-	
 	RTE_ASSERT(net_conf->num_rx_queues <= GATEKEEPER_MAX_QUEUES);
 	RTE_ASSERT(net_conf->num_tx_queues <= GATEKEEPER_MAX_QUEUES);
 
@@ -135,90 +384,26 @@ gatekeeper_init_network(struct net_config *net_conf)
 	/* Check port limits. */
 	net_conf->num_ports = rte_eth_dev_count();
 	RTE_ASSERT(net_conf->num_ports != 0 &&
-		net_conf->num_ports <= GATEKEEPER_MAX_PORTS);
+		net_conf->num_ports <= GATEKEEPER_MAX_PORTS &&
+		net_conf->num_ports ==
+			(net_conf->front.num_ports + net_conf->back.num_ports));
 
-	/* Initialize ports. */
-	for (port_id = 0; port_id < net_conf->num_ports; port_id++) {
-		uint32_t lcore;
-		struct rte_eth_link link;
-		
-		ret = rte_eth_dev_configure(port_id, net_conf->num_rx_queues,
-			net_conf->num_tx_queues, &gatekeeper_port_conf);
-		if (ret < 0) {
-			RTE_LOG(ERR, PORT,
-				"Failed to configure port %hhu (err=%d)!\n",
-				port_id, ret);
-			goto port;
-		}
+	/* Initialize interfaces. */
+	ret = init_iface(net_conf, &net_conf->front);
+	if (ret < 0)
+		goto out;
 
-		for (lcore = 0; lcore < num_lcores; lcore++) {
-			size_t numa_node;
-			
-			/* XXX Map queue = lcore, if necessary,
-			 * change the queues mapping.
-			 */
-			uint16_t queue = (uint16_t)lcore;
-
-			/* XXX In case the number of lcores is greater than
-			 * the number of queues.
-			 */
-			if (lcore >= net_conf->num_rx_queues ||
-					lcore >= net_conf->num_tx_queues)
-				break;
-
-			numa_node = rte_lcore_to_socket_id(lcore);
-
-			ret = rte_eth_rx_queue_setup(port_id, queue,
-					GATEKEEPER_NUM_RX_DESC,
-					(unsigned int)numa_node, NULL, 
-					net_conf->gatekeeper_pktmbuf_pool[
-						numa_node]);
-			if (ret < 0) {
-				RTE_LOG(ERR, PORT, "Failed to configure port %hhu rx_queue %hu (err=%d)!\n",
-					 port_id, queue, ret);
-				goto port;
-			}
-
-			ret = rte_eth_tx_queue_setup(port_id, queue,
-					GATEKEEPER_NUM_TX_DESC,
-					numa_node, NULL);
-			if (ret < 0) {
-				RTE_LOG(ERR, PORT, "Failed to configure port %hhu tx_queue %hu (err=%d)!\n",
-					 port_id, queue, ret);
-				goto port;
-			}
-		}
-
-		/* Start device. */
-		ret = rte_eth_dev_start(port_id);
-		if (ret < 0) {
-			RTE_LOG(ERR, PORT, "Failed to start port %hhu (err=%d)!\n",
-				port_id, ret);
-			goto port;
-		}
-		num_succ_ports++;
-		
-		/*
-		 * The following code ensures that the device is ready for
-		 * full speed RX/TX.
-		 * When the initialization is done without this,
-		 * the initial packet transmission may be blocked.
-		 */
-		rte_eth_link_get(port_id, &link);
-		if (!link.link_status) {
-			RTE_LOG(ERR, PORT, "Querying port %hhu, and link is down!\n",
-				port_id);
-			ret = -1;
-			goto port;
-		}
-	}
-
-	/* TODO Configure the Flow Director, RSS, and Filters. */
+	ret = init_iface(net_conf, &net_conf->back);
+	if (ret < 0)
+		goto close_front;
 
 	goto out;
 
-port:
-	close_num_ports(num_succ_ports);
+close_front:
+	close_iface_id(&net_conf->front, net_conf->front.num_ports);
+	close_iface_ports(&net_conf->front, net_conf->front.num_ports);
+	rte_free(net_conf->front.ports);
+	net_conf->front.ports = NULL;
 out:
 	return ret;
 }
@@ -226,5 +411,6 @@ out:
 void
 gatekeeper_free_network(void)
 {
-	close_num_ports(config.num_ports);
+	close_iface(&config.back);
+	close_iface(&config.front);
 }

--- a/lib/net.c
+++ b/lib/net.c
@@ -16,13 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdio.h>
-
 #include <rte_mbuf.h>
 #include <rte_errno.h>
-#include <rte_lcore.h>
-#include <rte_debug.h>
 #include <rte_ethdev.h>
+#include <rte_malloc.h>
 
 #include "gatekeeper_net.h"
 #include "gatekeeper_config.h"
@@ -83,9 +80,10 @@ gatekeeper_init_network(struct net_config *net_conf)
 	if (!config.gatekeeper_pktmbuf_pool) {
 		config.numa_nodes = find_num_numa_nodes();
 		config.gatekeeper_pktmbuf_pool =
-			calloc(config.numa_nodes, sizeof(struct rte_mempool *));
+			rte_calloc("mbuf_pool", config.numa_nodes,
+				sizeof(struct rte_mempool *), 0);
 		if (!config.gatekeeper_pktmbuf_pool) {
-			RTE_LOG(ERR, EAL, "%s: Out of memory\n", __func__);
+			RTE_LOG(ERR, MALLOC, "%s: Out of memory\n", __func__);
 			return -1;
 		}
 	}

--- a/lua/gatekeeperc.lua
+++ b/lua/gatekeeperc.lua
@@ -4,9 +4,23 @@ local ffi = require("ffi")
 -- TODO Define the C data structures for other functional blocks.
 ffi.cdef[[
 
+struct gatekeeper_if {
+	char		**pci_addrs;
+	uint8_t		num_ports;
+	char		*name;
+	/*
+	 * The fields below are for internal use.
+	 * Configuration files should not refer to them.
+	 */
+	uint8_t		*ports;
+	uint8_t         id;
+};
+
 struct net_config {
 	uint16_t		num_rx_queues;
 	uint16_t		num_tx_queues;
+	struct gatekeeper_if	front;
+	struct gatekeeper_if	back;
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
@@ -35,6 +49,10 @@ struct gk_config {
 -- Functions and wrappers
 -- TODO Define the C functions for other functional blocks.
 ffi.cdef[[
+
+int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
+	const char **pci_addrs, uint8_t num_pci_addrs);
+void lua_free_iface(struct gatekeeper_if *iface);
 
 struct net_config *get_net_conf(void);
 int gatekeeper_init_network(struct net_config *net_conf);

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -1,17 +1,53 @@
 local gatekeeperc = require("gatekeeperc")
+local ffi = require("ffi")
+local ifaces = require("if_map")
 
 local M = {}
+
+function init_iface(iface, name, ports)
+	local pci_strs = ffi.new("const char *[" .. #ports .. "]")
+	for i, v in ipairs(ports) do
+		pci_strs[i - 1] = ifaces[v]
+	end
+	return gatekeeperc.lua_init_iface(iface, name, pci_strs, #ports)
+end
 
 -- Function that sets up the network.
 function M.setup_block()
 
 	-- Init the network configuration structure.
 	local conf = gatekeeperc.get_net_conf()
-	conf.num_rx_queues = 1
-	conf.num_tx_queues = 1
+
+	-- Change these parameters to configure the network.
+	local front_ports = {"enp131s0f0"}
+	local back_ports = {"enp133s0f0"}
+	conf.num_rx_queues = 2
+	conf.num_tx_queues = 2
+
+	-- Code below this point should not need to be changed.
+	local ret = init_iface(conf.front, "front", front_ports)
+	if ret < 0 then
+		return ret
+	end
+
+	ret = init_iface(conf.back, "back", back_ports)
+	if ret < 0 then
+		goto front
+	end
 
 	-- Set up the network.
-	return gatekeeperc.gatekeeper_init_network(conf)
+	ret = gatekeeperc.gatekeeper_init_network(conf)
+	if ret < 0 then
+		goto back
+	end
+
+	do return ret end
+
+::back::
+	gatekeeperc.lua_free_iface(conf.back)
+::front::
+	gatekeeperc.lua_free_iface(conf.front)
+	return ret
 end
 
 return M

--- a/setup.sh
+++ b/setup.sh
@@ -61,4 +61,8 @@ sudo make install
 
 cd ../../
 
+# Build interface name -> PCI address map.
+gcc generate_if_map.c -o generate_if_map -Wall
+./generate_if_map
+
 echo "Environmental variables RTE_SDK and RTE_TARGET have been set, but not saved for future logins. You should save them to your shell's preferences file or set them after every login."


### PR DESCRIPTION
The point of this pull request is to add more networking configuration that will help the functional blocks, and also to add the beginnings of the BP block.

The operator needs to be able to specify which ports are the Gatekeeper front and back, so the second patch sets up the ability to specify which ports belong to which interface and creates a single identifier for receiving/transmitting.

The BP implementation is only a first effort, as we must answer some key questions before continuing. For example, if ntuple filter is not flexible, how will IPv4 rules be added? Additionally, will this block be able to listen directly on a queue, or will it have to wait for packets to be distributed to it in software? The next step is answering these questions for IPv4 (which will help other blocks), and then adding support for IPv6.