### PR TITLE
add LLS block and ARP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ SRCS-y += cps/main.c
 SRCS-y += ggu/main.c
 SRCS-y += gk/main.c
 SRCS-y += gt/main.c
-SRCS-y += lls/main.c
+SRCS-y += lls/main.c lls/cache.c lls/arp.c
 SRCS-y += rt/main.c
 
 # Libraries.

--- a/gk/main.c
+++ b/gk/main.c
@@ -54,14 +54,6 @@
 /* XXX Sample parameters, need to be tested for better performance. */
 #define GK_CMD_BURST_SIZE        (32)
 
-/*
- * XXX Sample parameters, all gk mailboxes have 128 entries by default.
- * rte_ring_create() requires that the ring size (i.e., parameter count)
- * must be a power of two. Moreover, the real usable ring size is count-1
- * instead of count to differentiate a free ring from an empty ring.
- */
-#define MAILBOX_MAX_ENTRIES      (128)
-
 /* Store information about a packet. */
 struct ipacket {
 	struct ip_flow  flow;

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -19,6 +19,206 @@
 #ifndef _GATEKEEPER_LLS_H_
 #define _GATEKEEPER_LLS_H_
 
-int run_lls(void);
+#include <netinet/in.h>
+
+#include <rte_timer.h>
+
+#include "gatekeeper_mailbox.h"
+#include "gatekeeper_net.h"
+
+/*
+ * Maximum key length (in bytes) for an LLS map. It should be set
+ * to the maximum key length needed. Currently, this is set to 16 for
+ * the number of bytes in an IPv6 address.
+ */
+#define LLS_MAX_KEY_LEN (16)
+
+/* Number of records that a LLS cache can hold. */
+#define LLS_CACHE_RECORDS (1024)
+
+/* Requests that can be made to the LLS block. */
+enum lls_req_ty {
+	/* Express interest in a map by registering a callback function. */
+	LLS_REQ_HOLD,
+	/*
+	 * Remove a previously-submitted hold, if not already deleted
+	 * by virtue of a callback function signaling it should not
+	 * be invoked again.
+	 */
+	LLS_REQ_PUT,
+};
+
+/* Replies that come from the LLS block. */
+enum lls_reply_ty {
+	/* The reply represents a map resolution (or update to one). */
+	LLS_REPLY_RESOLUTION,
+	/*
+	 * The reply is a notification that the hold is
+	 * removed, so the requester can free state as needed.
+	 */
+	LLS_REPLY_FREE,
+};
+
+/* Map that is returned to blocks that request resolution. */
+struct lls_map {
+	/* Ethernet address of this map. */
+	struct ether_addr ha;
+
+	/* Port on which this map exists. */
+	uint8_t           port_id;
+
+	/* Whether this map has been marked as stale. */
+	int               stale;
+
+	/* IP address for this map, in network ordering. */
+	uint8_t           ip_be[LLS_MAX_KEY_LEN];
+};
+
+/*
+ * Format of callback function for requesting LLS maps.
+ *
+ * The LLS block invokes the callbacks, so each block should ensure
+ * that the callback function deals with any race conditions and
+ * is aware that the blocks may reside in different NUMA nodes.
+ *
+ * If the requesting block wants future updates, it should set
+ * *@pcall_again to true before returning. Otherwise, by default
+ * the LLS block will remove the interest from the block. If
+ * *@pcall_again is set to true, then the block may release all
+ * resources attached to the callback before returning.
+ *
+ * When @ty is LLS_REPLY_FREE, @pcall_again is NULL to indicate
+ * that this will be the last callback for this hold.
+ */
+typedef void (*lls_req_cb)(const struct lls_map *map, void *arg,
+	enum lls_reply_ty ty, int *pcall_again);
+
+/* A hold for an LLS map. */
+struct lls_hold {
+	/* Callback function for replies from the LLS block. */
+	lls_req_cb   cb;
+
+	/* Optional argument to @cb. */
+	void         *arg;
+
+	/* The lcore that requested this hold. */
+	unsigned int lcore_id;
+};
+
+struct lls_record {
+	/* IP --> Ethernet address map for this record. */
+	struct lls_map  map;
+
+	 /* Timestamp of the last update to the map. */
+	time_t          ts;
+
+	/*
+	 * Number of requests to hold this map. Blocks
+	 * should only request a hold for a map once
+	 * to avoid multiple entries for an lcore in @holds.
+	 */
+	uint32_t        num_holds;
+
+	/* Holds for @map. */
+	struct lls_hold holds[RTE_MAX_LCORE];
+};
+
+struct lls_cache {
+	/* Length (in bytes) of keys for this cache. */
+	uint32_t          key_len;
+
+	/* Maximum length (in bytes) for strings of keys for this cache. */
+	uint32_t          key_str_len;
+
+	/* Timeout value (in seconds) to mark entries as stale. */
+	uint32_t          front_timeout_sec;
+	uint32_t          back_timeout_sec;
+
+	/* Name string (needed for cache hash). */
+	const char        *name;
+
+	/* Array of cache records indexed using @hash. */
+	struct lls_record records[LLS_CACHE_RECORDS];
+
+	/* Hash instance that maps IP address keys to LLS cache records. */
+	struct rte_hash   *hash;
+
+	/* Returns whether the cache is enabled for @iface. */
+	int (*iface_enabled)(struct net_config *net,
+		struct gatekeeper_if *iface);
+
+	/* Convert @ip_be to string form and store it in @buf. */
+	char *(*ip_str)(struct lls_cache *cache, const uint8_t *ip_be,
+		char *buf, size_t len);
+
+	/*
+	 * Function to transmit a request out of @iface to resolve
+	 * IP address @ip_be to an Ethernet address.
+	 *
+	 * If @ha is NULL, then broadcast. Otherwise, unicast to @ha.
+	 */
+	void (*xmit_req)(struct gatekeeper_if *iface, const uint8_t *ip_be,
+		const struct ether_addr *ha, uint16_t tx_queue);
+
+	/* Function to print a cache record. */
+	void (*print_record)(struct lls_cache *cache,
+		struct lls_record *record);
+};
+
+struct lls_config {
+	/* lcore that the LLS block runs on. */
+	unsigned int      lcore_id;
+
+	/*
+	 * When non-zero, all caches will be dumped when
+	 * they are changed or periodically scanned.
+	 */
+	int               debug;
+
+	/*
+	 * The fields below are for internal use.
+	 * Configuration files should not refer to them.
+	 */
+	struct net_config *net;
+
+	/* Mailbox to hold requests from other blocks. */
+	struct mailbox    requests;
+
+	/* Cache of entries that map IPv4 addresses to Ethernet addresses. */
+	struct lls_cache  arp_cache;
+
+	/* Timer to scan over LLS cache(s). */
+	struct rte_timer  timer;
+
+	/* Receive and transmit queues for both interfaces. */
+	uint16_t          rx_queue_front;
+	uint16_t          tx_queue_front;
+	uint16_t          rx_queue_back;
+	uint16_t          tx_queue_back;
+};
+
+/*
+ * Interface for functional blocks to resolve IPv4 --> Ethernet addresses.
+ *
+ * To obtain a map, a functional block running on @lcore_id should invoke
+ * hold_arp() with a callback function @cb and an optional @arg. When
+ * a resolution is available, @cb will be invoked by the LLS block to
+ * deliver a struct lls_map (and @arg) to the functional block.
+ *
+ * For every map requested through hold_arp(), functional blocks should
+ * also indicate in an invocation of the callback that they do not wish
+ * for it to be called again and/or call put_arp().
+ *
+ * Blocks should not repeatedly call hold_arp() for an already-requested
+ * map without first releasing the map by indicating the callback should
+ * not be called again and/or by calling put_arp() to clear its request
+ * from the LLS.
+ */
+int hold_arp(lls_req_cb cb, void *arg, struct in_addr *ip_be,
+	unsigned int lcore_id);
+int put_arp(struct in_addr *ip_be, unsigned int lcore_id);
+
+struct lls_config *get_lls_conf(void);
+int run_lls(struct net_config *net_conf, struct lls_config *lls_conf);
 
 #endif /* _GATEKEEPER_LLS_H_ */

--- a/include/gatekeeper_mailbox.h
+++ b/include/gatekeeper_mailbox.h
@@ -24,6 +24,14 @@
 
 #include "gatekeeper_main.h"
 
+/*
+ * XXX Sample parameters, all mailboxes have 128 entries by default.
+ * rte_ring_create() requires that the ring size (i.e., parameter count)
+ * must be a power of two. Moreover, the real usable ring size is count-1
+ * instead of count to differentiate a free ring from an empty ring.
+ */
+#define MAILBOX_MAX_ENTRIES (128)
+
 struct mailbox {
 	struct rte_ring    *ring;
 	struct rte_mempool *pool;

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -28,6 +28,8 @@
  */
 #define RTE_LOGTYPE_GATEKEEPER RTE_LOGTYPE_USER1
 
+#define GATEKEEPER_MAX_PKT_BURST (32)
+
 extern volatile int exiting;
 
 extern uint64_t cycles_per_sec;

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -24,7 +24,9 @@
 
 #include <rte_ethdev.h>
 
-#include <rte_atomic.h>
+/* To mark whether Gatekeeper server configures IPv4 or IPv6. */
+#define GK_CONFIGURED_IPV4 (1)
+#define GK_CONFIGURED_IPV6 (2)
 
 /* Size of the secret key of the RSS hash. */
 #define GATEKEEPER_RSS_KEY_LEN (40)
@@ -62,10 +64,16 @@ struct gatekeeper_if {
 	uint16_t        num_rx_queues;
 	uint16_t        num_tx_queues;
 
+	/* Timeout for cache entries (in seconds) for Link Layer Support. */
+	uint32_t	arp_cache_timeout_sec;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */
+
+	/* Ethernet address of this interface. */
+	struct ether_addr eth_addr;
 
 	/* DPDK port IDs corresponding to each address in @pci_addrs. */
 	uint8_t         *ports;
@@ -164,6 +172,8 @@ int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **ip_addrs, uint8_t num_ip_addrs);
 void lua_free_iface(struct gatekeeper_if *iface);
 
+int ethertype_filter_add(uint8_t port_id, uint16_t ether_type,
+	uint16_t queue_id);
 int ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
 	uint16_t src_port, uint16_t dst_port, uint16_t queue_id);
 struct net_config *get_net_conf(void);

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -69,6 +69,7 @@ init_mailbox(const char *tag,
 		RTE_LOG(ERR, MEMPOOL,
 			"mailbox: can't create mempool %s (len = %d) at lcore %u!\n",
 			pool_name, ret, lcore_id);
+		ret = -1;
         	goto free_ring;
     	}
 

--- a/lls/arp.c
+++ b/lls/arp.c
@@ -1,0 +1,231 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <arpa/inet.h>
+
+#include <rte_arp.h>
+
+#include "arp.h"
+#include "cache.h"
+
+int
+iface_arp_enabled(struct net_config *net, struct gatekeeper_if *iface)
+{
+	/* When @iface is the back, need to make sure it's enabled. */
+	if (iface == &net->back)
+		return net->back_iface_enabled &&
+			iface->configured_proto & GK_CONFIGURED_IPV4;
+
+	/* @iface is the front interface. */
+	return iface->configured_proto & GK_CONFIGURED_IPV4;
+}
+
+char *
+ipv4_str(struct lls_cache *cache, const uint8_t *ip_be, char *buf, size_t len)
+{
+	struct in_addr ipv4_addr;
+
+	if (sizeof(ipv4_addr) != cache->key_len) {
+		RTE_LOG(ERR, GATEKEEPER, "lls: the key size of an ARP entry should be %zu, but it is %"PRIx32"\n",
+			sizeof(ipv4_addr), cache->key_len);
+		return NULL;
+	}
+
+	/* Keep IP address in network order for inet_ntop(). */
+	ipv4_addr.s_addr = *(const uint32_t *)ip_be;
+	if (inet_ntop(AF_INET, &ipv4_addr, buf, len) == NULL) {
+		RTE_LOG(ERR, GATEKEEPER, "lls: %s: failed to convert a number to an IP address (%s)\n",
+			__func__, strerror(errno));
+		return NULL;
+	}
+
+	return buf;
+}
+
+void
+xmit_arp_req(struct gatekeeper_if *iface, const uint8_t *ip_be,
+	const struct ether_addr *ha, uint16_t tx_queue)
+{
+	struct rte_mbuf *created_pkt;
+	struct ether_hdr *eth_hdr;
+	struct arp_hdr *arp_hdr;
+	size_t pkt_size;
+	struct lls_config *lls_conf = get_lls_conf();
+	int ret;
+
+	struct rte_mempool *mp = lls_conf->net->gatekeeper_pktmbuf_pool[
+		rte_lcore_to_socket_id(lls_conf->lcore_id)];
+	created_pkt = rte_pktmbuf_alloc(mp);
+	if (created_pkt == NULL) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"lls: could not alloc a packet for an ARP request\n");
+		return;
+	}
+
+	pkt_size = sizeof(struct ether_hdr) + sizeof(struct arp_hdr);
+	created_pkt->data_len = pkt_size;
+	created_pkt->pkt_len = pkt_size;
+
+	/* Set-up Ethernet header. */
+	eth_hdr = rte_pktmbuf_mtod(created_pkt, struct ether_hdr *);
+	ether_addr_copy(&iface->eth_addr, &eth_hdr->s_addr);
+	if (ha == NULL)
+		memset(&eth_hdr->d_addr, 0xFF, ETHER_ADDR_LEN);
+	else
+		ether_addr_copy(ha, &eth_hdr->d_addr);
+	eth_hdr->ether_type = rte_cpu_to_be_16(ETHER_TYPE_ARP);
+
+	/* Set-up ARP header. */
+	arp_hdr = (struct arp_hdr *)(eth_hdr + 1);
+	arp_hdr->arp_hrd = rte_cpu_to_be_16(ARP_HRD_ETHER);
+	arp_hdr->arp_pro = rte_cpu_to_be_16(ETHER_TYPE_IPv4);
+	arp_hdr->arp_hln = ETHER_ADDR_LEN;
+	arp_hdr->arp_pln = sizeof(struct in_addr);
+	arp_hdr->arp_op = rte_cpu_to_be_16(ARP_OP_REQUEST);
+	ether_addr_copy(&iface->eth_addr, &arp_hdr->arp_data.arp_sha);
+	arp_hdr->arp_data.arp_sip = iface->ip4_addr.s_addr;
+	memset(&arp_hdr->arp_data.arp_tha, 0, ETHER_ADDR_LEN);
+	arp_hdr->arp_data.arp_tip = *(const uint32_t *)ip_be;
+
+	ret = rte_eth_tx_burst(iface->id, tx_queue, &created_pkt, 1);
+	if (ret <= 0) {
+		rte_pktmbuf_free(created_pkt);
+		RTE_LOG(ERR, GATEKEEPER,
+			"lls: could not transmit an ARP request\n");
+	}
+}
+
+/*
+ * A Gratuitous ARP is an ARP request that serves as an announcement of
+ * a neighbor's mapping. The sender and target IP address should be the same,
+ * AND the target Ethernet address should be the same as the sender Ethernet
+ * address OR zero.
+ */
+static inline int
+is_garp_pkt(const struct arp_hdr *arp_hdr)
+{
+	return (arp_hdr->arp_data.arp_sip == arp_hdr->arp_data.arp_tip) &&
+		(is_zero_ether_addr(&arp_hdr->arp_data.arp_tha) ||
+		is_same_ether_addr(&arp_hdr->arp_data.arp_tha,
+			&arp_hdr->arp_data.arp_sha));
+}
+
+int
+process_arp(struct lls_config *lls_conf, struct gatekeeper_if *iface,
+	uint16_t tx_queue, struct rte_mbuf *buf, struct ether_hdr *eth_hdr)
+{
+	struct lls_mod_req mod_req;
+	struct arp_hdr *arp_hdr;
+	uint16_t pkt_len = rte_pktmbuf_data_len(buf);
+
+	if (pkt_len < sizeof(*eth_hdr) + sizeof(*arp_hdr)) {
+		RTE_LOG(ERR, GATEKEEPER, "lls: %s interface received ARP packet of size %hu bytes, but it should be at least %zu bytes\n",
+			iface->name, pkt_len,
+			sizeof(*eth_hdr) + sizeof(*arp_hdr));
+		return -1;
+	}
+
+	arp_hdr = rte_pktmbuf_mtod_offset(buf, struct arp_hdr *,
+		sizeof(struct ether_hdr));
+
+	if (unlikely(arp_hdr->arp_hrd != rte_cpu_to_be_16(ARP_HRD_ETHER) ||
+		     arp_hdr->arp_pro != rte_cpu_to_be_16(ETHER_TYPE_IPv4) ||
+		     arp_hdr->arp_hln != ETHER_ADDR_LEN ||
+		     arp_hdr->arp_pln != sizeof(struct in_addr)))
+		return -1;
+
+	/* TODO If sip is not in the same subnet as our IP address, drop. */
+
+	/* Update cache with source resolution, regardless of operation. */
+	mod_req.cache = &lls_conf->arp_cache;
+	memcpy(mod_req.ip_be, &arp_hdr->arp_data.arp_sip,
+		lls_conf->arp_cache.key_len);
+	ether_addr_copy(&arp_hdr->arp_data.arp_sha, &mod_req.ha);
+	mod_req.port_id = iface->id;
+	mod_req.ts = time(NULL);
+	RTE_ASSERT(mod_req.ts >= 0);
+	lls_process_mod(lls_conf, &mod_req);
+
+	/*
+	 * If it's a Gratuitous ARP or if the target address
+	 * is not us, then no response is needed.
+	 */
+	if (is_garp_pkt(arp_hdr) ||
+			(iface->ip4_addr.s_addr != arp_hdr->arp_data.arp_tip))
+		return -1;
+
+	switch (rte_be_to_cpu_16(arp_hdr->arp_op)) {
+	case ARP_OP_REQUEST: {
+		uint16_t num_tx;
+
+		/* Set-up Ethernet header. */
+		ether_addr_copy(&eth_hdr->s_addr, &eth_hdr->d_addr);
+		ether_addr_copy(&iface->eth_addr, &eth_hdr->s_addr);
+
+		/* Set-up ARP header. */
+		arp_hdr->arp_op = rte_cpu_to_be_16(ARP_OP_REPLY);
+		ether_addr_copy(&arp_hdr->arp_data.arp_sha,
+			&arp_hdr->arp_data.arp_tha);
+		arp_hdr->arp_data.arp_tip = arp_hdr->arp_data.arp_sip;
+		ether_addr_copy(&iface->eth_addr, &arp_hdr->arp_data.arp_sha);
+		arp_hdr->arp_data.arp_sip = iface->ip4_addr.s_addr;
+
+		/* Need to transmit reply. */
+		num_tx = rte_eth_tx_burst(iface->id, tx_queue, &buf, 1);
+		if (unlikely(num_tx != 1)) {
+			RTE_LOG(NOTICE, GATEKEEPER, "lls: ARP reply failed\n");
+			return -1;
+		}
+		return 0;
+	}
+	case ARP_OP_REPLY:
+		/*
+		 * No further action required. Could check to make sure
+		 * arp_hdr->arp_data.arp_tha is equal to arp->ether_addr,
+		 * but there's nothing that can be done if it's wrong anyway.
+		 */
+		return -1;
+	default:
+		RTE_LOG(NOTICE, GATEKEEPER, "lls: %s received an ARP packet with an unknown operation (%hu)\n",
+			__func__, rte_be_to_cpu_16(arp_hdr->arp_op));
+		return -1;
+	}
+}
+
+void
+print_arp_record(struct lls_cache *cache, struct lls_record *record)
+{
+	struct lls_map *map = &record->map;
+	char ip_buf[cache->key_str_len];
+	char *ip_str = ipv4_str(cache, map->ip_be, ip_buf, cache->key_str_len);
+
+	if (ip_str == NULL)
+		return;
+
+	if (map->stale)
+		RTE_LOG(INFO, GATEKEEPER, "%s: unresolved (%u holds)\n",
+			ip_str, record->num_holds);
+	else
+		RTE_LOG(INFO, GATEKEEPER,
+			"%s: %02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8":%02"PRIx8" (port %hhu) (%u holds)\n",
+			ip_str,
+			map->ha.addr_bytes[0], map->ha.addr_bytes[1],
+			map->ha.addr_bytes[2], map->ha.addr_bytes[3],
+			map->ha.addr_bytes[4], map->ha.addr_bytes[5],
+			map->port_id, record->num_holds);
+}

--- a/lls/arp.h
+++ b/lls/arp.h
@@ -1,0 +1,48 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_LLS_ARP_H_
+#define _GATEKEEPER_LLS_ARP_H_
+
+#include "gatekeeper_lls.h"
+#include "gatekeeper_net.h"
+
+/* Whether ARP is enabled on this interface. */
+int iface_arp_enabled(struct net_config *net, struct gatekeeper_if *iface);
+
+/* Convert @ip_be to an IPv4 address and store it in @buf. */
+char *ipv4_str(struct lls_cache *cache, const uint8_t *ip_be,
+	char *buf, size_t len);
+
+/* Transmit an ARP request packet. */
+void xmit_arp_req(struct gatekeeper_if *iface, const uint8_t *ip_be,
+	const struct ether_addr *ha, uint16_t tx_queue);
+
+/*
+ * Process an ARP packet that arrived on @iface.
+ *
+ * Returns 0 if the packet was transmitted (and already freed),
+ * -1 if it does not need to be transmitted (and needs to be freed).
+ */
+int process_arp(struct lls_config *lls_conf, struct gatekeeper_if *iface,
+	uint16_t tx_queue, struct rte_mbuf *buf, struct ether_hdr *eth_hdr);
+
+/* Print an ARP record. */
+void print_arp_record(struct lls_cache *cache, struct lls_record *record);
+
+#endif /* _GATEKEEPER_LLS_ARP_H_ */

--- a/lls/cache.c
+++ b/lls/cache.c
@@ -1,0 +1,469 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+
+#include <rte_hash.h>
+
+#include <gatekeeper_lls.h>
+#include "cache.h"
+
+#ifdef RTE_MACHINE_CPUFLAG_SSE4_2
+#include <rte_hash_crc.h>
+#define DEFAULT_HASH_FUNC rte_hash_crc
+#else
+#include <rte_jhash.h>
+#define DEFAULT_HASH_FUNC rte_jhash
+#endif
+
+/* XXX Sample parameters, need to be tested for better performance. */
+#define LLS_CACHE_BURST_SIZE (32)
+
+static void
+lls_send_request(struct lls_config *lls_conf, struct lls_cache *cache,
+	const uint8_t *ip_be, const struct ether_addr *ha)
+{
+	/*
+	 * TODO Use network mask to determine which
+	 * iface to use for invalid entries.
+	 */
+	if (cache->iface_enabled(lls_conf->net, &lls_conf->net->front))
+		cache->xmit_req(&lls_conf->net->front, ip_be, ha,
+			lls_conf->tx_queue_front);
+	if (cache->iface_enabled(lls_conf->net, &lls_conf->net->back))
+		cache->xmit_req(&lls_conf->net->back, ip_be, ha,
+			lls_conf->tx_queue_back);
+}
+
+static void
+lls_cache_dump(struct lls_cache *cache)
+{
+	uint32_t iter = 0;
+	int32_t index;
+	const void *key;
+	void *data;
+
+	RTE_LOG(INFO, GATEKEEPER, "LLS cache (%s)\n=====================\n",
+		cache->name);
+	index = rte_hash_iterate(cache->hash, &key, &data, &iter);
+	while (index >= 0) {
+		cache->print_record(cache, &cache->records[index]);
+		index = rte_hash_iterate(cache->hash, &key, &data, &iter);
+	}
+}
+
+static void
+lls_update_subscribers(struct lls_record *record)
+{
+	unsigned int i;
+	for (i = 0; i < record->num_holds; i++) {
+		int call_again = false;
+
+		record->holds[i].cb(&record->map, record->holds[i].arg,
+			LLS_REPLY_RESOLUTION, &call_again);
+
+		if (call_again)
+			continue;
+
+		/* Delete hold; keep all holds in beginning of array. */
+		record->num_holds--;
+		if (i < record->num_holds) {
+			memcpy(&record->holds[i],
+				&record->holds[record->num_holds],
+				sizeof(record->holds[i]));
+			/*
+			 * This cancels out the update of the for loop so we
+			 * can redo update of hold at position @i, if needed.
+			 */
+			i--;
+		}
+	}
+}
+
+static int
+lls_add_record(struct lls_cache *cache, const uint8_t *ip_be)
+{
+	int ret = rte_hash_add_key(cache->hash, ip_be);
+	if (unlikely(ret == -EINVAL || ret == -ENOSPC)) {
+		char ip_buf[cache->key_str_len];
+		char *ip_str = cache->ip_str(cache, ip_be,
+			ip_buf, cache->key_str_len);
+		RTE_LOG(ERR, HASH, "%s, could not add record for %s\n",
+			ret == -EINVAL ? "Invalid params" : "No space",
+			ip_str == NULL ? cache->name : ip_str);
+	} else
+		RTE_ASSERT(ret >= 0);
+	return ret;
+}
+
+static void
+lls_del_record(struct lls_cache *cache, const uint8_t *ip_be)
+{
+	int32_t ret = rte_hash_del_key(cache->hash, ip_be);
+	if (unlikely(ret == -ENOENT || ret == -EINVAL)) {
+		char ip_buf[cache->key_str_len];
+		char *ip_str = cache->ip_str(cache, ip_be, ip_buf,
+			cache->key_str_len);
+		RTE_LOG(ERR, HASH, "%s, record for %s not deleted\n",
+			ret == -ENOENT ? "No map found" : "Invalid params",
+			ip_str == NULL ? cache->name : ip_str);
+	}
+}
+
+static void
+lls_process_hold(struct lls_config *lls_conf, struct lls_hold_req *hold_req)
+{
+	struct lls_cache *cache = hold_req->cache;
+	struct lls_record *record;
+	int ret = rte_hash_lookup(cache->hash, hold_req->ip_be);
+
+	if (ret == -ENOENT) {
+		ret = lls_add_record(cache, hold_req->ip_be);
+		if (ret < 0)
+			return;
+
+		record = &cache->records[ret];
+		record->map.stale = true;
+		memcpy(record->map.ip_be, hold_req->ip_be, cache->key_len);
+		record->ts = time(NULL);
+		RTE_ASSERT(record->ts >= 0);
+		record->holds[0] = hold_req->hold;
+		record->num_holds = 1;
+
+		/* Try to resolve record using broadcast. */
+		lls_send_request(lls_conf, cache, hold_req->ip_be, NULL);
+
+		if (lls_conf->debug)
+			lls_cache_dump(cache);
+		return;
+	} else if (unlikely(ret == -EINVAL)) {
+		char ip_buf[cache->key_str_len];
+		char *ip_str;
+		ip_str = cache->ip_str(cache, hold_req->ip_be, ip_buf,
+			cache->key_str_len);
+		RTE_LOG(ERR, HASH,
+			"Invalid params, could not get %s map; hold failed\n",
+			ip_str == NULL ? cache->name : ip_str);
+		return;
+	}
+
+	RTE_ASSERT(ret >= 0);
+	record = &cache->records[ret];
+
+	if (!record->map.stale) {
+		int call_again = false;
+		/* Alert requester this map is ready. */
+		hold_req->hold.cb(&record->map, hold_req->hold.arg,
+			LLS_REPLY_RESOLUTION, &call_again);
+		if (!call_again)
+			return;
+	}
+	record->holds[record->num_holds++] = hold_req->hold;
+
+	if (lls_conf->debug)
+		lls_cache_dump(cache);
+}
+
+static void
+lls_process_put(struct lls_config *lls_conf, struct lls_put_req *put_req)
+{
+	struct lls_cache *cache = put_req->cache;
+	struct lls_record *record;
+	unsigned int i;
+	int ret = rte_hash_lookup(cache->hash, put_req->ip_be);
+
+	if (ret == -ENOENT) {
+		/*
+		 * Not necessarily an error: the block may have indicated
+		 * it did not want its callback to be called again, and
+		 * all holds have been released on that entry.
+		 */
+		return;
+	} else if (unlikely(ret == -EINVAL)) {
+		char ip_buf[cache->key_str_len];
+		char *ip_str = cache->ip_str(cache, put_req->ip_be, ip_buf,
+			cache->key_str_len);
+		RTE_LOG(ERR, HASH,
+			"Invalid params, could not get %s map; put failed\n",
+			ip_str == NULL ? cache->name : ip_str);
+		return;
+	}
+
+	RTE_ASSERT(ret >= 0);
+	record = &cache->records[ret];
+
+	for (i = 0; i < record->num_holds; i++) {
+		if (put_req->lcore_id == record->holds[i].lcore_id)
+			break;
+	}
+
+	/* Requesting lcore not found in holds. */
+	if (i == record->num_holds)
+		return;
+
+	/*
+	 * Alert the requester that its hold will be removed, so it
+	 * may free any state that is keeping track of that hold.
+	 *
+	 * Technically the hold will be removed in the step
+	 * below, but alerting the requester first removes the need
+	 * to copy the hold into a temporary variable, remove
+	 * the hold from record->holds, and then alert the
+	 * requester using the temporary variable. This is OK since
+	 * there's only one writer.
+	 */
+	record->holds[i].cb(&record->map, record->holds[i].arg,
+		LLS_REPLY_FREE, NULL);
+
+	/* Keep all holds in beginning of array. */
+	record->num_holds--;
+	if (i < record->num_holds)
+		memcpy(&record->holds[i], &record->holds[record->num_holds],
+			sizeof(record->holds[i]));
+
+	if (lls_conf->debug)
+		lls_cache_dump(cache);
+}
+
+void
+lls_process_mod(struct lls_config *lls_conf, struct lls_mod_req *mod_req)
+{
+	struct lls_cache *cache = mod_req->cache;
+	struct lls_record *record;
+	int changed_ha = false;
+	int changed_port = false;
+	int changed_stale = false;
+	int ret = rte_hash_lookup(cache->hash, mod_req->ip_be);
+
+	if (ret == -ENOENT) {
+		ret = lls_add_record(cache, mod_req->ip_be);
+		if (ret < 0)
+			return;
+
+		/* Fill-in new record. */
+		record = &cache->records[ret];
+		ether_addr_copy(&mod_req->ha, &record->map.ha);
+		record->map.port_id = mod_req->port_id;
+		record->map.stale = false;
+		memcpy(record->map.ip_be, mod_req->ip_be, cache->key_len);
+		record->ts = mod_req->ts;
+		record->num_holds = 0;
+
+		if (lls_conf->debug)
+			lls_cache_dump(cache);
+		return;
+	} else if (unlikely(ret == -EINVAL)) {
+		char ip_buf[cache->key_str_len];
+		char *ip_str;
+		ip_str = cache->ip_str(cache, mod_req->ip_be, ip_buf,
+			cache->key_str_len);
+		RTE_LOG(ERR, HASH,
+			"Invalid params, could not get %s map; mod failed\n",
+			ip_str == NULL ? cache->name : ip_str);
+		return;
+	}
+
+	RTE_ASSERT(ret >= 0);
+	record = &cache->records[ret];
+
+	if (!is_same_ether_addr(&mod_req->ha, &record->map.ha)) {
+		ether_addr_copy(&mod_req->ha, &record->map.ha);
+		changed_ha = true;
+	}
+	if (record->map.port_id != mod_req->port_id) {
+		record->map.port_id = mod_req->port_id;
+		changed_port = true;
+	}
+	if (record->map.stale) {
+		record->map.stale = false;
+		changed_stale = true;
+	}
+	record->ts = mod_req->ts;
+
+	if (changed_ha || changed_port || changed_stale) {
+		lls_update_subscribers(record);
+		if (lls_conf->debug)
+			lls_cache_dump(cache);
+	}
+}
+
+unsigned int
+lls_process_reqs(struct lls_config *lls_conf)
+{
+	struct lls_request *reqs[LLS_CACHE_BURST_SIZE];
+	unsigned int count = mb_dequeue_burst(&lls_conf->requests,
+		(void **)reqs, LLS_CACHE_BURST_SIZE);
+	unsigned int i;
+
+	for (i = 0; i < count; i++) {
+		switch (reqs[i]->ty) {
+		case LLS_REQ_HOLD:
+			lls_process_hold(lls_conf, &reqs[i]->u.hold);
+			break;
+		case LLS_REQ_PUT:
+			lls_process_put(lls_conf, &reqs[i]->u.put);
+			break;
+		default:
+			RTE_LOG(ERR, GATEKEEPER,
+				"lls: unrecognized request type (%d)\n",
+				reqs[i]->ty);
+			break;
+		}
+		mb_free_entry(&lls_conf->requests, reqs[i]);
+	}
+
+	return count;
+}
+
+int
+lls_req(enum lls_req_ty ty, void *req_arg)
+{
+	struct lls_config *lls_conf = get_lls_conf();
+	struct lls_request *req = mb_alloc_entry(&lls_conf->requests);
+	int ret;
+
+	if (req == NULL) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"lls: allocation for request of type %d failed", ty);
+		return -1;
+	}
+
+	req->ty = ty;
+
+	switch (ty) {
+	case LLS_REQ_HOLD:
+		req->u.hold = *(struct lls_hold_req *)req_arg;
+		break;
+	case LLS_REQ_PUT:
+		req->u.put = *(struct lls_put_req *)req_arg;
+		break;
+	default:
+		mb_free_entry(&lls_conf->requests, req);
+		RTE_LOG(ERR, GATEKEEPER,
+			"lls: unknown request type %d failed", ty);
+		return -1;
+	}
+
+	ret = mb_send_entry(&lls_conf->requests, req);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+void
+lls_cache_scan(struct lls_config *lls_conf, struct lls_cache *cache)
+{
+	uint32_t iter = 0;
+	int32_t index;
+	const uint8_t *ip_be;
+	void *data;
+	struct gatekeeper_if *front = &lls_conf->net->front;
+	struct gatekeeper_if *back = &lls_conf->net->back;
+	time_t now = time(NULL);
+
+	RTE_ASSERT(now >= 0);
+	index = rte_hash_iterate(cache->hash, (void *)&ip_be, &data, &iter);
+	while (index >= 0) {
+		struct lls_record *record = &cache->records[index];
+		uint32_t timeout;
+
+		/*
+		 * If a map is already stale, continue to
+		 * try to resolve it while there's interest.
+		 */
+		if (record->map.stale) {
+			if (record->num_holds > 0)
+				lls_send_request(lls_conf, cache, ip_be, NULL);
+			else
+				lls_del_record(cache, ip_be);
+			goto next;
+		}
+
+		if (record->map.port_id == front->id)
+			timeout = cache->front_timeout_sec;
+		else if (lls_conf->net->back_iface_enabled &&
+				record->map.port_id == back->id)
+			timeout = cache->back_timeout_sec;
+		else {
+			char ip_buf[cache->key_str_len];
+			char *ip_str = cache->ip_str(cache, ip_be, ip_buf,
+				cache->key_str_len);
+			RTE_LOG(ERR, GATEKEEPER,
+				"lls: map for %s has an invalid port %hhu\n",
+				ip_str == NULL ? cache->name : ip_str,
+				record->map.port_id);
+			lls_del_record(cache, ip_be);
+			goto next;
+		}
+
+		if (now - record->ts >= timeout) {
+			record->map.stale = true;
+			lls_update_subscribers(record);
+			if (record->num_holds > 0)
+				lls_send_request(lls_conf, cache, ip_be,
+					&record->map.ha);
+		} else if (timeout > LLS_CACHE_SCAN_INTERVAL &&
+				(now - record->ts >=
+					timeout - LLS_CACHE_SCAN_INTERVAL)) {
+			/*
+			 * If the record is close to being stale,
+			 * preemptively send a unicast probe.
+			 */
+			if (record->num_holds > 0)
+				lls_send_request(lls_conf, cache, ip_be,
+					&record->map.ha);
+		}
+next:
+		index = rte_hash_iterate(cache->hash, (void *)&ip_be,
+			&data, &iter);
+	}
+
+	if (get_lls_conf()->debug)
+		lls_cache_dump(cache);
+}
+
+void
+lls_cache_destroy(struct lls_cache *cache)
+{
+	rte_hash_free(cache->hash);
+}
+
+int
+lls_cache_init(struct lls_config *lls_conf, struct lls_cache *cache)
+{
+	struct rte_hash_parameters lls_cache_params = {
+		.name = cache->name,
+		.entries = LLS_CACHE_RECORDS,
+		.reserved = 0,
+		.key_len = cache->key_len,
+		.hash_func = DEFAULT_HASH_FUNC,
+		.hash_func_init_val = 0,
+		.socket_id = rte_lcore_to_socket_id(lls_conf->lcore_id),
+		.extra_flag = 0,
+	};
+
+	RTE_ASSERT(cache->key_len <= LLS_MAX_KEY_LEN);
+	cache->hash = rte_hash_create(&lls_cache_params);
+	if (cache->hash == NULL) {
+		RTE_LOG(ERR, HASH, "Could not create %s cache hash\n",
+			cache->name);
+		return -1;
+	}
+	return 0;
+}

--- a/lls/cache.h
+++ b/lls/cache.h
@@ -1,0 +1,112 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_LLS_CACHE_H_
+#define _GATEKEEPER_LLS_CACHE_H_
+
+#include "gatekeeper_lls.h"
+
+/* Length of time (in seconds) to wait between scans of the cache. */
+#define LLS_CACHE_SCAN_INTERVAL 10
+
+/* Information needed to add a hold to a record. */
+struct lls_hold_req {
+	/* Cache that holds (or will hold) this map. */
+	struct lls_cache *cache;
+
+	/* IP address for this request, in network ordering. */
+	uint8_t          ip_be[LLS_MAX_KEY_LEN];
+
+	/* Hold that this is requesting. */
+	struct lls_hold  hold;
+};
+
+/* Information needed to drop a struct lls_hold from a record. */
+struct lls_put_req {
+	/* Cache that (possibly) has this hold. */
+	struct lls_cache *cache;
+
+	/* IP address for this request, in network ordering. */
+	uint8_t          ip_be[LLS_MAX_KEY_LEN];
+
+	/* The lcore that requested this put. */
+	unsigned int     lcore_id;
+};
+
+/* A modification to an LLS map. */
+struct lls_mod_req {
+	/* Cache that holds (or will hold) this map. */
+	struct lls_cache  *cache;
+
+	/* IP address for this modification, in network ordering. */
+	uint8_t           ip_be[LLS_MAX_KEY_LEN];
+
+	/*
+	 * Ethernet address of modification, possibly
+	 * not different from existing address in record.
+	 */
+	struct ether_addr ha;
+
+	/*
+	 * Port of modification, possibly not
+	 * different from existing port ID in record.
+	 */
+	uint8_t           port_id;
+
+	/* Timestamp of this modification. */
+	time_t            ts;
+};
+
+/* Request submitted to the LLS block. */
+struct lls_request {
+	/* Type of request. */
+	enum lls_req_ty ty;
+
+	union {
+		/* If @ty is LLS_REQ_HOLD, use @hold. */
+		struct lls_hold_req hold;
+		/* If @ty is LLS_REQ_PUT, use @put. */
+		struct lls_put_req  put;
+	} u;
+};
+
+int lls_cache_init(struct lls_config *lls_conf, struct lls_cache *cache);
+void lls_cache_destroy(struct lls_cache *cache);
+
+/* Process any requests to the LLS block. */
+unsigned int lls_process_reqs(struct lls_config *lls_conf);
+
+/*
+ * Submit a request to the LLS block, where @req_arg is one of the
+ * the members of the union in struct lls_request that matches @ty.
+ */
+int lls_req(enum lls_req_ty ty, void *req_arg);
+
+/*
+ * Modify a cache entry without going through the mailbox.
+ *
+ * NOTE
+ *	This should only be used by the LLS block itself. Other
+ *	requests to modify the cache should go through lls_req().
+ */
+void lls_process_mod(struct lls_config *lls_conf, struct lls_mod_req *mod);
+
+/* Scan the cache and send requests or remove entries as needed. */
+void lls_cache_scan(struct lls_config *lls_conf, struct lls_cache *cache);
+
+#endif /* _GATEKEEPER_LLS_CACHE_H_ */

--- a/lls/main.c
+++ b/lls/main.c
@@ -16,11 +16,320 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "gatekeeper_lls.h"
+#include <stdbool.h>
+
+#include <rte_cycles.h>
+#include <rte_ethdev.h>
+
+#include "arp.h"
+#include "cache.h"
+
+/* Length of time (in seconds) to wait between scans of the cache. */
+#define LLS_CACHE_SCAN_INTERVAL 10
+
+static struct lls_config lls_conf = {
+	.arp_cache = {
+		.key_len = sizeof(struct in_addr),
+		.key_str_len = INET_ADDRSTRLEN,
+		.name = "arp",
+		.iface_enabled = iface_arp_enabled,
+		.ip_str = ipv4_str,
+		.xmit_req = xmit_arp_req,
+		.print_record = print_arp_record,
+	},
+	/* TODO Initialize ND cache. */
+};
+
+static inline int
+arp_enabled(struct lls_config *lls_conf)
+{
+	return lls_conf->arp_cache.iface_enabled(lls_conf->net,
+			&lls_conf->net->front) ||
+		lls_conf->arp_cache.iface_enabled(lls_conf->net,
+			&lls_conf->net->back);
+}
+
+struct lls_config *
+get_lls_conf(void)
+{
+	return &lls_conf;
+}
+
+static int
+cleanup_lls(void)
+{
+	/* TODO Destroy ND cache. */
+	if (arp_enabled(&lls_conf))
+		lls_cache_destroy(&lls_conf.arp_cache);
+	destroy_mailbox(&lls_conf.requests);
+	rte_timer_stop(&lls_conf.timer);
+	return 0;
+}
+
+int hold_arp(lls_req_cb cb, void *arg, struct in_addr *ip_be,
+	unsigned int lcore_id)
+{
+	if (arp_enabled(&lls_conf)) {
+		struct lls_hold_req hold_req = {
+			.cache = &lls_conf.arp_cache,
+			.hold = {
+				.cb = cb,
+				.arg = arg,
+				.lcore_id = lcore_id,
+			},
+		};
+		memcpy(hold_req.ip_be, ip_be, sizeof(*ip_be));
+		return lls_req(LLS_REQ_HOLD, &hold_req);
+	}
+
+	RTE_LOG(WARNING, GATEKEEPER,
+		"lls: lcore %u called %s but ARP service is not enabled\n",
+		lcore_id, __func__);
+	return -1;
+}
+
+int put_arp(struct in_addr *ip_be, unsigned int lcore_id)
+{
+	if (arp_enabled(&lls_conf)) {
+		struct lls_put_req put_req = {
+			.cache = &lls_conf.arp_cache,
+			.lcore_id = lcore_id,
+		};
+		memcpy(put_req.ip_be, ip_be, sizeof(*ip_be));
+		return lls_req(LLS_REQ_PUT, &put_req);
+	}
+
+	RTE_LOG(WARNING, GATEKEEPER,
+		"lls: lcore %u called %s but ARP service is not enabled\n",
+		lcore_id, __func__);
+	return -1;
+}
+
+static void
+lls_scan(__attribute__((unused)) struct rte_timer *timer, void *arg)
+{
+	struct lls_config *lls_conf = (struct lls_config *)arg;
+	if (arp_enabled(lls_conf))
+		lls_cache_scan(lls_conf, &lls_conf->arp_cache);
+	/* TODO Scan the ND cache. */
+}
+
+static void
+process_pkts(struct lls_config *lls_conf, struct gatekeeper_if *iface,
+	uint16_t rx_queue, uint16_t tx_queue)
+{
+	struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
+	uint16_t num_rx = rte_eth_rx_burst(iface->id, rx_queue, bufs,
+		GATEKEEPER_MAX_PKT_BURST);
+	uint16_t i;
+
+	for (i = 0; i < num_rx; i++) {
+		struct ether_hdr *eth_hdr = rte_pktmbuf_mtod(bufs[i],
+			struct ether_hdr *);
+
+		/*
+		 * The destination MAC address should be the broadcast
+		 * address or match the interface's Ethernet address,
+		 * because for round robin and LACP bonding the
+		 * slave interfaces assume the MAC address of the
+		 * bonded interface.
+		 *
+		 * See: http://dpdk.org/doc/guides/prog_guide/link_bonding_poll_mode_drv_lib.html#configuration
+		 */
+		if (!is_broadcast_ether_addr(&eth_hdr->d_addr) &&
+		    !is_same_ether_addr(&eth_hdr->d_addr, &iface->eth_addr))
+			goto free_buf;
+
+		/* TODO Add support for ND packets. */
+		switch (rte_be_to_cpu_16(eth_hdr->ether_type)) {
+		case ETHER_TYPE_ARP:
+			if (process_arp(lls_conf, iface, tx_queue,
+					bufs[i], eth_hdr) == -1)
+				goto free_buf;
+
+			/* ARP reply was sent, so no free is needed. */
+			continue;
+		default:
+			RTE_LOG(ERR, GATEKEEPER, "lls: %s interface should not be seeing a packet with EtherType 0x%04hx\n",
+				iface->name,
+				rte_be_to_cpu_16(eth_hdr->ether_type));
+			goto free_buf;
+		}
+free_buf:
+		rte_pktmbuf_free(bufs[i]);
+	}
+}
+
+static int
+lls_proc(void *arg)
+{
+	struct lls_config *lls_conf = (struct lls_config *)arg;
+	struct net_config *net_conf = lls_conf->net;
+	int ret;
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"lls: the LLS block is running at lcore = %u\n",
+		lls_conf->lcore_id);
+
+	/* Wait for network devices to start. */
+	while (net_conf->configuring)
+		;
+
+	/* Filters must be added after the network device starts. */
+	if (lls_conf->arp_cache.iface_enabled(net_conf, &net_conf->front)) {
+		ret = ethertype_filter_add(net_conf->front.id,
+			ETHER_TYPE_ARP, lls_conf->rx_queue_front);
+		if (ret < 0) {
+			exiting = true;
+			goto out;
+		}
+	}
+
+	if (lls_conf->arp_cache.iface_enabled(net_conf, &net_conf->back)) {
+		ret = ethertype_filter_add(net_conf->back.id,
+			ETHER_TYPE_ARP, lls_conf->rx_queue_back);
+		if (ret < 0) {
+			exiting = true;
+			goto out;
+		}
+	}
+
+	/* TODO Add ND filters. */
+
+	while (likely(!exiting)) {
+		/* Read in packets on front and back interfaces. */
+		process_pkts(lls_conf, &net_conf->front,
+			lls_conf->rx_queue_front, lls_conf->tx_queue_front);
+		if (net_conf->back_iface_enabled)
+			process_pkts(lls_conf, &net_conf->back,
+				lls_conf->rx_queue_back,
+				lls_conf->tx_queue_back);
+
+		/* Process any requests. */
+		if (likely(lls_process_reqs(lls_conf) == 0)) {
+			/*
+			 * If there are no requests to go through, then do a
+			 * scan of the cache (if enough time has passed).
+			 *
+			 * XXX In theory, many new LLS changes could starve
+			 * the ability to scan, but this will not likely
+			 * happen. In fact, we may want to reduce the amount
+			 * of times this is called, since reading the HPET
+			 * timer is inefficient. See the timer application.
+			 */
+			rte_timer_manage();
+		}
+	}
+out:
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"lls: the LLS block at lcore = %u is exiting\n",
+		lls_conf->lcore_id);
+
+	return cleanup_lls();
+}
+
+static int
+assign_lls_queue_ids(struct lls_config *lls_conf)
+{
+	int ret = get_queue_id(&lls_conf->net->front, QUEUE_TYPE_RX,
+		lls_conf->lcore_id);
+	if (ret < 0)
+		return ret;
+	lls_conf->rx_queue_front = (uint16_t)ret;
+
+	ret = get_queue_id(&lls_conf->net->front, QUEUE_TYPE_TX,
+		lls_conf->lcore_id);
+	if (ret < 0)
+		return ret;
+	lls_conf->tx_queue_front = (uint16_t)ret;
+
+	if (lls_conf->net->back_iface_enabled) {
+		ret = get_queue_id(&lls_conf->net->back, QUEUE_TYPE_RX,
+			lls_conf->lcore_id);
+		if (ret < 0)
+			return ret;
+		lls_conf->rx_queue_back = (uint16_t)ret;
+
+		ret = get_queue_id(&lls_conf->net->back, QUEUE_TYPE_TX,
+			lls_conf->lcore_id);
+		if (ret < 0)
+			return ret;
+		lls_conf->tx_queue_back = (uint16_t)ret;
+	}
+
+	return 0;
+}
 
 int
-run_lls(void)
+run_lls(struct net_config *net_conf, struct lls_config *lls_conf)
 {
-	/* TODO Initialize and run Link Layer Support functional block. */
+	int ret;
+
+	if (net_conf == NULL || lls_conf == NULL) {
+		ret = -1;
+		goto out;
+	}
+
+	lls_conf->net = net_conf;
+
+	/* Do LLS cache scan every LLS_CACHE_SCAN_INTERVAL seconds. */
+	rte_timer_init(&lls_conf->timer);
+	ret = rte_timer_reset(&lls_conf->timer,
+		LLS_CACHE_SCAN_INTERVAL * rte_get_timer_hz(), PERIODICAL,
+		lls_conf->lcore_id, lls_scan, lls_conf);
+	if (ret < 0) {
+		RTE_LOG(ERR, TIMER, "Cannot set LLS scan timer\n");
+		return -1;
+	}
+
+	ret = assign_lls_queue_ids(lls_conf);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER, "lls: cannot assign queues\n");
+		goto timer;
+	}
+
+	ret = init_mailbox("lls_req", MAILBOX_MAX_ENTRIES,
+		sizeof(struct lls_request), lls_conf->lcore_id,
+		&lls_conf->requests);
+	if (ret < 0)
+		goto timer;
+
+	if (arp_enabled(lls_conf)) {
+		ret = lls_cache_init(lls_conf, &lls_conf->arp_cache);
+		if (ret < 0) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"lls: ARP cache cannot be started\n");
+			goto requests;
+		}
+
+		/* Set timeouts for front and back (if needed). */
+		if (lls_conf->arp_cache.iface_enabled(net_conf,
+				&net_conf->front))
+			lls_conf->arp_cache.front_timeout_sec =
+				net_conf->front.arp_cache_timeout_sec;
+		if (lls_conf->arp_cache.iface_enabled(net_conf,
+				&net_conf->back))
+			lls_conf->arp_cache.back_timeout_sec =
+				lls_conf->net->back.arp_cache_timeout_sec;
+	}
+
+	/* TODO Initialize ND cache. */
+
+	ret = rte_eal_remote_launch(lls_proc, lls_conf, lls_conf->lcore_id);
+	if (ret) {
+		RTE_LOG(ERR, EAL, "lcore %u failed to launch LLs\n",
+			lls_conf->lcore_id);
+		goto arp;
+	}
+
 	return 0;
+arp:
+	if (arp_enabled(lls_conf))
+		lls_cache_destroy(&lls_conf->arp_cache);
+requests:
+	destroy_mailbox(&lls_conf->requests);
+timer:
+	rte_timer_stop(&lls_conf->timer);
+out:
+	return ret;
 }

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -14,6 +14,10 @@ function gatekeeper_init()
 	local net_conf = net.setup_block()
 	if net_conf == nil then return -1 end
 
+	local lls = require("lls")
+	local lls_conf = lls.setup_block(net_conf, numa_table)
+	if lls_conf == nil then return -1 end
+
 	-- Disable the GK and GGU blocks just removing the X below.
 	--X[[
 	local gk = require("gk")

--- a/lua/gatekeeperc.lua
+++ b/lua/gatekeeperc.lua
@@ -10,6 +10,7 @@ struct gatekeeper_if {
 	char     *name;
 	uint16_t num_rx_queues;
 	uint16_t num_tx_queues;
+	uint32_t arp_cache_timeout_sec;
 	/* This struct has hidden fields. */
 };
 
@@ -29,6 +30,12 @@ struct ggu_config {
 	unsigned int      lcore_id;
 	uint16_t          ggu_src_port;
 	uint16_t          ggu_dst_port;
+	/* This struct has hidden fields. */
+};
+
+struct lls_config {
+	unsigned int lcore_id;
+	int          debug;
 	/* This struct has hidden fields. */
 };
 
@@ -55,6 +62,9 @@ struct ggu_config *alloc_ggu_conf(void);
 int run_ggu(struct net_config *net_conf,
 	struct gk_config *gk_conf, struct ggu_config *ggu_conf);
 int cleanup_ggu(struct ggu_config *ggu_conf);
+
+struct lls_config *get_lls_conf(void);
+int run_lls(struct net_config *net_conf, struct lls_config *lls_conf);
 
 ]]
 

--- a/lua/lls.lua
+++ b/lua/lls.lua
@@ -1,0 +1,23 @@
+local gatekeeperc = require("gatekeeperc")
+
+local M = {}
+
+-- Function that sets up the GK functional block.
+function M.setup_block(net_conf, numa_table)
+
+	-- Init the LLS configuration structure.
+	local lls_conf = gatekeeperc.get_lls_conf()
+	if lls_conf == nil then return nil end
+
+	-- Change these parameters to configure the LLS block.
+	lls_conf.debug = false
+
+	-- Setup the LLS functional block.
+	lls_conf.lcore_id = gatekeeper.alloc_an_lcore(numa_table)
+	local ret = gatekeeperc.run_lls(net_conf, lls_conf)
+	if ret < 0 then return nil end
+
+	return lls_conf
+end
+
+return M

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -35,18 +35,21 @@ function M.setup_block()
 	-- Each interface should have at most two ip addresses:
 	-- 1 IPv4, 1 IPv6.
 	local front_ips  = {"10.0.0.1", "3ffe:2501:200:1fff::7"}
+	local front_arp_cache_timeout_sec = 7200
 
-	local front_rx_queues = 2
-	local front_tx_queues = 0
+	local front_rx_queues = 3
+	local front_tx_queues = 1
 
 	local back_iface_enabled = true
 	local back_ports = {"enp133s0f1"}
 	local back_ips  = {"10.0.0.2", "3ffe:2501:200:1fff::8"}
-	local back_rx_queues = 1
-	local back_tx_queues = 2
+	local back_arp_cache_timeout_sec = 7200
+	local back_rx_queues = 2
+	local back_tx_queues = 3
 
 	-- Code below this point should not need to be changed.
 	local front_iface = gatekeeperc.get_if_front(conf)
+	front_iface.arp_cache_timeout_sec = front_arp_cache_timeout_sec
 	front_iface.num_rx_queues = front_rx_queues
 	front_iface.num_tx_queues = front_tx_queues
 	local ret = init_iface(front_iface, "front", front_ports, front_ips)
@@ -57,6 +60,7 @@ function M.setup_block()
 	conf.back_iface_enabled = back_iface_enabled
 	if back_iface_enabled then
 		local back_iface = gatekeeperc.get_if_back(conf)
+		back_iface.arp_cache_timeout_sec = back_arp_cache_timeout_sec
 		back_iface.num_rx_queues = back_rx_queues
 		back_iface.num_tx_queues = back_tx_queues
 		ret = init_iface(back_iface, "back", back_ports, back_ips)

--- a/main/main.c
+++ b/main/main.c
@@ -27,6 +27,7 @@
 #include <rte_common.h>
 #include <rte_launch.h>
 #include <rte_cycles.h>
+#include <rte_timer.h>
 
 #include "gatekeeper_main.h"
 #include "gatekeeper_config.h"
@@ -135,6 +136,9 @@ main(int argc, char **argv)
 
 	/* XXX Set the global log level. Change it as needed. */
 	rte_set_log_level(RTE_LOG_DEBUG);
+
+	/* Used by the LLS block. */
+	rte_timer_subsystem_init();
 
 	/* Given the nature of signal, it's okay to not have a cleanup for them. */
 	ret = run_signal_handler();


### PR DESCRIPTION
The LLS block and the ARP cache, implemented to allow other functional blocks to request one-time resolution or to always be notified of updates to an entry.

@mengxiang0811 This patch, not included in this pull request, should give you an idea of how the GK block can subscribe to LLS entries.