### PR TITLE
net: improve queue configuration

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -460,7 +460,7 @@ setup_gk_instance(unsigned int lcore_id, struct gk_config *gk_conf)
 	ip_flow_hash_params.name = ht_name;
 	ip_flow_hash_params.socket_id = rte_lcore_to_socket_id(lcore_id);
 	instance->ip_flow_hash_table = rte_hash_create(&ip_flow_hash_params);
-	if (!instance->ip_flow_hash_table) {
+	if (instance->ip_flow_hash_table == NULL) {
 		RTE_LOG(ERR, HASH,
 			"The GK block cannot create hash table at lcore %u!\n",
 			lcore_id);
@@ -474,7 +474,7 @@ setup_gk_instance(unsigned int lcore_id, struct gk_config *gk_conf)
 	/* Setup the flow entry table for GK block @block_idx. */
 	instance->ip_flow_entry_table = (struct flow_entry *)rte_calloc(NULL,
 		gk_conf->flow_ht_size, sizeof(struct flow_entry), 0);
-	if (!instance->ip_flow_entry_table) {
+	if (instance->ip_flow_entry_table == NULL) {
 		RTE_LOG(ERR, MALLOC,
 			"The GK block can't create flow entry table at lcore %u!\n",
 			lcore_id);
@@ -498,11 +498,10 @@ gk_proc(void *arg)
 {
 	/* TODO Implement the basic algorithm of a GK block. */
 
-	unsigned int block_idx;
 	unsigned int lcore = rte_lcore_id();
 	struct gk_instance *instance;
-	struct gk_config   *gk_conf = (struct gk_config *)arg;
-	block_idx = lcore - gk_conf->lcore_start_id;
+	struct gk_config *gk_conf = (struct gk_config *)arg;
+	unsigned int block_idx = lcore - gk_conf->lcore_start_id;
 
 	uint8_t port_in = get_net_conf()->front.id;
 	uint8_t port_out = get_net_conf()->back.id;
@@ -557,11 +556,13 @@ gk_proc(void *arg)
 			 * Find the flow entry for the IP pair.
 			 * Create a new flow entry if not found.
 			 */
-			ret = rte_hash_lookup_with_hash(instance->ip_flow_hash_table,
+			ret = rte_hash_lookup_with_hash(
+				instance->ip_flow_hash_table,
 				&packet.flow, pkt->hash.rss);
 			if (ret < 0) {
 				/* Create a new flow entry. */
-				ret = rte_hash_add_key_with_hash(instance->ip_flow_hash_table,
+				ret = rte_hash_add_key_with_hash(
+					instance->ip_flow_hash_table,
  					(void *)&packet.flow, pkt->hash.rss);
 				if (ret < 0) {
 					RTE_LOG(ERR, HASH,
@@ -624,7 +625,8 @@ gk_proc(void *arg)
 		}
 
 		/* Send burst of TX packets, to second port of pair. */
-		num_tx_succ = rte_eth_tx_burst(port_out, tx_queue, tx_bufs, num_tx);
+		num_tx_succ = rte_eth_tx_burst(port_out, tx_queue,
+			tx_bufs, num_tx);
 
 		/* XXX Do something better here! For now, free any unsent packets. */
 		if (unlikely(num_tx_succ < num_tx)) {
@@ -665,7 +667,7 @@ run_gk(struct gk_config *gk_conf)
 	uint16_t gk_queues[GK_MAX_NUM_LCORES];
 	struct gk_instance *inst_ptr;
 
-	if (!gk_conf) {
+	if (gk_conf == NULL) {
 		ret = -1;
 		goto out;
 	}
@@ -686,7 +688,7 @@ run_gk(struct gk_config *gk_conf)
 
 	gk_conf->instances = (struct gk_instance *)rte_calloc(NULL,
 		num_lcores, sizeof(struct gk_instance), 0);
-	if (!gk_conf->instances) {
+	if (gk_conf->instances == NULL) {
 		ret = -1;
 		goto out;
 	}
@@ -695,7 +697,7 @@ run_gk(struct gk_config *gk_conf)
 		/* Setup the gk instance for lcore @i. */
 		ret = setup_gk_instance(i, gk_conf);
 		if (ret < 0) {
-			RTE_LOG(ERR, GATEKEEPER, 
+			RTE_LOG(ERR, GATEKEEPER,
 				"gk: failed to setup gk instances for GK block at %u!\n",
 				i);
 			goto setup;
@@ -724,7 +726,8 @@ setup:
 	/*
 	 * If failed to setup the first gk instance, needs to release
 	 * 'gk_conf->instances' and 'gk_conf'.
-	 * Otherwise, the launched gk instances need to call cleanup_gk() to release.
+	 * Otherwise, the launched gk instances need to call
+	 * cleanup_gk() to release.
 	 */
 	if (i == gk_conf->lcore_start_id) {
 		rte_free(gk_conf->instances);
@@ -741,7 +744,9 @@ int
 cleanup_gk(struct gk_config *gk_conf)
 {
 	unsigned int i;
-	unsigned int num_lcores = gk_conf->lcore_end_id - gk_conf->lcore_start_id + 1;
+	unsigned int num_lcores = gk_conf->lcore_end_id -
+		gk_conf->lcore_start_id + 1;
+
 	/*
 	 * Atomically decrements the atomic counter (v) by one and returns true 
 	 * if the result is 0, or false in all other cases.
@@ -749,10 +754,12 @@ cleanup_gk(struct gk_config *gk_conf)
 	if (rte_atomic32_dec_and_test(&gk_conf->ref_cnt)) {
 		for (i = 0; i < num_lcores; i++) {
 			if (gk_conf->instances[i].ip_flow_hash_table)
-				rte_hash_free(gk_conf->instances[i].ip_flow_hash_table);
+				rte_hash_free(gk_conf->instances[i].
+					ip_flow_hash_table);
 
 			if (gk_conf->instances[i].ip_flow_entry_table)
-				rte_free(gk_conf->instances[i].ip_flow_entry_table);
+				rte_free(gk_conf->instances[i].
+					ip_flow_entry_table);
 		}
 
 		rte_free(gk_conf->instances);

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -25,6 +25,10 @@
 struct gk_instance {
 	struct rte_hash   *ip_flow_hash_table;
 	struct flow_entry *ip_flow_entry_table;
+	/* RX queue on the front interface. */
+	uint16_t          rx_queue_front;
+	/* TX queue on the back interface. */
+	uint16_t          tx_queue_back;
 };
 
 /* Configuration for the GK functional block. */
@@ -45,10 +49,11 @@ struct gk_config {
 	 */
 	rte_atomic32_t	   ref_cnt;
 	struct gk_instance *instances;
+	struct net_config  *net;
 };
 
 struct gk_config *alloc_gk_conf(void);
-int run_gk(struct gk_config *gk_conf);
+int run_gk(struct net_config *net_conf, struct gk_config *gk_conf);
 int cleanup_gk(struct gk_config *gk_conf);
 
 #endif /* _GATEKEEPER_GK_H_ */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -21,6 +21,8 @@
 
 #include <stdint.h>
 
+#include <rte_atomic.h>
+
 /* Size of the secret key of the RSS hash. */
 #define GATEKEEPER_RSS_KEY_LEN (40)
 
@@ -39,6 +41,10 @@ struct gatekeeper_if {
 	/* Name of the interface. Needed for setting/getting bonded port. */
 	char		*name;
 
+	/* Number of RX and TX queues for this interface. */
+	uint16_t	num_rx_queues;
+	uint16_t	num_tx_queues;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
@@ -55,23 +61,61 @@ struct gatekeeper_if {
 	 * *bonded* port ID representing all of those ports.
 	 */
 	uint8_t         id;
+
+	/* The RX and TX queue assignments on this interface for each lcore. */
+	int16_t		rx_queues[RTE_MAX_LCORE];
+	int16_t		tx_queues[RTE_MAX_LCORE];
+
+	/*
+	 * The next RX and TX queues to be assigned on this interface.
+	 * We need atomic here in case multiple blocks are trying to
+	 * configure their queues on the same interface at the same time.
+	 */
+	rte_atomic16_t	rx_queue_id;
+	rte_atomic16_t	tx_queue_id;
 };
+
+/*
+ * The atomic counters for @rx_queue_id and @tx_queue_id are
+ * signed, so we get about 2^15 possible queues available for use,
+ * which is much more than is needed.
+ *
+ * Use this constant as an out-of-band value to represent that
+ * a queue has not been allocated; if one of the atomic counters
+ * reaches this value, we have exceeded the number of possible
+ * queues.
+ */
+#define GATEKEEPER_QUEUE_UNALLOCATED	(INT16_MIN)
+
+enum queue_type {
+	QUEUE_TYPE_RX,
+	QUEUE_TYPE_TX,
+	QUEUE_TYPE_MAX,
+};
+
+int get_queue_id(struct gatekeeper_if *iface, enum queue_type ty,
+	unsigned int lcore);
 
 /* Configuration for the Network. */
 struct net_config {
-	uint16_t		num_rx_queues;
-	uint16_t		num_tx_queues;
-
-	struct gatekeeper_if	front;
-	struct gatekeeper_if	back;
-
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */
+	struct gatekeeper_if	front;
+	struct gatekeeper_if	back;
+
 	uint32_t		num_ports;
 	uint32_t		numa_nodes;
 	struct rte_mempool 	**gatekeeper_pktmbuf_pool;
+
+	/*
+	 * Set to true while network devices are being configured,
+	 * and set to false when all network devices have started.
+	 * This is needed to enforce the ordering:
+	 *  configure devices -> configure per-block queues -> start devices
+	 */
+	volatile int		configuring;
 };
 
 extern uint8_t default_rss_key[GATEKEEPER_RSS_KEY_LEN];
@@ -85,6 +129,7 @@ struct gatekeeper_if *get_if_front(struct net_config *net_conf);
 struct gatekeeper_if *get_if_back(struct net_config *net_conf);
 int gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues);
 int gatekeeper_init_network(struct net_config *net_conf);
+int gatekeeper_start_network(void);
 void gatekeeper_free_network(void);
 
 #endif /* _GATEKEEPER_NET_H_ */

--- a/lib/net.c
+++ b/lib/net.c
@@ -247,7 +247,8 @@ gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues)
 	}
 
 	/* RETA update. */
-	ret = rte_eth_dev_rss_reta_update(portid, reta_conf, dev_info.reta_size);
+	ret = rte_eth_dev_rss_reta_update(portid, reta_conf,
+		dev_info.reta_size);
 	if (ret == -ENOTSUP) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu hardware doesn't support.",
@@ -469,15 +470,15 @@ gatekeeper_init_network(struct net_config *net_conf)
 	int i;
 	int ret = -1;
 
-	if (!net_conf)
+	if (net_conf == NULL)
 		return -1;
 
-	if (!config.gatekeeper_pktmbuf_pool) {
+	if (config.gatekeeper_pktmbuf_pool == NULL) {
 		config.numa_nodes = find_num_numa_nodes();
 		config.gatekeeper_pktmbuf_pool =
 			rte_calloc("mbuf_pool", config.numa_nodes,
 				sizeof(struct rte_mempool *), 0);
-		if (!config.gatekeeper_pktmbuf_pool) {
+		if (config.gatekeeper_pktmbuf_pool == NULL) {
 			RTE_LOG(ERR, MALLOC, "%s: Out of memory\n", __func__);
 			return -1;
 		}

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -1,13 +1,16 @@
 -- TODO Add configuration for other functional blocks.
 local block_names = {
-	"net",
 	"gk",
 }
 
 function gatekeeper_init()
+	local net = require("net")
+	local net_conf = net.setup_block()
+	if net_conf == nil then return -1 end
+
 	for _, value in ipairs(block_names) do
 		local block = require(value)
-		local ret = block.setup_block()
+		local ret = block.setup_block(net_conf)
 		if ret < 0 then return ret end
 	end
 

--- a/lua/gatekeeperc.lua
+++ b/lua/gatekeeperc.lua
@@ -5,15 +5,15 @@ local ffi = require("ffi")
 ffi.cdef[[
 
 struct gatekeeper_if {
-	char	**pci_addrs;
-	uint8_t	num_ports;
-	char	*name;
+	char     **pci_addrs;
+	uint8_t  num_ports;
+	char     *name;
+	uint16_t num_rx_queues;
+	uint16_t num_tx_queues;
 	/* This struct has hidden fields. */
 };
 
 struct net_config {
-	uint16_t num_rx_queues;
-	uint16_t num_tx_queues;
 	/* This struct has hidden fields. */
 };
 
@@ -40,7 +40,7 @@ struct gatekeeper_if *get_if_back(struct net_config *net_conf);
 int gatekeeper_init_network(struct net_config *net_conf);
 
 struct gk_config *alloc_gk_conf(void);
-int run_gk(struct gk_config *gk_conf);
+int run_gk(struct net_config *net_conf, struct gk_config *gk_conf);
 
 ]]
 

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -3,7 +3,7 @@ local gatekeeperc = require("gatekeeperc")
 local M = {}
 
 -- Function that sets up the GK functional block.
-function M.setup_block()
+function M.setup_block(net_conf)
 
 	-- Init the GK configuration structure.
 	local conf = gatekeeperc.alloc_gk_conf()
@@ -12,7 +12,7 @@ function M.setup_block()
 	conf.flow_ht_size = 1024
 
 	-- Setup the GK functional block.
-	return gatekeeperc.run_gk(conf)
+	return gatekeeperc.run_gk(net_conf, conf)
 end
 
 return M

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -20,18 +20,25 @@ function M.setup_block()
 
 	-- Change these parameters to configure the network.
 	local front_ports = {"enp133s0f0"}
+	local front_rx_queues = 2
+	local front_tx_queues = 0
+
 	local back_ports = {"enp133s0f1"}
-	conf.num_rx_queues = 3
-	conf.num_tx_queues = 3
+	local back_rx_queues = 0
+	local back_tx_queues = 2
 
 	-- Code below this point should not need to be changed.
 	local front_iface = gatekeeperc.get_if_front(conf)
+	front_iface.num_rx_queues = front_rx_queues
+	front_iface.num_tx_queues = front_tx_queues
 	local ret = init_iface(front_iface, "front", front_ports)
 	if ret < 0 then
-		return ret
+		return nil
 	end
 
 	local back_iface = gatekeeperc.get_if_back(conf)
+	back_iface.num_rx_queues = back_rx_queues
+	back_iface.num_tx_queues = back_tx_queues
 	ret = init_iface(back_iface, "back", back_ports)
 	if ret < 0 then
 		goto front
@@ -43,13 +50,13 @@ function M.setup_block()
 		goto back
 	end
 
-	do return ret end
+	do return conf end
 
 ::back::
 	gatekeeperc.lua_free_iface(back_iface)
 ::front::
 	gatekeeperc.lua_free_iface(front_iface)
-	return ret
+	return nil
 end
 
 return M

--- a/main/main.c
+++ b/main/main.c
@@ -155,11 +155,19 @@ main(int argc, char **argv)
 
 	ret = config_and_launch();
 	if (ret < 0) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"Fail to initialize Gatekeeper!\n");
+		RTE_LOG(ERR, GATEKEEPER, "Failed to initialize Gatekeeper!\n");
+		exiting = true;
+		goto wait;
+	}
+
+	ret = gatekeeper_start_network();
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER, "Failed to start Gatekeeper!\n");
 		exiting = true;
 	}
 
+wait:
+	get_net_conf()->configuring = false;
 	rte_eal_mp_wait_lcore();
 
 	/* TODO Perform any needed state destruction. */


### PR DESCRIPTION
This patch removes the assumption that all blocks use both the TX
and RX queues on both interfaces. It allows each block to be assigned
a queue identifier on a per-interface, per-queue type (RX or TX)
basis. Gatekeeper can now be run with any set of lcores, and permits
different numbers of RX queues and TX queues to be created on the
different interfaces.

To do so, the configuration must be split up. This is because these
functions must be called in this order:
- rte_eth_dev_configure()
- rte_eth_rx_queue_setup()/rte_eth_tx_queue_setup()
- rte_eth_dev_start()

Therefore, the net configuration code must configure each port,
and then allow the functional blocks to run so that they may
call the rte_eth_{r/t}x_queue_setup() functions via assign_queue_id().
Then, the functional blocks wait for the devices to be started.
