### PR TITLE
add LPM table and integrate LLS to gk block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ SRCS-y += rt/main.c
 
 # Libraries.
 SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c \
-	lib/luajit-ffi-cdata.c lib/launch.c
+	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c
 
 LDLIBS += $(LDIR) -Bstatic -lluajit-5.1 -Bdynamic -lm
 CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include -I/usr/local/include/luajit-2.0/

--- a/gk/main.c
+++ b/gk/main.c
@@ -18,6 +18,7 @@
 
 #include <string.h>
 #include <stdbool.h>
+#include <arpa/inet.h>
 
 #include <rte_ip.h>
 #include <rte_log.h>
@@ -30,9 +31,6 @@
 
 #include "gatekeeper_gk.h"
 #include "gatekeeper_main.h"
-#include "gatekeeper_net.h"
-#include "gatekeeper_mailbox.h"
-#include "gatekeeper_ipip.h"
 #include "gatekeeper_config.h"
 #include "gatekeeper_launch.h"
 #include "gatekeeper_lls.h"
@@ -60,6 +58,12 @@ struct flow_entry {
 	/* The state of the entry. */
 	enum gk_flow_state state;
 
+	/*
+	 * The fib entry that instructs where
+	 * to send the packets for this flow entry.
+	 */
+	struct gk_fib *grantor_fib;
+
 	union {
 		struct {
 			/* The time the last packet of the entry was seen. */
@@ -76,11 +80,6 @@ struct flow_entry {
 			 * @last_priority.
 			 */
 			uint8_t allowance;
-			/* 
-			 * The ID of the Grantor server to which packets to
-			 * @dst must be sent.
-			 */
-			int grantor_id;
 		} request;
 
 		struct {
@@ -96,11 +95,9 @@ struct flow_entry {
 			/* How many bytes @src can still send in current cycle. */
 			int budget_byte;
 			/*
-			 * The ID of the Grantor server to which packets to
-			 * @dst must be sent.
+			 * When GK should send the next renewal to
+			 * the corresponding grantor.
 			 */
-			int grantor_id;
-			/* When GK should send the next renewal to @grantor_id. */
 			uint64_t send_next_renewal_at;
 			/*
 			 * How many cycles (unit) GK must wait before
@@ -157,8 +154,34 @@ priority_from_delta_time(uint64_t present, uint64_t past)
 	return integer_log_base_2(delta_time);
 }
 
+static struct gk_fib *
+look_up_fib(struct gk_lpm *ltbl, struct ip_flow *flow)
+{
+	int fib_id;
+
+	if (flow->proto == ETHER_TYPE_IPv4) {
+		fib_id = lpm_lookup_ipv4(ltbl->lpm, flow->f.v4.dst);
+		if (fib_id < 0)
+			return NULL;
+		return &ltbl->fib_tbl[fib_id];
+	}
+
+	if (likely(flow->proto == ETHER_TYPE_IPv6)) {
+		fib_id = lpm_lookup_ipv6(ltbl->lpm6, flow->f.v6.dst);
+		if (fib_id < 0)
+			return NULL;
+		return &ltbl->fib_tbl6[fib_id];
+	}
+
+	rte_panic("Unexpected condition at %s: unknown flow type %hu\n",
+		__func__, flow->proto);
+
+	return NULL; /* Unreachable. */
+}
+
 static inline void
-initialize_flow_entry(struct flow_entry *fe, struct ip_flow *flow)
+initialize_flow_entry(struct flow_entry *fe,
+	struct ip_flow *flow, struct gk_fib *grantor_fib)
 {
 	rte_memcpy(&fe->flow, flow, sizeof(*flow));
 
@@ -166,8 +189,25 @@ initialize_flow_entry(struct flow_entry *fe, struct ip_flow *flow)
 	fe->u.request.last_packet_seen_at = rte_rdtsc();
 	fe->u.request.last_priority = START_PRIORITY;
 	fe->u.request.allowance = START_ALLOWANCE - 1;
-	/* TODO Grantor ID comes from LPM lookup. */
-	fe->u.request.grantor_id = 0;
+
+	/*
+	 * TODO Flow entries should maintain the reference counter of
+	 * the grantor FIB entry to avoid the entry to go away before the flow.
+	 *
+	 * Notice that all GK blocks are calling this function, so a solution
+	 * needs to deal with concurrency.
+	 *
+	 * Moreover, the chose solution must be very efficient due to
+	 * the impact on the throughout of the GK blocks. For example,
+	 * a simple atomic counter will slow down all GK blocks;
+	 * especially if there is only one grantor FIB entry.
+	 *
+	 * Ideas for solution: trade the need to maintain the reference counter
+	 * of the grantor FIB entry for some expensive operation that is only
+	 * needed while editing the FIB table.
+	 */
+	fe->grantor_fib = grantor_fib;
+	grantor_fib->ref_cnt++;
 }
 
 static inline void
@@ -177,8 +217,6 @@ reinitialize_flow_entry(struct flow_entry *fe, uint64_t now)
 	fe->u.request.last_packet_seen_at = now;
 	fe->u.request.last_priority = START_PRIORITY;
 	fe->u.request.allowance = START_ALLOWANCE - 1;
-	/* TODO Grantor ID comes from LPM lookup. */
-	fe->u.request.grantor_id = 0;
 }
 
 static inline int
@@ -202,10 +240,7 @@ gk_process_request(struct flow_entry *fe, struct ipacket *packet)
 	uint64_t now = rte_rdtsc();
 	uint8_t priority = priority_from_delta_time(now,
 			fe->u.request.last_packet_seen_at);
-
-	/* TODO The tunnel information should come from the LPM table. */
-	struct ipip_tunnel_info tunnel;
-	memset(&tunnel, 0, sizeof(tunnel));
+	struct gk_fib *fib = fe->grantor_fib;
 
 	fe->u.request.last_packet_seen_at = now;
 
@@ -224,6 +259,10 @@ gk_process_request(struct flow_entry *fe, struct ipacket *packet)
 	}
 
 	/*
+	 * TODO If the nexthop MAC address is stale, then drop the packet.
+	 */
+
+	/*
 	 * Adjust @priority for the DSCP field.
 	 * DSCP 0 for legacy packets; 1 for granted packets; 
 	 * 2 for capability renew; 3-63 for requests.
@@ -235,9 +274,11 @@ gk_process_request(struct flow_entry *fe, struct ipacket *packet)
 	/* The assigned priority is @priority. */
 
 	/* Encapsulate the packet as a request. */
-	ret = encapsulate(packet->pkt, priority, &tunnel);
+	ret = encapsulate(packet->pkt, priority, &fib->u.grantor.flow);
 	if (ret < 0)
 		return ret;
+
+	/* TODO Fill up the Ethernet header of the packet. */
 
 	/* TODO Put this encapsulated packet in the request queue. */
 
@@ -258,10 +299,7 @@ gk_process_granted(struct flow_entry *fe, struct ipacket *packet)
 	uint8_t priority = PRIORITY_GRANTED;
 	uint64_t now = rte_rdtsc();
 	struct rte_mbuf *pkt = packet->pkt;
-
-	/* TODO The tunnel information should come from the LPM table. */
-	struct ipip_tunnel_info tunnel;
-	memset(&tunnel, 0, sizeof(tunnel));
+	struct gk_fib *fib = fe->grantor_fib;
 
 	if (now >= fe->u.granted.cap_expire_at) {
 		reinitialize_flow_entry(fe, now);
@@ -285,13 +323,19 @@ gk_process_granted(struct flow_entry *fe, struct ipacket *packet)
 	}
 
 	/*
+	 * TODO If the nexthop MAC address is stale, then drop the packet.
+	 */
+
+	/*
 	 * Encapsulate packet as a granted packet,
 	 * mark it as a capability renewal request if @renew_cap is true,
-	 * enter destination according to @fe->u.granted.grantor_id.
+	 * enter destination according to @fe->grantor_fib.
 	 */
-	ret = encapsulate(packet->pkt, priority, &tunnel);
+	ret = encapsulate(packet->pkt, priority, &fib->u.grantor.flow);
 	if (ret < 0)
 		return ret;
+
+	/* TODO Fill up the Ethernet header of the packet. */
 
 	/* TODO Put the encapsulated packet in the granted queue. */
 
@@ -311,7 +355,8 @@ gk_process_declined(struct flow_entry *fe, struct ipacket *packet)
 	return drop_packet(packet->pkt);
 }
 
-static int get_block_idx(struct gk_config *gk_conf, unsigned int lcore_id)
+static int
+get_block_idx(struct gk_config *gk_conf, unsigned int lcore_id)
 {
 	int i;
 	for (i = 0; i < gk_conf->num_lcores; i++)
@@ -387,32 +432,128 @@ out:
 }
 
 static void
-add_ggu_policy(struct ggu_policy *policy, struct gk_instance *instance)
+print_flow_err_msg(struct ip_flow *flow, const char *err_msg)
+{
+	char src[128];
+	char dst[128];
+
+	if (flow->proto == ETHER_TYPE_IPv4) {
+		if (inet_ntop(AF_INET, &flow->f.v4.src,
+				src, sizeof(struct in_addr)) == NULL) {
+			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv4 address (%s)\n",
+				__func__, strerror(errno));
+			return;
+		}
+
+		if (inet_ntop(AF_INET, &flow->f.v4.dst,
+				dst, sizeof(struct in_addr)) == NULL) {
+			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv4 address (%s)\n",
+				__func__, strerror(errno));
+			return;
+		}
+	} else if (likely(flow->proto == ETHER_TYPE_IPv6)) {
+		if (inet_ntop(AF_INET6, flow->f.v6.src,
+				src, sizeof(struct in6_addr)) == NULL) {
+			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv6 address (%s)\n",
+				__func__, strerror(errno));
+			return;
+		}
+
+		if (inet_ntop(AF_INET6, flow->f.v6.dst,
+				dst, sizeof(struct in6_addr)) == NULL) {
+			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv6 address (%s)\n",
+				__func__, strerror(errno));
+			return;
+		}
+	} else
+		rte_panic("Unexpected condition at %s: unknown flow type %hu!\n",
+			__func__, flow->proto);
+
+	RTE_LOG(ERR, GATEKEEPER,
+		"%s for the flow with IP source address %s, and destination address %s!\n",
+		err_msg, src, dst);
+}
+
+/*
+ * This function is only called when a policy from GGU block
+ * tries to add a new flow entry in the flow table.
+ *
+ * Notice, the function doesn't fully initialize the new flow entry,
+ * instead it only initializes the @flow and @grantor_fib fields.
+ */
+static struct flow_entry *
+add_new_flow_from_policy(
+	struct ggu_policy *policy, struct gk_instance *instance,
+	struct gk_lpm *ltbl, uint32_t rss_hash_val)
+{
+	int ret;
+	struct gk_fib *fib;
+	struct flow_entry *fe;
+
+	fib = look_up_fib(ltbl, &policy->flow);
+	if (fib == NULL || fib->action != GK_FWD_GRANTOR) {
+		/*
+		 * Drop this solicitation to add
+		 * a policy decision.
+		 */
+		char err_msg[128];
+		ret = snprintf(err_msg, sizeof(err_msg),
+			"gk: at %s initialize flow entry error", __func__);
+		RTE_VERIFY(ret > 0 && ret < (int)sizeof(err_msg));
+		print_flow_err_msg(&policy->flow, err_msg);
+		return NULL;
+	}
+
+	/* Create a new flow entry. */
+	ret = rte_hash_add_key_with_hash(
+		instance->ip_flow_hash_table,
+ 		&policy->flow, rss_hash_val);
+	if (ret < 0) {
+		RTE_LOG(ERR, HASH,
+			"The GK block failed to add new key to hash table in %s!\n",
+			__func__);
+		return NULL;
+	}
+
+	fe = &instance->ip_flow_entry_table[ret];
+	rte_memcpy(&fe->flow, &policy->flow, sizeof(fe->flow));
+
+	fe->grantor_fib = fib;
+	fib->ref_cnt++;
+
+	return fe;
+}
+
+static void
+add_ggu_policy(struct ggu_policy *policy,
+	struct gk_instance *instance, struct gk_lpm *ltbl)
 {
 	int ret;
 	uint64_t now = rte_rdtsc();
 	struct flow_entry *fe;
 	uint32_t rss_hash_val = rss_ip_flow_hf(&policy->flow, 0, 0);
 
+	/*
+	 * When the flow entry already exists,
+	 * the grantor ID should be already known.
+	 * Otherwise, Grantor ID comes from LPM lookup.
+	 */
 	ret = rte_hash_lookup_with_hash(instance->ip_flow_hash_table,
 		&policy->flow, rss_hash_val);
 	if (ret < 0) {
-		/* Create a new flow entry. */
-		ret = rte_hash_add_key_with_hash(
-			instance->ip_flow_hash_table,
- 			(void *)&policy->flow, rss_hash_val);
-		if (ret < 0) {
-			RTE_LOG(ERR, HASH,
-				"The GK block failed to add new key to hash table!\n");
+		/*
+	 	 * The function add_ggu_policy() only fills up
+		 * GK_GRANTED and GK_DECLINED states. So, it doesn't
+		 * need to call initialize_flow_entry().
+		 */
+		fe = add_new_flow_from_policy(
+			policy, instance, ltbl, rss_hash_val);
+		if (fe == NULL)
 			return;
-		}
-
-		fe = &instance->ip_flow_entry_table[ret];
-		initialize_flow_entry(fe, &policy->flow);
 	} else
 		fe = &instance->ip_flow_entry_table[ret];
 
-	switch(policy->state) {
+	switch (policy->state) {
 	case GK_GRANTED:
 		fe->state = GK_GRANTED;
 		fe->u.granted.cap_expire_at = now +
@@ -430,8 +571,6 @@ add_ggu_policy(struct ggu_policy *policy, struct gk_instance *instance)
 			now + cycle_from_second(1);
 		fe->u.granted.budget_byte =
 			fe->u.granted.tx_rate_kb_cycle * 1024;
-
-		/* TODO Fill up the grantor id field. */
 		break;
 
 	case GK_DECLINED:
@@ -448,11 +587,12 @@ add_ggu_policy(struct ggu_policy *policy, struct gk_instance *instance)
 }
 
 static void
-process_gk_cmd(struct gk_cmd_entry *entry, struct gk_instance *instance)
+process_gk_cmd(struct gk_cmd_entry *entry,
+	struct gk_instance *instance, struct gk_lpm *ltbl)
 {
-	switch(entry->op) {
+	switch (entry->op) {
 	case GGU_POLICY_ADD:
-		add_ggu_policy(&entry->u.ggu, instance);
+		add_ggu_policy(&entry->u.ggu, instance, ltbl);
 		break;
 
 	default:
@@ -546,34 +686,83 @@ gk_proc(void *arg)
 
 			/* 
 			 * Find the flow entry for the IP pair.
-			 * Create a new flow entry if not found.
+			 *
+			 * If the pair of source and destination addresses 
+			 * is in the flow table, proceed as the entry instructs,
+			 * and go to the next packet.
 			 */
 			ret = rte_hash_lookup_with_hash(
 				instance->ip_flow_hash_table,
 				&packet.flow, pkt->hash.rss);
-			if (ret < 0) {
-				/* Create a new flow entry. */
-				ret = rte_hash_add_key_with_hash(
-					instance->ip_flow_hash_table,
- 					(void *)&packet.flow, pkt->hash.rss);
-				if (ret < 0) {
-					RTE_LOG(ERR, HASH,
-						"The GK block failed to add new key to hash table!\n");
-					rte_pktmbuf_free(pkt);
+			if (ret >= 0)
+				fe = &instance->ip_flow_entry_table[ret];
+			else {
+				/*
+				 * Otherwise, look up the destination address
+			 	 * in the global LPM table.
+				 */
+				struct gk_fib *fib = look_up_fib(
+					&gk_conf->lpm_tbl, &packet.flow);
+
+			 	/*
+				 * No entry for the destination,
+				 * drop the packet.
+				 */
+				if (fib == NULL) {
+					print_flow_err_msg(&packet.flow,
+						"gk: failed to get the fib entry");
+					drop_packet(pkt);
 					continue;
 				}
 
-				fe = &instance->ip_flow_entry_table[ret];
-				initialize_flow_entry(fe, &packet.flow);
-			} else
-				fe = &instance->ip_flow_entry_table[ret];
+				switch (fib->action) {
+				case GK_FWD_GRANTOR:
+					/*
+			 		 * The entry instructs to enforce
+					 * policies over its packets,
+			 		 * initialize an entry in the
+					 * flow table, proceed as the
+					 * brand-new entry instructs, and
+			 		 * go to the next packet.
+			 		 */
+					ret = rte_hash_add_key_with_hash(
+						instance->ip_flow_hash_table,
+ 						&packet.flow, pkt->hash.rss);
+					if (ret < 0) {
+						RTE_LOG(ERR, HASH,
+							"The GK block failed to add new key to hash table!\n");
+						drop_packet(pkt);
+						continue;
+					}
 
-			/*
-			 * 1.1 If the pair of source and destination addresses 
-			 * is in the flow table, proceed as the entry instructs,
-			 * and go to the next packet.
-			 */
-			switch(fe->state) {
+					fe = &instance->
+						ip_flow_entry_table[ret];
+					initialize_flow_entry(fe,
+						&packet.flow, fib);
+					break;
+
+				case GK_FWD_BACK_NET:
+			 		/*
+					 * TODO The entry instructs to forward
+					 * its packets to the back interface,
+					 * forward accordingly.
+					 *
+					 * Implementing the BP block here.
+					 *
+					 * Notice that one needs to update
+					 * the Ethernet header.
+					 */
+					continue;
+
+				case GK_DROP:
+					/* FALLTHROUGH */
+				default:
+					drop_packet(pkt);
+					continue;
+				}
+			}
+
+			switch (fe->state) {
 			case GK_REQUEST:
 				ret = gk_process_request(fe, &packet);
 				break;
@@ -598,22 +787,6 @@ gk_proc(void *arg)
 				rte_pktmbuf_free(pkt);
 			else
 				tx_bufs[num_tx++] = pkt;
-
-			/*
-			 * TODO 1.2 Otherwise, look up the destination address
-			 * in the global LPM table.
-			 *
-			 * 1.2.1 If there is an entry for the destination and 
-			 * the entry instructs to enforce policies over its packets,
- 			 * initialize an entry in the flow table, proceed as the 
-			 * brand-new entry instructs, and go to the next packet.
-			 *
-			 * 1.2.2 If there is an entry for the destination and
-			 * the entry instructs to forward its packets to the
-			 * back interface, forward accordingly.
-			 *
-			 * 1.2.3 Otherwise, drop the packet.
-			 */
 		}
 
 		/* Send burst of TX packets, to second port of pair. */
@@ -631,7 +804,7 @@ gk_proc(void *arg)
                 	(void **)gk_cmds, GK_CMD_BURST_SIZE);
 
         	for (i = 0; i < num_cmd; i++) {
-			process_gk_cmd(gk_cmds[i], instance);
+			process_gk_cmd(gk_cmds[i], instance, &gk_conf->lpm_tbl);
 			mb_free_entry(&instance->mb, gk_cmds[i]);
         	}
 	}
@@ -646,6 +819,13 @@ struct gk_config *
 alloc_gk_conf(void)
 {
 	return rte_calloc("gk_config", 1, sizeof(struct gk_config), 0);
+}
+
+static void
+destroy_gk_lpm(struct gk_lpm *ltbl)
+{
+	destroy_ipv4_lpm(ltbl->lpm);
+	destroy_ipv6_lpm(ltbl->lpm6);
 }
 
 static int
@@ -664,6 +844,8 @@ cleanup_gk(struct gk_config *gk_conf)
 
                 destroy_mailbox(&gk_conf->instances[i].mb);
 	}
+
+	destroy_gk_lpm(&gk_conf->lpm_tbl);
 
 	rte_free(gk_conf->instances);
 	rte_free(gk_conf->lcores);
@@ -685,21 +867,78 @@ gk_conf_put(struct gk_config *gk_conf)
 	return 0;
 }
 
+/*
+ * XXX Only instantiate the LPM tables needed, for example,
+ * there's no need for an IPv6 LPM table in an IPv4-only deployment.
+ */
+static int
+setup_gk_lpm(struct gk_config *gk_conf, unsigned int socket_id)
+{
+	int ret;
+	struct rte_lpm_config ipv4_lpm_config;
+	struct rte_lpm6_config ipv6_lpm_config;
+	struct gk_lpm *ltbl = &gk_conf->lpm_tbl;
+
+	ipv4_lpm_config.max_rules = gk_conf->max_num_ipv4_rules;
+	ipv4_lpm_config.number_tbl8s = gk_conf->num_ipv4_tbl8s;
+	ipv6_lpm_config.max_rules = gk_conf->max_num_ipv6_rules;
+	ipv6_lpm_config.number_tbl8s = gk_conf->num_ipv6_tbl8s;
+
+	/*
+	 * The GK blocks only need to create one single IPv4 LPM table
+	 * on the @socket_id, so the @lcore and @identifier are set to 0.
+	 */
+	ltbl->lpm = init_ipv4_lpm("gk", &ipv4_lpm_config, socket_id, 0, 0);
+	if (ltbl->lpm == NULL) {
+		ret = -1;
+		goto out;
+	}
+
+	/*
+	 * The GK blocks only need to create one single IPv6 LPM table
+	 * on the @socket_id, so the @lcore and @identifier are set to 0.
+	 */
+	ltbl->lpm6 = init_ipv6_lpm("gk", &ipv6_lpm_config, socket_id, 0, 0);
+	if (ltbl->lpm6 == NULL) {
+		ret = -1;
+		goto free_lpm;
+	}
+
+	ret = 0;
+	goto out;
+
+free_lpm:
+	destroy_ipv4_lpm(ltbl->lpm);
+
+out:
+	return ret;
+}
+
 static int
 gk_stage1(void *arg)
 {
 	struct gk_config *gk_conf = arg;
-	int i;
+	int ret, i;
 
 	gk_conf->instances = rte_calloc(__func__, gk_conf->num_lcores,
 		sizeof(struct gk_instance), 0);
 	if (gk_conf->instances == NULL)
 		return -1;
 
+	/*
+	 * Set up the GK LPM table. We assume that
+	 * all the GK instances are running on the same socket.
+	 */
+	ret = setup_gk_lpm(gk_conf,
+		rte_lcore_to_socket_id(gk_conf->lcores[0]));
+	if (ret < 0) {
+		cleanup_gk(gk_conf);
+		return -1;
+	}
+
 	for (i = 0; i < gk_conf->num_lcores; i++) {
 		unsigned int lcore = gk_conf->lcores[i];
 		struct gk_instance *inst_ptr = &gk_conf->instances[i];
-		int ret;
 
 		/* Set up queue identifiers for RSS. */
 
@@ -719,7 +958,7 @@ gk_stage1(void *arg)
 		}
 		inst_ptr->tx_queue_back = ret;
 
-		/* Setup the gk instance at @lcore. */
+		/* Setup the GK instance at @lcore. */
 		ret = setup_gk_instance(lcore, gk_conf);
 		if (ret < 0) {
 			RTE_LOG(ERR, GATEKEEPER,
@@ -740,6 +979,9 @@ gk_stage2(void *arg)
 	return gk_setup_rss(gk_conf);
 }
 
+/*
+ * TODO Implement the addition of FIB entries in the dynamic configuration.
+ */
 int
 run_gk(struct net_config *net_conf, struct gk_config *gk_conf)
 {
@@ -822,7 +1064,7 @@ get_responsible_gk_mailbox(const struct ip_flow *flow,
 	shift = rss_hash_val % RTE_RETA_GROUP_SIZE;
 	queue_id = gk_conf->rss_conf.reta_conf[idx].reta[shift];
 
-	/* XXX Change mapping queue id to the gk instance id efficiently. */
+	/* XXX Change mapping queue id to the GK instance id efficiently. */
 	for (i = 0; i < gk_conf->num_lcores; i++)
 		if (gk_conf->instances[i].rx_queue_front == queue_id) {
 			block_idx = i;

--- a/include/gatekeeper_ipip.h
+++ b/include/gatekeeper_ipip.h
@@ -21,6 +21,7 @@
 
 #include <rte_ether.h>
 
+#include "gatekeeper_main.h"
 #include "gatekeeper_flow.h"
 
 #define IP_VERSION              (0x40)
@@ -31,14 +32,19 @@
 #define IP_VHL_DEF              (IP_VERSION | IP_HDRLEN)
 #define IP_DN_FRAGMENT_FLAG     (0x0040)
 
-struct ipip_tunnel_info {
-	struct ip_flow	     flow;
-	struct ether_addr    source_mac;
-	/* TODO The MAC addresses must come from the LLS block. */
-	struct ether_addr    nexthop_mac;
-};
-
-int encapsulate(struct rte_mbuf *pkt, uint8_t priority,
-	struct ipip_tunnel_info *info);
+/*
+ * TODO The encapsulation function should not add the Ethernet header.
+ * This way we can compose the Ethernet header copying it from a cache,
+ * or by setting his fields.
+ * Implement a way to add the Ethernet header.
+ * Also, the function to add Ethernet header
+ * needs to set the @outer_l2_len field of the packet.
+ *
+ * Notice that, the original packet should contain the Ethernet header,
+ * while the function shouldn't add an Ethernet header.
+ * When allocating space for the outer IP header,
+ * it only needs to allocate the extra needed space.
+ */
+int encapsulate(struct rte_mbuf *pkt, uint8_t priority, struct ip_flow *fow);
 
 #endif /* _GATEKEEPER_IPIP_H_ */

--- a/include/gatekeeper_lpm.h
+++ b/include/gatekeeper_lpm.h
@@ -1,0 +1,55 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_LPM_H_
+#define _GATEKEEPER_LPM_H_
+
+#include <rte_lpm.h>
+#include <rte_lpm6.h>
+
+/* TODO Implement functions to edit IPv4/IPv6 routes. */
+
+/*
+ * The API here aims to be general and allow developers
+ * to create more than one LPM table on a single lcore id.
+ * @lcore and @identifier are only used to differentiate instances.
+ */
+struct rte_lpm *init_ipv4_lpm(const char *tag,
+	const struct rte_lpm_config *lpm_conf,
+	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
+int lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip);
+
+/* Similar to init_ipv4_lpm(), see above. */
+struct rte_lpm6 *init_ipv6_lpm(const char *tag,
+	const struct rte_lpm6_config *lpm6_conf,
+	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
+int lpm_lookup_ipv6(struct rte_lpm6 *lpm, uint8_t *ip);
+
+static inline void
+destroy_ipv4_lpm(struct rte_lpm *lpm)
+{
+	rte_lpm_free(lpm);
+}
+
+static inline void
+destroy_ipv6_lpm(struct rte_lpm6 *lpm)
+{
+	rte_lpm6_free(lpm);
+}
+
+#endif /* _GATEKEEPER_LPM_H_ */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -20,6 +20,7 @@
 #define _GATEKEEPER_NET_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <netinet/in.h>
 
 #include <rte_ethdev.h>
@@ -43,6 +44,17 @@ struct ipacket {
 	uint16_t        len;
 	/* The type of the next header, if present. */
 	uint8_t         next_hdr;
+};
+
+struct ipaddr {
+	/* The network layer protocol of the nexthop. */
+	uint16_t proto;
+
+	/* The IP address of the nexthop. */
+	union {
+		struct in_addr  v4;
+		struct in6_addr v6;
+	} ip;
 };
 
 /* Size of the secret key of the RSS hash. */
@@ -261,6 +273,18 @@ int gatekeeper_get_rss_config(uint8_t portid,
 	struct gatekeeper_rss_config *rss_conf);
 int gatekeeper_init_network(struct net_config *net_conf);
 void gatekeeper_free_network(void);
+
+static inline bool
+ipv4_if_configured(struct gatekeeper_if *iface)
+{
+	return !!(iface->configured_proto & GK_CONFIGURED_IPV4);
+}
+
+static inline bool
+ipv6_if_configured(struct gatekeeper_if *iface)
+{
+	return !!(iface->configured_proto & GK_CONFIGURED_IPV6);
+}
 
 /*
  * Postpone the execution of f(arg) until the Lua configuration finishes,

--- a/lib/lpm.c
+++ b/lib/lpm.c
@@ -1,0 +1,119 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <rte_log.h>
+#include <rte_debug.h>
+
+#include "gatekeeper_lpm.h"
+#include "gatekeeper_main.h"
+
+struct rte_lpm *
+init_ipv4_lpm(const char *tag,
+	const struct rte_lpm_config *lpm_conf,
+	unsigned int socket_id, unsigned int lcore, unsigned int identifier)
+{
+	int ret;
+	char lpm_name[128];
+	struct rte_lpm *lpm;
+
+	ret = snprintf(lpm_name, sizeof(lpm_name),
+		"%s_lpm_ipv4_%u_%u", tag, lcore, identifier);
+	RTE_VERIFY(ret > 0 && ret < (int)sizeof(lpm_name));
+
+	lpm = rte_lpm_create(lpm_name, socket_id, lpm_conf);
+	if (lpm == NULL) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"Unable to create the IPv4 LPM table %s on socket %u!\n",
+			lpm_name, socket_id);
+		return NULL;
+	}
+
+	return lpm;
+}
+
+int
+lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip)
+{
+	int ret;
+	uint32_t next_hop;
+
+	ret = rte_lpm_lookup(lpm, ip, &next_hop);
+	if (ret == -EINVAL) {
+		RTE_LOG(ERR, LPM,
+			"lpm: incorrect arguments for IPv4 lookup!\n");
+		ret = -1;
+		goto out;
+	} else if (ret == -ENOENT) {
+		RTE_LOG(WARNING, LPM, "lpm: IPv4 lookup miss!\n");
+		ret = -1;
+		goto out;
+	}
+
+	ret = next_hop;
+
+out:
+	return ret;
+}
+
+struct rte_lpm6 *
+init_ipv6_lpm(const char *tag,
+	const struct rte_lpm6_config *lpm6_conf,
+	unsigned int socket_id, unsigned int lcore, unsigned int identifier)
+{
+	int ret;
+	char lpm_name[128];
+	struct rte_lpm6 *lpm;
+
+	ret = snprintf(lpm_name, sizeof(lpm_name),
+		"%s_lpm_ipv6_%u_%u", tag, lcore, identifier);
+	RTE_VERIFY(ret > 0 && ret < (int)sizeof(lpm_name));
+
+	lpm = rte_lpm6_create(lpm_name, socket_id, lpm6_conf);
+	if (lpm == NULL) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"Unable to create the IPv6 LPM table %s on socket %u!\n",
+			lpm_name, socket_id);
+		return NULL;
+	}
+
+	return lpm;
+}
+
+int
+lpm_lookup_ipv6(struct rte_lpm6 *lpm, uint8_t *ip)
+{
+	int ret;
+	uint8_t next_hop;
+
+	ret = rte_lpm6_lookup(lpm, ip, &next_hop);
+	if (ret == -EINVAL) {
+		RTE_LOG(ERR, LPM,
+			"lpm: incorrect arguments for IPv6 lookup!\n");
+		ret = -1;
+		goto out;
+	} else if (ret == -ENOENT) {
+		RTE_LOG(WARNING, LPM, "lpm: IPv6 lookup miss!\n");
+		ret = -1;
+		goto out;
+	}
+
+	ret = next_hop;
+
+out:
+	return ret;
+}

--- a/lib/net.c
+++ b/lib/net.c
@@ -543,12 +543,12 @@ get_ip_type(const char *ip_addr)
 }
 
 static inline int
-max_prefix_len(int gk_type)
+max_prefix_len(int ip_type)
 {
-	RTE_VERIFY(gk_type == AF_INET || gk_type == AF_INET6);
-	return 8 * (gk_type == AF_INET
-		? sizeof(struct in_addr)
-		: sizeof(struct in6_addr));
+	RTE_VERIFY(ip_type == AF_INET || ip_type == AF_INET6);
+	return ip_type == AF_INET
+		? sizeof(struct in_addr) * 8
+		: sizeof(struct in6_addr) * 8;
 }
 
 int
@@ -1095,7 +1095,7 @@ start_iface(struct gatekeeper_if *iface)
 
 out:
 	rte_eth_macaddr_get(iface->id, &iface->eth_addr);
-	if (iface->configured_proto & GK_CONFIGURED_IPV6)
+	if (ipv6_if_configured(iface))
 		setup_ipv6_addrs(iface);
 	return 0;
 

--- a/lls/arp.c
+++ b/lls/arp.c
@@ -28,11 +28,10 @@ iface_arp_enabled(struct net_config *net, struct gatekeeper_if *iface)
 {
 	/* When @iface is the back, need to make sure it's enabled. */
 	if (iface == &net->back)
-		return net->back_iface_enabled &&
-			iface->configured_proto & GK_CONFIGURED_IPV4;
+		return net->back_iface_enabled && ipv4_if_configured(iface);
 
 	/* @iface is the front interface. */
-	return iface->configured_proto & GK_CONFIGURED_IPV4;
+	return ipv4_if_configured(iface);
 }
 
 char *

--- a/lls/nd.c
+++ b/lls/nd.c
@@ -133,11 +133,10 @@ iface_nd_enabled(struct net_config *net, struct gatekeeper_if *iface)
 {
 	/* When @iface is the back, need to make sure it's enabled. */
 	if (iface == &net->back)
-		return net->back_iface_enabled &&
-			iface->configured_proto & GK_CONFIGURED_IPV6;
+		return net->back_iface_enabled && ipv6_if_configured(iface);
 
 	/* @iface is the front interface. */
-	return iface->configured_proto & GK_CONFIGURED_IPV6;
+	return ipv6_if_configured(iface);
 }
 
 char *

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -117,6 +117,10 @@ struct net_config {
 
 struct gk_config {
 	unsigned int flow_ht_size;
+	unsigned int max_num_ipv4_rules;
+	unsigned int num_ipv4_tbl8s;
+	unsigned int max_num_ipv6_rules;
+	unsigned int num_ipv6_tbl8s;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -10,7 +10,7 @@ function gatekeeper_init()
 	-- When gatekeeper_server is true,
 	-- Gatekeeper will run as a Gatekeeper server.
 	-- Otherwise, it will run as a grantor server.
-	local gatekeeper_server = false
+	local gatekeeper_server = true
 
 	local numa_table = gatekeeper.get_numa_table()
 

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -15,6 +15,13 @@ return function (net_conf, numa_table)
 	local ggu_lcore = table.remove(gk_lcores)
 	gatekeeper.gk_assign_lcores(gk_conf, gk_lcores)
 
+	gk_conf.max_num_ipv4_rules = 1024
+	gk_conf.num_ipv4_tbl8s = 256
+	gk_conf.max_num_ipv6_rules = 1024
+	gk_conf.num_ipv6_tbl8s = 65536
+
+ 	-- TODO Edit of the FIB table.
+
 	-- Setup the GK functional block.
 	local ret = gatekeeper.c.run_gk(net_conf, gk_conf)
 	if ret < 0 then


### PR DESCRIPTION
These patches add a global LPM table, and integrate LLS to the gk block. For the LPM table, we assume that all the gk instances are running on the same NUMA node, so only one global LPM table is needed.