### PR TITLE
net: add prefix length to IP addresses

### DIFF
--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -152,6 +152,12 @@ struct lls_cache {
 		char *buf, size_t len);
 
 	/*
+	 * Returns whether @ip_be is in the same subnet as the
+	 * relevant address for this cache assigned to @iface.
+	 */
+	int (*ip_in_subnet)(struct gatekeeper_if *iface, const void *ip_be);
+
+	/*
 	 * Function to transmit a request out of @iface to resolve
 	 * IP address @ip_be to an Ethernet address.
 	 *

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -106,7 +106,9 @@ struct gatekeeper_if {
 	 */
 	uint8_t         configured_proto;
 	struct in_addr  ip4_addr;
+	struct in_addr  ip4_mask;
 	struct in6_addr ip6_addr;
+	struct in6_addr ip6_mask;
 };
 
 /*
@@ -161,7 +163,7 @@ extern uint8_t rss_key_be[RTE_DIM(default_rss_key)];
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_addrs, uint8_t num_ip_addrs);
+	const char **ip_cidrs, uint8_t num_ip_cidrs);
 void lua_free_iface(struct gatekeeper_if *iface);
 
 int ethertype_filter_add(uint8_t port_id, uint16_t ether_type,

--- a/lls/arp.h
+++ b/lls/arp.h
@@ -29,6 +29,9 @@ int iface_arp_enabled(struct net_config *net, struct gatekeeper_if *iface);
 char *ipv4_str(struct lls_cache *cache, const uint8_t *ip_be,
 	char *buf, size_t len);
 
+/* Return whether @ip_be is in the same subnet as @iface's IPv4 address. */
+int ipv4_in_subnet(struct gatekeeper_if *iface, const void *ip_be);
+
 /* Transmit an ARP request packet. */
 void xmit_arp_req(struct gatekeeper_if *iface, const uint8_t *ip_be,
 	const struct ether_addr *ha, uint16_t tx_queue);

--- a/lls/cache.c
+++ b/lls/cache.c
@@ -38,14 +38,14 @@ static void
 lls_send_request(struct lls_config *lls_conf, struct lls_cache *cache,
 	const uint8_t *ip_be, const struct ether_addr *ha)
 {
-	/*
-	 * TODO Use network mask to determine which
-	 * iface to use for invalid entries.
-	 */
-	if (cache->iface_enabled(lls_conf->net, &lls_conf->net->front))
+	struct gatekeeper_if *front = &lls_conf->net->front;
+	struct gatekeeper_if *back = &lls_conf->net->back;
+	if (cache->iface_enabled(lls_conf->net, front) &&
+			cache->ip_in_subnet(front, ip_be))
 		cache->xmit_req(&lls_conf->net->front, ip_be, ha,
 			lls_conf->tx_queue_front);
-	if (cache->iface_enabled(lls_conf->net, &lls_conf->net->back))
+	if (cache->iface_enabled(lls_conf->net, back) &&
+			cache->ip_in_subnet(back, ip_be))
 		cache->xmit_req(&lls_conf->net->back, ip_be, ha,
 			lls_conf->tx_queue_back);
 }

--- a/lls/main.c
+++ b/lls/main.c
@@ -36,6 +36,7 @@ static struct lls_config lls_conf = {
 		.name = "arp",
 		.iface_enabled = iface_arp_enabled,
 		.ip_str = ipv4_str,
+		.ip_in_subnet = ipv4_in_subnet,
 		.xmit_req = xmit_arp_req,
 		.print_record = print_arp_record,
 	},

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -139,7 +139,7 @@ ffi.cdef[[
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_addrs, uint8_t num_ip_addrs);
+	const char **ip_cidrs, uint8_t num_ip_cidrs);
 void lua_free_iface(struct gatekeeper_if *iface);
 
 struct net_config *get_net_conf(void);
@@ -168,7 +168,7 @@ c = ffi.C
 
 local ifaces = require("if_map")
 
-function init_iface(iface, name, ports, ips)
+function init_iface(iface, name, ports, cidrs)
 	local pci_strs = ffi.new("const char *[" .. #ports .. "]")
 	for i, v in ipairs(ports) do
 		local pci_addr = ifaces[v]
@@ -178,13 +178,13 @@ function init_iface(iface, name, ports, ips)
 		pci_strs[i - 1] = pci_addr
 	end
 
-	local ip_strs = ffi.new("const char *[" .. #ips .. "]")
-	for i, v in ipairs(ips) do
-		ip_strs[i - 1] = v
+	local ip_cidrs = ffi.new("const char *[" .. #cidrs .. "]")
+	for i, v in ipairs(cidrs) do
+		ip_cidrs[i - 1] = v
 	end
 
 	local ret = c.lua_init_iface(iface, name, pci_strs, #ports,
-		ip_strs, #ips)
+		ip_cidrs, #cidrs)
 	if ret < 0 then
 		error("Failed to initilialize " .. name .. " interface")
 	end

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -6,12 +6,12 @@ return function ()
 	local front_ports = {"enp133s0f0"}
 	-- Each interface should have at most two ip addresses:
 	-- 1 IPv4, 1 IPv6.
-	local front_ips  = {"10.0.0.1", "3ffe:2501:200:1fff::7"}
+	local front_ips  = {"10.0.0.1/24", "3ffe:2501:200:1fff::7/48"}
 	local front_arp_cache_timeout_sec = 7200
 
 	local back_iface_enabled = true
 	local back_ports = {"enp133s0f1"}
-	local back_ips  = {"10.0.0.2", "3ffe:2501:200:1fff::8"}
+	local back_ips  = {"10.0.0.2/24", "3ffe:2501:200:1fff::8/48"}
 	local back_arp_cache_timeout_sec = 7200
 
 	--


### PR DESCRIPTION
Enable the operator to specify the subnet prefix length during
configuration, and use that subnet information to decide which
interface to send resolution broadcasts and to determine whether
a received packet's source address is valid.