### PR TITLE
Add IPIP encapsulation for GK, and a simple GK-GT Unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ SRCS-y += lls/main.c
 SRCS-y += rt/main.c
 
 # Libraries.
-SRCS-y += lib/mailbox.c lib/net.c
+SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c
 
 LDLIBS += $(LDIR) -lm -lluajit-5.1
 CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include -I/usr/local/include/luajit-2.0/

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -16,11 +16,391 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
+
+#include <rte_ip.h>
+#include <rte_udp.h>
+#include <rte_log.h>
+#include <rte_lcore.h>
+#include <rte_malloc.h>
+#include <rte_ethdev.h>
+#include <rte_atomic.h>
+
+#include "gatekeeper_gk.h"
 #include "gatekeeper_ggu.h"
+#include "gatekeeper_net.h"
+#include "gatekeeper_main.h"
+#include "gatekeeper_config.h"
+
+#define GGU_PD_VER1 (1)
+
+static void
+process_single_policy(const struct ggu_policy *policy, const struct ggu_config *ggu_conf)
+{
+	struct gk_cmd_entry *entry;
+	/*
+	 * Obtain mailbox of that GK block,
+	 * and send the policy decision to the GK block.
+	 */
+	struct mailbox *mb =
+		get_responsible_gk_mailbox(&policy->flow, ggu_conf->gk);
+
+	if (mb == NULL)
+		return;
+
+	entry = mb_alloc_entry(mb);
+	if (entry == NULL)
+		return;
+
+	entry->op = GGU_POLICY_ADD;
+	entry->u.ggu.state = policy->state;
+	rte_memcpy(&entry->u.ggu.flow, &policy->flow, sizeof(entry->u.ggu.flow));
+
+	switch(policy->state) {
+	case GK_GRANTED:
+		entry->u.ggu.params.u.granted.tx_rate_kb_sec =
+			rte_be_to_cpu_32(
+			policy->params.u.granted.tx_rate_kb_sec);
+		entry->u.ggu.params.u.granted.cap_expire_sec =
+			rte_be_to_cpu_32(
+			policy->params.u.granted.cap_expire_sec);
+		entry->u.ggu.params.u.granted.next_renewal_ms =
+			rte_be_to_cpu_32(
+			policy->params.u.granted.next_renewal_ms);
+		entry->u.ggu.params.u.granted.renewal_step_ms =
+			rte_be_to_cpu_32(
+			policy->params.u.granted.renewal_step_ms);
+		break;
+
+	case GK_DECLINED:
+		entry->u.ggu.params.u.declined.expire_sec =
+			rte_be_to_cpu_32(policy->params.u.declined.expire_sec);
+		break;
+
+	default:
+		RTE_LOG(ERR, GATEKEEPER, "ggu: impossible policy state %hhu\n",
+			policy->state);
+		mb_free_entry(mb, entry);
+		return;
+	}
+
+	mb_send_entry(mb, entry);
+}
+
+static int
+validate_packet_len(struct rte_mbuf *pkt, uint16_t proto)
+{
+	uint16_t minimum_size = sizeof(struct ether_hdr);
+
+	if (proto == ETHER_TYPE_IPv4)
+		minimum_size += sizeof(struct ipv4_hdr);
+	else if (proto == ETHER_TYPE_IPv6)
+		minimum_size += sizeof(struct ipv6_hdr);
+	else {
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"ggu: unknown packet type %hu\n",
+			proto);
+		return -1;
+	}
+
+	minimum_size += sizeof(struct udp_hdr) + sizeof(struct ggu_common_hdr);
+
+	if (pkt->data_len < minimum_size) {
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"ggu: the packet's actual size is %hu, which doesn't have the minimum expected size %hu\n",
+			pkt->data_len, minimum_size);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void
+process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
+{
+	uint8_t j;
+	uint8_t *policy_ptr;
+	uint16_t ether_type;
+	struct ether_hdr *eth_hdr;
+	struct ipv4_hdr *ip4hdr;
+	struct ipv6_hdr *ip6hdr;
+	struct udp_hdr *udphdr;
+	struct ggu_common_hdr *gguhdr;
+	uint16_t real_payload_len;
+	uint16_t expected_payload_len;
+	struct ggu_policy policy;
+
+	eth_hdr = rte_pktmbuf_mtod(pkt, struct ether_hdr *);
+	ether_type = rte_be_to_cpu_16(eth_hdr->ether_type);
+
+	switch (ether_type) {
+	case ETHER_TYPE_IPv4:
+		if (validate_packet_len(pkt, ETHER_TYPE_IPv4) < 0)
+			goto free_packet;
+
+		ip4hdr = rte_pktmbuf_mtod_offset(pkt, 
+			struct ipv4_hdr *, sizeof(struct ether_hdr));
+		if (ip4hdr->next_proto_id != IPPROTO_UDP) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"ggu: received non-UDP packets, IPv4 ntuple filter bug!\n");
+			goto free_packet;
+		}
+
+		if (ip4hdr->dst_addr != ggu_conf->net->back.ip4_addr.s_addr) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"ggu: received packets not destined to the Gatekeeper server, IPv4 ntuple filter bug!\n");
+			goto free_packet;
+		}
+
+		udphdr = (struct udp_hdr *)&ip4hdr[1];
+		break;
+
+	case ETHER_TYPE_IPv6:
+		if (validate_packet_len(pkt, ETHER_TYPE_IPv6) < 0)
+			goto free_packet;
+
+		ip6hdr = rte_pktmbuf_mtod_offset(pkt, 
+			struct ipv6_hdr *, sizeof(struct ether_hdr));
+		if (ip6hdr->proto != IPPROTO_UDP) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"ggu: received non-UDP packets, IPv6 ntuple filter bug!\n");
+			goto free_packet;
+		}
+
+		/*
+		 * TODO Given that IPv6 ntuple filter doesn't check
+		 * the destination address, it must be done here.
+		 * If the IPv6 packet is not destined to
+		 * the Gatekeeper server, redirect the packet properly.
+		 */
+		if (memcmp(ip6hdr->dst_addr,
+				ggu_conf->net->back.ip6_addr.s6_addr,
+				sizeof(ip6hdr->dst_addr)) != 0) {
+			return;
+		}
+
+		udphdr = (struct udp_hdr *)&ip6hdr[1];
+		break;
+
+	default:
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"ggu: unknown network layer protocol %hu\n",
+			ether_type);
+		goto free_packet;
+		break;
+	}
+
+	if (udphdr->src_port != ggu_conf->ggu_src_port ||
+			udphdr->dst_port != ggu_conf->ggu_dst_port) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"ggu: unknown udp src port %hu, dst port %hu, ntuple filter bug!\n",
+			rte_be_to_cpu_16(udphdr->src_port),
+			rte_be_to_cpu_16(udphdr->dst_port));
+		goto free_packet;
+	}
+
+	/* XXX Check the UDP checksum. */
+
+	gguhdr = (struct ggu_common_hdr *)&udphdr[1];
+	if (gguhdr->v1 != GGU_PD_VER1) {
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"ggu: unknown policy decision format %hhu\n",
+			gguhdr->v1);
+		goto free_packet;
+	}
+
+	policy_ptr = (uint8_t *)&gguhdr[1];
+
+	real_payload_len = rte_be_to_cpu_16(udphdr->dgram_len);
+	expected_payload_len = sizeof(*udphdr) + sizeof(*gguhdr) +
+		(gguhdr->n1 + gguhdr->n3) * sizeof(policy.flow.f.v4) +
+		(gguhdr->n2 + gguhdr->n4) * sizeof(policy.flow.f.v6) +
+		(gguhdr->n1 + gguhdr->n2) * sizeof(policy.params.u.declined) + 
+		(gguhdr->n3 + gguhdr->n4) * sizeof(policy.params.u.granted);
+	if (real_payload_len < expected_payload_len) {
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"ggu: the size (%hu) of the payload available in the UDP header doesn't match the expected size (%hu)!\n",
+			real_payload_len, expected_payload_len);
+		goto free_packet;
+	}
+
+	/* Loop over each policy decision on the packet. */
+
+	/* Process the IPv4 decline decisions. */
+	memset(&policy, 0, sizeof(policy));
+	policy.state = GK_DECLINED;
+	policy.flow.proto = ETHER_TYPE_IPv4;
+	for (j = 0; j < gguhdr->n1; j++) {
+		rte_memcpy(&policy.flow.f.v4, policy_ptr,
+			sizeof(policy.flow.f.v4));
+		policy_ptr += sizeof(policy.flow.f.v4);
+		rte_memcpy(&policy.params.u.declined, policy_ptr,
+			sizeof(policy.params.u.declined));
+		policy_ptr += sizeof(policy.params.u.declined);
+		process_single_policy(&policy, ggu_conf);
+	}
+
+	/* Process the IPv6 decline decisions. */
+	policy.flow.proto = ETHER_TYPE_IPv6;
+	for (j = 0; j < gguhdr->n2; j++) {
+		rte_memcpy(&policy.flow.f.v6, policy_ptr,
+			sizeof(policy.flow.f.v6));
+		policy_ptr += sizeof(policy.flow.f.v6);
+		rte_memcpy(&policy.params.u.declined, policy_ptr,
+			sizeof(policy.params.u.declined));
+		policy_ptr += sizeof(policy.params.u.declined);
+		process_single_policy(&policy, ggu_conf);
+	}
+
+	/* Process the IPv4 granted decisions. */
+	policy.state = GK_GRANTED;
+	policy.flow.proto = ETHER_TYPE_IPv4;
+	for (j = 0; j < gguhdr->n3; j++) {
+		rte_memcpy(&policy.flow.f.v4, policy_ptr,
+			sizeof(policy.flow.f.v4));
+		policy_ptr += sizeof(policy.flow.f.v4);
+		rte_memcpy(&policy.params.u.granted, policy_ptr,
+			sizeof(policy.params.u.granted));
+		policy_ptr += sizeof(policy.params.u.granted);
+		process_single_policy(&policy, ggu_conf);
+	}
+
+	/* Process the IPv6 granted decisions. */
+	policy.flow.proto = ETHER_TYPE_IPv6;
+	for (j = 0; j < gguhdr->n4; j++) {
+		rte_memcpy(&policy.flow.f.v6, policy_ptr,
+			sizeof(policy.flow.f.v6));
+		policy_ptr += sizeof(policy.flow.f.v6);
+		rte_memcpy(&policy.params.u.granted, policy_ptr,
+			sizeof(policy.params.u.granted));
+		policy_ptr += sizeof(policy.params.u.granted);
+		process_single_policy(&policy, ggu_conf);
+	}
+
+free_packet:
+	rte_pktmbuf_free(pkt);
+}
+
+static int
+ggu_proc(void *arg)
+{
+	int ret;
+	uint32_t lcore = rte_lcore_id();
+	struct ggu_config *ggu_conf = (struct ggu_config *)arg;
+	uint8_t port_in = ggu_conf->net->back.id;
+	uint16_t rx_queue = ggu_conf->rx_queue_back;
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"ggu: the GK-GT unit is running at lcore = %u\n", lcore);
+
+	/* Wait for network devices to start. */
+	while (ggu_conf->net->configuring)
+		;
+
+	/*
+	 * Setup the ntuple filter that assign the GK-GT packets
+	 * to its queue for both IPv4 and IPv6 addresses.
+	 * Accordnig to the DPDK documentation, any functions from
+	 * the rte_ethdev.h library should be called after the 
+	 * network devices are started. So as the ntuple filters functions.
+	 */
+	ret = ntuple_filter_add(port_in,
+		ggu_conf->net->back.ip4_addr.s_addr,
+		ggu_conf->ggu_src_port,
+		ggu_conf->ggu_dst_port,
+		ggu_conf->rx_queue_back);
+	if (ret < 0)
+		exiting = true;
+
+	while (likely(!exiting)) {
+		uint16_t i;
+		uint16_t num_rx;
+		struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
+
+		/* Load a set of GK-GT packets from the back NIC. */
+		num_rx = rte_eth_rx_burst(port_in, rx_queue, bufs,
+			GATEKEEPER_MAX_PKT_BURST);
+		if (unlikely(num_rx == 0))
+			continue;
+
+		for (i = 0; i < num_rx; i++)
+			process_single_packet(bufs[i], ggu_conf);
+	}
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"ggu: the GK-GT unit at lcore = %u is exiting\n", lcore);
+	return cleanup_ggu(ggu_conf);
+}
 
 int
-run_ggu(__attribute__((unused)) const struct ggu_config *ggu_conf)
+run_ggu(struct net_config *net_conf,
+	struct gk_config *gk_conf, struct ggu_config *ggu_conf)
 {
-	/* TODO Initialize and run GK-GT Unit functional block. */
+	int ret;
+
+	if (ggu_conf == NULL || net_conf == NULL || gk_conf == NULL) {
+		ret = -1;
+		goto out;
+	}
+
+	ggu_conf->net = net_conf;
+	gk_conf_hold(gk_conf);
+	ggu_conf->gk = gk_conf;
+
+	/*
+	 * Convert port numbers in CPU order to network order
+	 * to avoid recomputation for each packet.
+	 */
+	ggu_conf->ggu_src_port = rte_cpu_to_be_16(ggu_conf->ggu_src_port);
+	ggu_conf->ggu_dst_port = rte_cpu_to_be_16(ggu_conf->ggu_dst_port);
+
+	ret = get_queue_id(&ggu_conf->net->back,
+		QUEUE_TYPE_RX, ggu_conf->lcore_id);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER, "gk: cannot assign an RX queue for the back interface for lcore %u\n",
+			ggu_conf->lcore_id);
+		goto out;
+	}
+	ggu_conf->rx_queue_back = (uint16_t)ret;
+
+	ret = rte_eal_remote_launch(ggu_proc, ggu_conf, ggu_conf->lcore_id);
+	if (ret) {
+		RTE_LOG(ERR, EAL, "lcore %u failed to launch GGU\n",
+			ggu_conf->lcore_id);
+		ret = -1;
+		goto out;
+	}
+
+	ret = 0;
+out:
+	return ret;
+}
+
+/*
+ * There should be only one ggu_config instance.
+ * Return an error if trying to allocate the second instance.
+ */
+struct ggu_config *
+alloc_ggu_conf(void)
+{
+	static rte_atomic16_t num_ggu_conf_alloc = RTE_ATOMIC16_INIT(0);
+
+	if (rte_atomic16_test_and_set(&num_ggu_conf_alloc) == 1)
+		return rte_calloc("ggu_config", 1, sizeof(struct ggu_config), 0);
+	else {
+		RTE_LOG(ERR, GATEKEEPER,
+			"ggu: trying to allocate the second instance of struct ggu_config\n");
+		return NULL;
+	}
+}
+
+int
+cleanup_ggu(struct ggu_config *ggu_conf)
+{
+	ggu_conf->net = NULL;
+	gk_conf_put(ggu_conf->gk);
+	ggu_conf->gk = NULL;
+	rte_free(ggu_conf);
+
 	return 0;
 }

--- a/include/gatekeeper_config.h
+++ b/include/gatekeeper_config.h
@@ -77,6 +77,8 @@
  */
 #define GATEKEEPER_CACHE_SIZE	(512)
 
+#define GATEKEEPER_MAX_PKT_BURST (32)
+
 /* Configuration for the Dynamic Config functional block. */
 struct dynamic_config {
 	unsigned int	lcore_id;

--- a/include/gatekeeper_flow.h
+++ b/include/gatekeeper_flow.h
@@ -1,0 +1,47 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_FLOW_H_
+#define _GATEKEEPER_FLOW_H_
+
+#include <stdio.h>
+#include <stdint.h>
+
+struct ip_flow {
+	/* IPv4 or IPv6. */
+	uint16_t proto;
+
+	union {
+		struct {
+			uint32_t src;
+			uint32_t dst;
+		} v4;
+
+		struct {
+			uint8_t src[16];
+			uint8_t dst[16];
+		} v6;
+	} f;
+};
+
+uint32_t rss_ip_flow_hf(const void *data,
+	uint32_t data_len, uint32_t init_val);
+
+int ip_flow_cmp_eq(const void *key1, const void *key2, size_t key_len);
+
+#endif /* _GATEKEEPER_FLOW_H_ */

--- a/include/gatekeeper_ggu.h
+++ b/include/gatekeeper_ggu.h
@@ -19,11 +19,106 @@
 #ifndef _GATEKEEPER_GGU_H_
 #define _GATEKEEPER_GGU_H_
 
+#include "gatekeeper_net.h"
+#include "gatekeeper_flow.h"
+
 /* Configuration for the GK-GT Unit functional block. */
 struct ggu_config {
-	unsigned int	lcore_id;
+	unsigned int      lcore_id;
+
+	/* The UDP source and destination port numbers for GGU. */
+	uint16_t          ggu_src_port;
+	uint16_t          ggu_dst_port;
+
+	/*
+	 * The fields below are for internal use.
+	 * Configuration files should not refer to them.
+	 */
+
+	/* RX queue on the back interface. */
+	uint16_t          rx_queue_back;
+	struct net_config *net;
+	struct gk_config  *gk;
 };
 
-int run_ggu(const struct ggu_config *ggu_conf);
+/*
+ * Since the length of IPv6 policy is much larger than IPv4 policy,
+ * to save network bandwidth, we choose to use different data structures
+ * to store the in-packet policies for IPv4 and IPv6, respectively.
+ *
+ * Packet format: Ethernet headers + IP header + UDP header + Data.
+ * In the UDP payload, the following format would save a lot of bytes
+ * when there are decline decisions:
+ *  v1, n1, n2, n3, n4: Each of these fields are 1-byte long.
+ *  v1 is a constant indicating the version of the format, in this case 1.
+ *  n1 is the number of IPv4 decline decisions.
+ *  n2 is the number of IPv6 decline decisions.
+ *  n3 is the number of IPv4 granted decisions.
+ *  n4 is the number of IPv6 granted decisions.
+ * 
+ * Field v1 will enable us to change the format, incrementally update
+ * the Gatekeeper servers, and incrementally update the Grantor servers.
+ *
+ * Notice that, to guarantee that all the accesses after struct ggu_common_hdr
+ * in a packet are 32-bit aligned, we add uint8_t reserved[3]; at the very end
+ * of struct ggu_common_hdr.
+ */
+struct ggu_common_hdr {
+	uint8_t v1;
+	uint8_t n1;
+	uint8_t n2;
+	uint8_t n3;
+	uint8_t n4;
+	uint8_t reserved[3];
+}__attribute__((packed));
+
+struct ggu_policy {
+	uint8_t  state;
+	struct ip_flow flow;
+
+	struct {
+		/*
+		 * XXX Add state fields for the flow if necessary.
+		 * The policy decision sent to a GK block must have
+		 * enough information to fill out the fields of
+		 * struct flow_entry at the corresponding state.
+		 */
+		union {
+			struct {
+				/* Rate limit: kilobyte/second. */
+				uint32_t tx_rate_kb_sec;
+				/*
+				 * How much time (unit: second) a GK block waits
+				 * before it expires the capability.
+				 */
+				uint32_t cap_expire_sec;
+				/*
+				 * The first value of send_next_renewal_at at
+				 * flow entry comes from next_renewal_ms.
+				 */
+				uint32_t next_renewal_ms;
+				/*
+				 * How many milliseconds (unit) GK must wait
+				 * before sending the next capability renewal
+				 * request.
+				 */
+				uint32_t renewal_step_ms;
+			} granted;
+
+			struct {
+				/*
+				 * How much time (unit: second) a GK block waits
+				 * before it expires the declined capability.
+				 */
+				uint32_t expire_sec;
+			} declined;
+		} u;
+	}__attribute__((packed)) params;
+};
+
+struct ggu_config *alloc_ggu_conf(void);
+int run_ggu(struct net_config *net_conf,
+	struct gk_config *gk_conf, struct ggu_config *ggu_conf);
+int cleanup_ggu(struct ggu_config *ggu_conf);
 
 #endif /* _GATEKEEPER_GGU_H_ */

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -21,6 +21,16 @@
 
 #include <rte_atomic.h>
 
+#include "gatekeeper_ipip.h"
+#include "gatekeeper_ggu.h"
+#include "gatekeeper_mailbox.h"
+
+/*
+ * A flow entry can be in one of three states:
+ * request, granted, or declined.
+ */
+enum gk_flow_state { GK_REQUEST, GK_GRANTED, GK_DECLINED };
+
 /* Structures for each GK instance. */
 struct gk_instance {
 	struct rte_hash   *ip_flow_hash_table;
@@ -29,6 +39,7 @@ struct gk_instance {
 	uint16_t          rx_queue_front;
 	/* TX queue on the back interface. */
 	uint16_t          tx_queue_back;
+	struct mailbox    mb; 
 };
 
 /* Configuration for the GK functional block. */
@@ -50,10 +61,36 @@ struct gk_config {
 	rte_atomic32_t	   ref_cnt;
 	struct gk_instance *instances;
 	struct net_config  *net;
+	struct gatekeeper_rss_config rss_conf;
+};
+
+/* Define the possible command operations for GK block. */
+enum gk_cmd_op { GGU_POLICY_ADD, };
+
+/*
+ * XXX Structure for each command. Add new fields to support more commands.
+ *
+ * Notice that, the writers of a GK mailbox: the GK-GT unit and Dynamic config.
+ */
+struct gk_cmd_entry {
+	enum gk_cmd_op  op;
+
+	union {
+		struct ggu_policy ggu;
+	} u;
 };
 
 struct gk_config *alloc_gk_conf(void);
+int gk_conf_put(struct gk_config *gk_conf);
 int run_gk(struct net_config *net_conf, struct gk_config *gk_conf);
 int cleanup_gk(struct gk_config *gk_conf);
+struct mailbox *get_responsible_gk_mailbox(
+	const struct ip_flow *flow, const struct gk_config *gk_conf);
+
+static inline void
+gk_conf_hold(struct gk_config *gk_conf)
+{
+	rte_atomic32_inc(&gk_conf->ref_cnt);
+}
 
 #endif /* _GATEKEEPER_GK_H_ */

--- a/include/gatekeeper_ipip.h
+++ b/include/gatekeeper_ipip.h
@@ -1,0 +1,36 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_IPIP_H_
+#define _GATEKEEPER_IPIP_H_
+
+#include <rte_ether.h>
+
+#include "gatekeeper_flow.h"
+
+struct ipip_tunnel_info {
+	struct ip_flow	     flow;
+	struct ether_addr    source_mac;
+	/* TODO The MAC addresses must come from the LLS block. */
+	struct ether_addr    nexthop_mac;
+};
+
+int encapsulate(struct rte_mbuf *pkt, uint8_t priority,
+	struct ipip_tunnel_info *info);
+
+#endif /* _GATEKEEPER_IPIP_H_ */

--- a/include/gatekeeper_mailbox.h
+++ b/include/gatekeeper_mailbox.h
@@ -19,14 +19,33 @@
 #ifndef _GATEKEEPER_MAILBOX_H_
 #define _GATEKEEPER_MAILBOX_H_
 
-/*
- * TODO Remove this preprocessing directive when there are
- * are calls to these functions; for now, the mailbox is
- * just an example of how to set up a library.
- */
-#if 0
-void create_mailbox(void);
-void destroy_mailbox(void);
-#endif
+#include <rte_ring.h>
+#include <rte_mempool.h>
+
+#include "gatekeeper_main.h"
+
+struct mailbox {
+	struct rte_ring    *ring;
+	struct rte_mempool *pool;
+};
+
+int init_mailbox(
+	const char *tag, int ele_count,
+	int ele_size, unsigned int lcore_id, struct mailbox *mb);
+void *mb_alloc_entry(struct mailbox *mb);
+int mb_send_entry(struct mailbox *mb, void *obj);
+void destroy_mailbox(struct mailbox *mb);
+
+static inline int
+mb_dequeue_burst(struct mailbox *mb, void **obj_table, unsigned n)
+{
+	return rte_ring_sc_dequeue_burst(mb->ring, obj_table, n);
+}
+
+static inline void
+mb_free_entry(struct mailbox *mb, void *obj)
+{
+	rte_mempool_put(mb->pool, obj);
+}
 
 #endif /* _GATEKEEPER_MAILBOX_H_ */

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -31,6 +31,7 @@
 extern volatile int exiting;
 
 extern uint64_t cycles_per_sec;
+extern uint64_t cycles_per_ms;
 extern uint64_t picosec_per_cycle;
 
 #endif /* _GATEKEEPER_MAIN_H_ */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -20,6 +20,7 @@
 #define _GATEKEEPER_NET_H_
 
 #include <stdint.h>
+#include <netinet/in.h>
 
 #include <rte_atomic.h>
 
@@ -73,6 +74,15 @@ struct gatekeeper_if {
 	 */
 	rte_atomic16_t	rx_queue_id;
 	rte_atomic16_t	tx_queue_id;
+
+	/*
+	 * Specify the IPv4 and IPv6 addresses of this interface.
+	 * Notice that, while one address must always be there,
+	 * there may not be the second address.
+	 */
+	uint8_t         configured_proto;
+	struct in_addr  ip4_addr;
+	struct in6_addr ip6_addr;
 };
 
 /*
@@ -119,9 +129,11 @@ struct net_config {
 };
 
 extern uint8_t default_rss_key[GATEKEEPER_RSS_KEY_LEN];
+extern uint8_t rss_key_be[RTE_DIM(default_rss_key)];
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
-	const char **pci_addrs, uint8_t num_pci_addrs);
+	const char **pci_addrs, uint8_t num_pci_addrs,
+	const char **ip_addrs, uint8_t num_ip_addrs);
 void lua_free_iface(struct gatekeeper_if *iface);
 
 struct net_config *get_net_conf(void);

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -22,10 +22,26 @@
 #include <stdint.h>
 #include <netinet/in.h>
 
+#include <rte_ethdev.h>
+
 #include <rte_atomic.h>
 
 /* Size of the secret key of the RSS hash. */
 #define GATEKEEPER_RSS_KEY_LEN (40)
+
+/*
+ * The maximum number of "rte_eth_rss_reta_entry64" structures can be used to
+ * configure the Redirection Table of the Receive Side Scaling (RSS) feature.
+ * Notice, each "rte_eth_rss_reta_entry64" structure can configure 64 entries 
+ * of the table. To configure more than 64 entries supported by hardware,
+ * an array of this structure is needed.
+ */
+#define GATEKEEPER_RETA_MAX_SIZE (ETH_RSS_RETA_SIZE_512 / RTE_RETA_GROUP_SIZE)
+
+struct gatekeeper_rss_config {
+	uint16_t reta_size;
+	struct rte_eth_rss_reta_entry64 reta_conf[GATEKEEPER_RETA_MAX_SIZE];
+};
 
 /*
  * A Gatekeeper interface is specified by a set of PCI addresses
@@ -136,10 +152,14 @@ int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **ip_addrs, uint8_t num_ip_addrs);
 void lua_free_iface(struct gatekeeper_if *iface);
 
+int ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
+	uint16_t src_port, uint16_t dst_port, uint16_t queue_id);
 struct net_config *get_net_conf(void);
 struct gatekeeper_if *get_if_front(struct net_config *net_conf);
 struct gatekeeper_if *get_if_back(struct net_config *net_conf);
 int gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues);
+int gatekeeper_get_rss_config(uint8_t portid,
+	struct gatekeeper_rss_config *rss_conf);
 int gatekeeper_init_network(struct net_config *net_conf);
 int gatekeeper_start_network(void);
 void gatekeeper_free_network(void);

--- a/lib/flow.c
+++ b/lib/flow.c
@@ -1,0 +1,111 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <rte_thash.h>
+#include <rte_debug.h>
+#include <rte_ether.h>
+
+#include "gatekeeper_net.h"
+#include "gatekeeper_flow.h"
+
+/*
+ * Optimized generic implementation of RSS hash function.
+ * If you want the calculated hash value matches NIC RSS value,
+ * you have to use special converted key with rte_convert_rss_key() fn.
+ * @param input_tuple
+ *   Pointer to input tuple with network order.
+ * @param input_len
+ *   Length of input_tuple in 4-bytes chunks.
+ * @param *rss_key
+ *   Pointer to RSS hash key.
+ * @return
+ *   Calculated hash value.
+ */
+static inline uint32_t
+gk_softrss_be(const uint32_t *input_tuple, uint32_t input_len,
+		const uint8_t *rss_key)
+{
+	uint32_t i;
+	uint32_t j;
+	uint32_t ret = 0;
+
+	for (j = 0; j < input_len; j++) {
+		/*
+		 * Need to use little endian,
+		 * since it takes ordering as little endian in both bytes and bits.
+		 */
+		uint32_t val = rte_be_to_cpu_32(input_tuple[j]);
+		for (i = 0; i < 32; i++)
+			if (val & (1 << (31 - i))) {
+				/*
+				 * The cast (uint64_t) is needed because when
+				 * @i == 0, the expression requires a 32-bit
+				 * shift of a 32-bit unsigned integer,
+				 * what is undefined.
+				 * The C standard only defines bit shifting
+				 * up to the bit-size of the integer minus one.
+				 * Finally, the cast (uint32_t) avoid promoting
+				 * the expression before the bit-or (i.e. `|`)
+				 * to uint64_t.
+				 */
+				ret ^= ((const uint32_t *)rss_key)[j] << i |
+					(uint32_t)((uint64_t)
+						(((const uint32_t *)rss_key)
+							[j + 1])
+						>> (32 - i));
+			}
+	}
+
+	return ret;
+}
+
+uint32_t
+rss_ip_flow_hf(const void *data,
+	__attribute__((unused)) uint32_t data_len,
+        __attribute__((unused)) uint32_t init_val)
+{
+	const struct ip_flow *flow = (const struct ip_flow *)data;
+
+	if (flow->proto == ETHER_TYPE_IPv4)
+		return gk_softrss_be((const uint32_t *)&flow->f,
+				(sizeof(flow->f.v4)/sizeof(uint32_t)), rss_key_be);
+	else if (flow->proto == ETHER_TYPE_IPv6)
+		return gk_softrss_be((const uint32_t *)&flow->f,
+				(sizeof(flow->f.v6)/sizeof(uint32_t)), rss_key_be);
+	else
+		RTE_ASSERT(false);
+
+	return 0;
+}
+
+/* Type of function used to compare the hash key. */
+int
+ip_flow_cmp_eq(const void *key1, const void *key2,
+	__attribute__((unused)) size_t key_len)
+{
+	const struct ip_flow *f1 = (const struct ip_flow *)key1;
+	const struct ip_flow *f2 = (const struct ip_flow *)key2;
+
+	if (f1->proto != f2->proto)
+		return f1->proto == ETHER_TYPE_IPv4 ? -1 : 1;
+
+	if (f1->proto == ETHER_TYPE_IPv4)
+		return memcmp(&f1->f.v4, &f2->f.v4, sizeof(f1->f.v4));
+	else
+		return memcmp(&f1->f.v6, &f2->f.v6, sizeof(f1->f.v6));
+}

--- a/lib/ipip.c
+++ b/lib/ipip.c
@@ -1,0 +1,133 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+#include <rte_memcpy.h>
+#include <rte_byteorder.h>
+
+#include "gatekeeper_ipip.h"
+
+#define IP_VERSION              (0x40)
+/* Default IP header length == five 32-bits words. */
+#define IP_HDRLEN               (0x05)
+/* From RFC 1340. */
+#define IP_DEFTTL               (64)
+#define IP_VHL_DEF              (IP_VERSION | IP_HDRLEN)
+#define IP_DN_FRAGMENT_FLAG     (0x0040)
+
+#define IPv6_DEFAULT_VTC_FLOW   (0x60000000)
+#define IPv6_DEFAULT_HOP_LIMITS (0xFF)
+
+int
+encapsulate(struct rte_mbuf *pkt, uint8_t priority,
+	struct ipip_tunnel_info *info)
+{
+	struct ether_hdr *new_eth;
+	struct ipv4_hdr *outer_ip4hdr;
+	struct ipv6_hdr *outer_ip6hdr;
+
+	if (info->flow.proto == ETHER_TYPE_IPv4) {
+		/* Allocate space for outer IPv4 header. */
+		new_eth = (struct ether_hdr *)rte_pktmbuf_prepend(pkt,
+			sizeof(struct ipv4_hdr));
+		if (new_eth == NULL) {
+			RTE_LOG(ERR, MBUF,
+				"Not enough headroom space in the first segment!\n");
+			return -1;
+		}
+
+		outer_ip4hdr = (struct ipv4_hdr *)&new_eth[1];
+
+		/* Fill up the new Ethernet header. */
+		rte_memcpy(&new_eth->s_addr, &info->source_mac,
+			sizeof(new_eth->s_addr));
+		/* Fill up the destination MAC address via Gateway MAC. */
+		rte_memcpy(&new_eth->d_addr, &info->nexthop_mac,
+			sizeof(new_eth->d_addr));
+
+		new_eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_IPv4);
+
+		/* Fill up the outer IP header. */
+		outer_ip4hdr->version_ihl = IP_VHL_DEF;
+		outer_ip4hdr->type_of_service = (priority << 2);
+		outer_ip4hdr->packet_id = 0;
+		outer_ip4hdr->fragment_offset = IP_DN_FRAGMENT_FLAG;
+		outer_ip4hdr->time_to_live = IP_DEFTTL;
+		outer_ip4hdr->next_proto_id = IPPROTO_IPIP;
+		/* The source address is the Gatekeeper server IP address. */
+		outer_ip4hdr->src_addr = info->flow.f.v4.src;
+		/* The destination address is the Grantor server IP address. */
+		outer_ip4hdr->dst_addr = info->flow.f.v4.dst;
+
+		outer_ip4hdr->total_length = rte_cpu_to_be_16(pkt->data_len
+			- sizeof(struct ether_hdr));
+
+		/*
+		 * The IP header checksum filed must be set to 0
+		 * in order to offload the checksum calculation.
+		 */
+		outer_ip4hdr->hdr_checksum = 0;
+
+		pkt->outer_l2_len = sizeof(struct ether_hdr);
+		pkt->outer_l3_len = sizeof(struct ipv4_hdr);
+		/* Offload checksum computation for the outer IPv4 header. */
+		pkt->ol_flags |= (PKT_TX_IPV4 |
+			PKT_TX_IP_CKSUM | PKT_TX_OUTER_IPV4);
+	} else if (info->flow.proto == ETHER_TYPE_IPv6) {
+		/* Allocate space for new IPv6 header. */
+		new_eth = (struct ether_hdr *)rte_pktmbuf_prepend(pkt,
+			sizeof(struct ipv6_hdr));
+		if (new_eth == NULL) {
+			RTE_LOG(ERR, MBUF,
+				"Not enough headroom space in the first segment!\n");
+			return -1;
+		}
+
+		outer_ip6hdr = (struct ipv6_hdr *)&new_eth[1];
+
+		/* Fill up the new Ethernet header. */
+		rte_memcpy(&new_eth->s_addr, &info->source_mac,
+			sizeof(new_eth->s_addr));
+		/* Fill up the destination MAC address via Gateway MAC. */
+		rte_memcpy(&new_eth->d_addr, &info->nexthop_mac,
+			sizeof(new_eth->d_addr));
+
+		new_eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_IPv6);
+
+		/* Fill up the outer IP header. */
+		outer_ip6hdr->vtc_flow = rte_cpu_to_be_32(
+			IPv6_DEFAULT_VTC_FLOW | (priority << 18));
+		outer_ip6hdr->proto = IPPROTO_IPIP; 
+		outer_ip6hdr->hop_limits = IPv6_DEFAULT_HOP_LIMITS;
+
+		rte_memcpy(outer_ip6hdr->src_addr, info->flow.f.v6.src,
+			sizeof(info->flow.f.v6.src));
+		rte_memcpy(outer_ip6hdr->dst_addr, info->flow.f.v6.dst,
+			sizeof(info->flow.f.v6.dst));
+
+		outer_ip6hdr->payload_len = rte_cpu_to_be_16(pkt->data_len
+			- sizeof(struct ether_hdr));
+
+		pkt->outer_l2_len = sizeof(struct ether_hdr);
+		pkt->outer_l3_len = sizeof(struct ipv6_hdr);
+	} else 
+		return -1;
+
+	return 0;
+}

--- a/lib/net.c
+++ b/lib/net.c
@@ -36,14 +36,7 @@
 /* Number of attempts to wait for a link to come up. */
 #define NUM_ATTEMPTS_LINK_GET	(5)
 
-/*
- * The maximum number of "rte_eth_rss_reta_entry64" structures can be used to
- * configure the Redirection Table of the Receive Side Scaling (RSS) feature.
- * Notice, each "rte_eth_rss_reta_entry64" structure can configure 64 entries 
- * of the table. To configure more than 64 entries supported by hardware,
- * an array of this structure is needed.
- */
-#define GATEKEEPER_RETA_MAX_SIZE (ETH_RSS_RETA_SIZE_512 / RTE_RETA_GROUP_SIZE)
+#define GATEKEEPER_PKT_DROP_QUEUE (127)
 
 /* To mark whether Gatekeeper server configures IPv4 or IPv6. */
 #define GK_CONFIGURED_IPV4 (1)
@@ -81,6 +74,115 @@ static struct rte_eth_conf gatekeeper_port_conf = {
 		},
 	},
 };
+
+/*
+ * @dst_ip, @src_port and @dst_port must be in big endian.
+ * By specifying the tuple (proto, src_port, dst_port),
+ * it can filter both IPv4 and IPv6 addresses.
+ */
+int
+ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
+	uint16_t src_port, uint16_t dst_port, uint16_t queue_id)
+{
+	int ret = 0;
+	struct rte_eth_ntuple_filter filter_v4 = {
+		.flags = RTE_5TUPLE_FLAGS,
+		.dst_ip = dst_ip,
+		.dst_ip_mask = UINT32_MAX,
+		.src_ip = 0,
+		.src_ip_mask = 0,
+		.dst_port = dst_port,
+		.dst_port_mask = UINT16_MAX,
+		.src_port = src_port,
+		.src_port_mask = UINT16_MAX,
+		.proto = IPPROTO_UDP,
+		.proto_mask = UINT8_MAX,
+		.tcp_flags = 0,
+		.priority = 1,
+		.queue = queue_id,
+	};
+
+	struct rte_eth_ntuple_filter filter_v6 = {
+		.flags = RTE_5TUPLE_FLAGS,
+		.dst_ip = 0,
+		.dst_ip_mask = 0,
+		.src_ip = 0,
+		.src_ip_mask = 0,
+		.dst_port = dst_port,
+		.dst_port_mask = UINT16_MAX,
+		.src_port = src_port,
+		.src_port_mask = UINT16_MAX,
+		.proto = IPPROTO_UDP,
+		.proto_mask = UINT8_MAX,
+		.tcp_flags = 0,
+		.priority = 1,
+		.queue = queue_id,
+	};
+
+	ret = rte_eth_dev_filter_supported(portid, RTE_ETH_FILTER_NTUPLE);
+	if (ret < 0) {
+		RTE_LOG(ERR, PORT,
+			"Ntuple filter is not supported on port %hhu.\n",
+			portid);
+		ret = -1;
+		goto out;
+	}
+
+	if (dst_ip != 0) {
+		ret = rte_eth_dev_filter_ctrl(portid,
+			RTE_ETH_FILTER_NTUPLE,
+			RTE_ETH_FILTER_ADD,
+			&filter_v4);
+		if (ret == -ENOTSUP) {
+			RTE_LOG(ERR, PORT,
+				"Hardware doesn't support adding an IPv4 ntuple filter on port %hhu!\n",
+				portid);
+			ret = -1;
+			goto out;
+		} else if (ret == -ENODEV) {
+			RTE_LOG(ERR, PORT,
+				"Port %hhu is invalid for adding an IPv4 ntuple filter!\n",
+				portid);
+			ret = -1;
+			goto out;
+		} else if (ret != 0) {
+			RTE_LOG(ERR, PORT,
+				"Other errors that depend on the specific operations implementation on port %hhu for adding an IPv4 ntuple filter!\n",
+				portid);
+			ret = -1;
+			goto out;
+		}
+	}
+
+	ret = rte_eth_dev_filter_ctrl(portid,
+		RTE_ETH_FILTER_NTUPLE,
+		RTE_ETH_FILTER_ADD,
+		&filter_v6);
+	if (ret == -ENOTSUP) {
+		RTE_LOG(ERR, PORT,
+			"Hardware doesn't support adding an IPv6 ntuple filter on port %hhu!\n",
+			portid);
+		ret = -1;
+		goto out;
+	} else if (ret == -ENODEV) {
+		RTE_LOG(ERR, PORT,
+			"Port %hhu is invalid for adding an IPv6 ntuple filter!\n",
+			portid);
+		ret = -1;
+		goto out;
+	} else if (ret != 0) {
+		RTE_LOG(ERR, PORT,
+			"Other errors that depend on the specific operations implementation on port %hhu for adding an IPv6 ntuple filter!\n",
+			portid);
+		ret = -1;
+		goto out;
+	}
+
+	ret = 0;
+
+out:
+	return ret;
+}
 
 static uint32_t
 find_num_numa_nodes(void)
@@ -467,6 +569,52 @@ gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues)
 	} else if (ret == -EINVAL) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu (RETA query with bad redirection table parameter)!\n",
+			portid);
+		ret = -1;
+	}
+
+out:
+	return ret;
+}
+
+int
+gatekeeper_get_rss_config(uint8_t portid,
+	struct gatekeeper_rss_config *rss_conf)
+{
+	int ret = 0;
+	uint16_t i;
+	struct rte_eth_dev_info dev_info;
+
+	/* Get RSS redirection table (RETA) information. */
+	memset(&dev_info, 0, sizeof(dev_info));
+	rte_eth_dev_info_get(portid, &dev_info);
+	rss_conf->reta_size = dev_info.reta_size;
+	if (rss_conf->reta_size == 0 ||
+			rss_conf->reta_size > ETH_RSS_RETA_SIZE_512) {
+		RTE_LOG(ERR, PORT,
+			"Failed to setup RSS at port %hhu (invalid RETA size = %hu)!\n",
+			portid, rss_conf->reta_size);
+		ret = -1;
+		goto out;
+	}
+
+	for (i = 0; i < dev_info.reta_size; i++) {
+		uint32_t idx = i / RTE_RETA_GROUP_SIZE;
+		/* Select all fields to query. */
+		rss_conf->reta_conf[idx].mask = ~0LL;
+	}
+
+	/* RETA query. */
+	ret = rte_eth_dev_rss_reta_query(portid,
+		rss_conf->reta_conf, rss_conf->reta_size);
+	if (ret == -ENOTSUP) {
+		RTE_LOG(ERR, PORT,
+			"Failed to query RSS configuration at port %hhu hardware doesn't support!\n",
+			portid);
+		ret = -1;
+	} else if (ret == -EINVAL) {
+		RTE_LOG(ERR, PORT,
+			"Failed to query RSS configuration at port %hhu (RETA query with bad redirection table parameter)!\n",
 			portid);
 		ret = -1;
 	}

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -1,18 +1,17 @@
 -- TODO Add configuration for other functional blocks.
-local block_names = {
-	"gk",
-}
 
 function gatekeeper_init()
 	local net = require("net")
 	local net_conf = net.setup_block()
 	if net_conf == nil then return -1 end
 
-	for _, value in ipairs(block_names) do
-		local block = require(value)
-		local ret = block.setup_block(net_conf)
-		if ret < 0 then return ret end
-	end
+	local gk = require("gk")
+	local gk_conf = gk.setup_block(net_conf)
+	if gk_conf == nil then return -1 end
+
+	local ggu = require("ggu")
+	local ggu_conf = ggu.setup_block(net_conf, gk_conf)
+	if ggu_conf == nil then return -1 end
 
 	return 0
 end

--- a/lua/gatekeeperc.lua
+++ b/lua/gatekeeperc.lua
@@ -31,7 +31,8 @@ struct gk_config {
 ffi.cdef[[
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
-	const char **pci_addrs, uint8_t num_pci_addrs);
+	const char **pci_addrs, uint8_t num_pci_addrs,
+	const char **ip_addrs, uint8_t num_ip_addrs);
 void lua_free_iface(struct gatekeeper_if *iface);
 
 struct net_config *get_net_conf(void);

--- a/lua/gatekeeperc.lua
+++ b/lua/gatekeeperc.lua
@@ -24,6 +24,13 @@ struct gk_config {
 	/* This struct has hidden fields. */
 };
 
+struct ggu_config {
+	unsigned int      lcore_id;
+	uint16_t          ggu_src_port;
+	uint16_t          ggu_dst_port;
+	/* This struct has hidden fields. */
+};
+
 ]]
 
 -- Functions and wrappers
@@ -42,6 +49,11 @@ int gatekeeper_init_network(struct net_config *net_conf);
 
 struct gk_config *alloc_gk_conf(void);
 int run_gk(struct net_config *net_conf, struct gk_config *gk_conf);
+
+struct ggu_config *alloc_ggu_conf(void);
+int run_ggu(struct net_config *net_conf,
+	struct gk_config *gk_conf, struct ggu_config *ggu_conf);
+int cleanup_ggu(struct ggu_config *ggu_conf);
 
 ]]
 

--- a/lua/ggu.lua
+++ b/lua/ggu.lua
@@ -1,0 +1,27 @@
+local gatekeeperc = require("gatekeeperc")
+
+local M = {}
+
+-- Function that sets up the GGU functional block.
+function M.setup_block(net_conf, gk_conf)
+
+	-- Init the GGU configuration structure.
+	local ggu_conf = gatekeeperc.alloc_ggu_conf()
+	if ggu_conf == nil then return nil end
+
+	ggu_conf.lcore_id = 3
+	ggu_conf.ggu_src_port = 0xA0A0
+	ggu_conf.ggu_dst_port = 0xB0B0
+
+	-- Setup the GGU functional block.
+	local ret = gatekeeperc.run_ggu(net_conf, gk_conf, ggu_conf)
+	if ret < 0 then
+		gatekeeperc.cleanup_ggu(ggu_conf)
+		ggu_conf = nil
+		return nil
+	end
+
+	return ggu_conf
+end
+
+return M

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -6,15 +6,19 @@ local M = {}
 function M.setup_block(net_conf)
 
 	-- Init the GK configuration structure.
-	local conf = gatekeeperc.alloc_gk_conf()
+	local gk_conf = gatekeeperc.alloc_gk_conf()
+	if gk_conf == nil then return nil end
 	
 	-- Change these parameters to configure the Gatekeeper.
-	conf.lcore_start_id = 1
-	conf.lcore_end_id = 2
-	conf.flow_ht_size = 1024
+	gk_conf.lcore_start_id = 1
+	gk_conf.lcore_end_id = 2
+	gk_conf.flow_ht_size = 1024
 
 	-- Setup the GK functional block.
-	return gatekeeperc.run_gk(net_conf, conf)
+	local ret = gatekeeperc.run_gk(net_conf, gk_conf)
+	if ret < 0 then return nil end
+
+	return gk_conf
 end
 
 return M

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -7,6 +7,8 @@ function M.setup_block(net_conf)
 
 	-- Init the GK configuration structure.
 	local conf = gatekeeperc.alloc_gk_conf()
+	
+	-- Change these parameters to configure the Gatekeeper.
 	conf.lcore_start_id = 1
 	conf.lcore_end_id = 2
 	conf.flow_ht_size = 1024

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -4,12 +4,19 @@ local ifaces = require("if_map")
 
 local M = {}
 
-function init_iface(iface, name, ports)
+function init_iface(iface, name, ports, ips)
 	local pci_strs = ffi.new("const char *[" .. #ports .. "]")
 	for i, v in ipairs(ports) do
 		pci_strs[i - 1] = ifaces[v]
 	end
-	return gatekeeperc.lua_init_iface(iface, name, pci_strs, #ports)
+
+	local ip_strs = ffi.new("const char *[" .. #ips .. "]")
+	for i, v in ipairs(ips) do
+		ip_strs[i - 1] = v
+	end
+
+	return gatekeeperc.lua_init_iface(
+		iface, name, pci_strs, #ports, ip_strs, #ips)
 end
 
 -- Function that sets up the network.
@@ -20,10 +27,16 @@ function M.setup_block()
 
 	-- Change these parameters to configure the network.
 	local front_ports = {"enp133s0f0"}
+
+	-- Each interface should have at most two ip addresses:
+	-- 1 IPv4, 1 IPv6.
+	local front_ips  = {"10.0.0.1", "3ffe:2501:200:1fff::7"}
+
 	local front_rx_queues = 2
 	local front_tx_queues = 0
 
 	local back_ports = {"enp133s0f1"}
+	local back_ips  = {"10.0.0.2", "3ffe:2501:200:1fff::8"}
 	local back_rx_queues = 0
 	local back_tx_queues = 2
 
@@ -31,7 +44,7 @@ function M.setup_block()
 	local front_iface = gatekeeperc.get_if_front(conf)
 	front_iface.num_rx_queues = front_rx_queues
 	front_iface.num_tx_queues = front_tx_queues
-	local ret = init_iface(front_iface, "front", front_ports)
+	local ret = init_iface(front_iface, "front", front_ports, front_ips)
 	if ret < 0 then
 		return nil
 	end
@@ -39,7 +52,7 @@ function M.setup_block()
 	local back_iface = gatekeeperc.get_if_back(conf)
 	back_iface.num_rx_queues = back_rx_queues
 	back_iface.num_tx_queues = back_tx_queues
-	ret = init_iface(back_iface, "back", back_ports)
+	ret = init_iface(back_iface, "back", back_ports, back_ips)
 	if ret < 0 then
 		goto front
 	end

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -37,7 +37,7 @@ function M.setup_block()
 
 	local back_ports = {"enp133s0f1"}
 	local back_ips  = {"10.0.0.2", "3ffe:2501:200:1fff::8"}
-	local back_rx_queues = 0
+	local back_rx_queues = 1
 	local back_tx_queues = 2
 
 	-- Code below this point should not need to be changed.

--- a/main/main.c
+++ b/main/main.c
@@ -40,6 +40,7 @@ volatile int exiting = false;
  * initialized via time_resolution_init() function.
  */
 uint64_t cycles_per_sec;
+uint64_t cycles_per_ms;
 uint64_t picosec_per_cycle;
 
 /* Obtain the system time resolution. */
@@ -76,11 +77,12 @@ time_resolution_init(void)
 	}
 
 	cycles_per_sec = cycles * 1000000000UL / diff_ns;
+	cycles_per_ms = cycles_per_sec / 1000UL;
 	picosec_per_cycle = 1000UL * diff_ns / cycles;
 
 	RTE_LOG(NOTICE, TIMER,
-		"cycles/second = %" PRIu64 ", picosec/cycle = %" PRIu64 "!\n",
-		cycles_per_sec, picosec_per_cycle);
+		"cycles/second = %" PRIu64 ", cycles/millisecond = %" PRIu64 ", picosec/cycle = %" PRIu64 "!\n",
+		cycles_per_sec, cycles_per_ms, picosec_per_cycle);
 
 	return 0;
 }


### PR DESCRIPTION
The first patch adds support for IP over IP encapsulation for GK block, it supports both IPv4 and IPv6 addresses.  In this patch, the ``struct ip_flow`` is reorganized, since it will be shared by several blocks, so I chose to make it as a library.

The second patch adds a simple GK-GT Unit. The policies will be batched in a packet, for each policy decision, it first calculates the RSS hash value for that IP flow, then the last 7 bits will be used to index the Redirection table entries, where it stores the queue id. With the queue id, we may need to find an efficient way to lookup the corresponding GK block, who is responsible for that IP flow. For now, it simply iterates all the GK instances to find the matched one. With this patch, both RSS and ntuple filters support IPv6 as expected.