### PR TITLE
add LACP and IPv6 ACLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ SRCS-y += rt/main.c
 
 # Libraries.
 SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c \
-	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c
+	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c lib/acl.c
 
 LDLIBS += $(LDIR) -Bstatic -lluajit-5.1 -Bdynamic -lm
 CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include -I/usr/local/include/luajit-2.0/

--- a/gk/main.c
+++ b/gk/main.c
@@ -51,6 +51,14 @@
 /* XXX Sample parameters, need to be tested for better performance. */
 #define GK_CMD_BURST_SIZE        (32)
 
+/* Store information about a packet. */
+struct ipacket {
+	/* Flow identifier for this packet. */
+	struct ip_flow  flow;
+	/* Pointer to the packet itself. */
+	struct rte_mbuf *pkt;
+};
+
 struct flow_entry {
 	/* IP flow information. */
 	struct ip_flow flow;
@@ -177,6 +185,71 @@ look_up_fib(struct gk_lpm *ltbl, struct ip_flow *flow)
 		__func__, flow->proto);
 
 	return NULL; /* Unreachable. */
+}
+
+static int
+extract_packet_info(struct rte_mbuf *pkt, struct ipacket *packet)
+{
+	int ret = 0;
+	uint16_t ether_type;
+	struct ether_hdr *eth_hdr;
+	struct ipv4_hdr *ip4_hdr;
+	struct ipv6_hdr *ip6_hdr;
+	uint16_t pkt_len = rte_pktmbuf_data_len(pkt);
+
+	eth_hdr = rte_pktmbuf_mtod(pkt, struct ether_hdr *);
+	ether_type = rte_be_to_cpu_16(eth_hdr->ether_type);
+
+	switch (ether_type) {
+	case ETHER_TYPE_IPv4:
+		if (pkt_len < sizeof(*eth_hdr) + sizeof(*ip4_hdr)) {
+			packet->flow.proto = 0;
+			RTE_LOG(NOTICE, GATEKEEPER,
+				"gk: packet is too short to be IPv4 (%" PRIu16 ")!\n",
+				pkt_len);
+			ret = -1;
+			goto out;
+		}
+
+		ip4_hdr = rte_pktmbuf_mtod_offset(pkt,
+					struct ipv4_hdr *,
+					sizeof(struct ether_hdr));
+		packet->flow.proto = ETHER_TYPE_IPv4;
+		packet->flow.f.v4.src = ip4_hdr->src_addr;
+		packet->flow.f.v4.dst = ip4_hdr->dst_addr;
+		break;
+
+	case ETHER_TYPE_IPv6:
+		if (pkt_len < sizeof(*eth_hdr) + sizeof(*ip6_hdr)) {
+			packet->flow.proto = 0;
+			RTE_LOG(NOTICE, GATEKEEPER,
+				"gk: packet is too short to be IPv6 (%" PRIu16 ")!\n",
+				pkt_len);
+			ret = -1;
+			goto out;
+		}
+
+		ip6_hdr = rte_pktmbuf_mtod_offset(pkt,
+					struct ipv6_hdr *,
+					sizeof(struct ether_hdr));
+		packet->flow.proto = ETHER_TYPE_IPv6;
+		rte_memcpy(packet->flow.f.v6.src, ip6_hdr->src_addr,
+			sizeof(packet->flow.f.v6.src));
+		rte_memcpy(packet->flow.f.v6.dst, ip6_hdr->dst_addr,
+			sizeof(packet->flow.f.v6.dst));
+		break;
+
+	default:
+		packet->flow.proto = 0;
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"gk: unknown network layer protocol %" PRIu16 "!\n",
+			ether_type);
+		ret = -1;
+		break;
+	}
+out:
+	packet->pkt = pkt;
+	return ret;
 }
 
 static inline void
@@ -652,6 +725,7 @@ gk_proc(void *arg)
 		struct rte_mbuf *rx_bufs[GATEKEEPER_MAX_PKT_BURST];
 		struct rte_mbuf *tx_bufs[GATEKEEPER_MAX_PKT_BURST];
 		struct gk_cmd_entry *gk_cmds[GK_CMD_BURST_SIZE];
+		IPV6_ACL_SEARCH_DEF(acl);
 
 		/* Load a set of packets from the front NIC. */
 		num_rx = rte_eth_rx_burst(port_in, rx_queue, rx_bufs,
@@ -673,14 +747,6 @@ gk_proc(void *arg)
 			if (ret < 0) {
 				/* Drop non-IP packets. */
 				drop_packet(pkt);
-				continue;
-			} else if (pkt_is_nd(&packet, &gk_conf->net->front)) {
-				/*
-				 * TODO Use DPDK packet classification
-				 * and distribution here instead.
-				 */
-				if (submit_nd(pkt, &gk_conf->net->front) == -1)
-					drop_packet(pkt);
 				continue;
 			}
 
@@ -709,9 +775,14 @@ gk_proc(void *arg)
 				 * drop the packet.
 				 */
 				if (fib == NULL) {
-					print_flow_err_msg(&packet.flow,
-						"gk: failed to get the fib entry");
-					drop_packet(pkt);
+					if (packet.flow.proto ==
+							ETHER_TYPE_IPv6)
+						add_pkt_ipv6_acl(&acl, pkt);
+					else {
+						print_flow_err_msg(&packet.flow,
+							"gk: failed to get the fib entry");
+						drop_packet(pkt);
+					}
 					continue;
 				}
 
@@ -807,6 +878,8 @@ gk_proc(void *arg)
 			process_gk_cmd(gk_cmds[i], instance, &gk_conf->lpm_tbl);
 			mb_free_entry(&instance->mb, gk_cmds[i]);
         	}
+
+		process_pkts_ipv6_acl(&gk_conf->net->front, lcore, &acl);
 	}
 
 	RTE_LOG(NOTICE, GATEKEEPER,

--- a/gt/main.c
+++ b/gt/main.c
@@ -711,7 +711,7 @@ init_gt_instances(struct gt_config *gt_conf)
 		if (ret < 0) {
 			RTE_LOG(ERR, GATEKEEPER, "gt: cannot assign an RX queue for the front interface for lcore %u\n",
 				lcore);
-			goto out;
+			goto free_lua_state;
 		}
 		inst_ptr->rx_queue = ret;
 
@@ -719,7 +719,7 @@ init_gt_instances(struct gt_config *gt_conf)
 		if (ret < 0) {
 			RTE_LOG(ERR, GATEKEEPER, "gt: cannot assign a TX queue for the front interface for lcore %u\n",
 				lcore);
-			goto out;
+			goto free_lua_state;
 		}
 		inst_ptr->tx_queue = ret;
 
@@ -759,7 +759,7 @@ gt_stage1(void *arg)
 
 	ret = init_gt_instances(gt_conf);
 	if (ret < 0)
-		goto  instance;
+		goto instance;
 
 	goto out;
 
@@ -776,7 +776,15 @@ static int
 gt_stage2(void *arg)
 {
 	struct gt_config *gt_conf = arg;
-	return gt_setup_rss(gt_conf);
+	int ret = gt_setup_rss(gt_conf);
+	if (ret < 0)
+		goto cleanup;
+
+	return 0;
+
+cleanup:
+	cleanup_gt(gt_conf);
+	return ret;
 }
 
 int

--- a/include/gatekeeper_acl.h
+++ b/include/gatekeeper_acl.h
@@ -1,0 +1,90 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_ACL_H_
+#define _GATEKEEPER_ACL_H_
+
+#include "gatekeeper_config.h"
+#include "gatekeeper_net.h"
+
+/* TODO Add fields and rules to match IPv6 BGP packets for the CPS block. */
+
+/* Fields that can be checked in an IPv6 ACL rule. */
+enum {
+	PROTO_FIELD_IPV6,
+	DST1_FIELD_IPV6,
+	DST2_FIELD_IPV6,
+	DST3_FIELD_IPV6,
+	DST4_FIELD_IPV6,
+	TYPE_FIELD_ICMPV6,
+	NUM_FIELDS_IPV6,
+};
+
+extern struct rte_acl_field_def ipv6_defs[NUM_FIELDS_IPV6];
+RTE_ACL_RULE_DEF(ipv6_acl_rule, RTE_DIM(ipv6_defs));
+
+struct acl_search {
+	/* References to the start of the IPv6 header in each packet. */
+	const uint8_t   *data[GATEKEEPER_MAX_PKT_BURST];
+	/* References to each packet's mbuf. */
+	struct rte_mbuf *mbufs[GATEKEEPER_MAX_PKT_BURST];
+	/* The classification results for each packet. */
+	uint32_t        res[GATEKEEPER_MAX_PKT_BURST];
+	/* The number of packets held for classification. */
+	unsigned int    num;
+};
+
+/* Allocate and free IPv6 ACLs. */
+int init_ipv6_acls(struct gatekeeper_if *iface);
+void destroy_ipv6_acls(struct gatekeeper_if *iface);
+
+/* Register IPv6 ACL rules and callback functions. */
+int register_ipv6_acl(struct ipv6_acl_rule *rules, unsigned int num_rules,
+	acl_cb_func cb_f, struct gatekeeper_if *iface);
+
+/* Build the ACL trie. This should be invoked after all ACL rules are added. */
+int build_ipv6_acls(struct gatekeeper_if *iface);
+
+/* Classify batches of packets in @acl and invoke callback functions. */
+int process_ipv6_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
+	struct acl_search *acl);
+
+/* Definitions for blocks making use of the IPv6 ACLs. */
+
+#define IPV6_ACL_SEARCH_DEF(name) struct acl_search name = { .num = 0, }
+
+/* This function expects that the mbuf includes the Ethernet header. */
+static inline void
+add_pkt_ipv6_acl(struct acl_search *acl, struct rte_mbuf *pkt)
+{
+	acl->data[acl->num] = rte_pktmbuf_mtod_offset(pkt, uint8_t *,
+		sizeof(struct ether_hdr));
+	acl->mbufs[acl->num] = pkt;
+	acl->num++;
+}
+
+static inline int
+process_pkts_ipv6_acl(struct gatekeeper_if *iface, unsigned int lcore,
+	struct acl_search *acl)
+{
+	if (acl->num == 0)
+		return 0;
+	return process_ipv6_acl(iface, lcore, acl);
+}
+
+#endif /* _GATEKEEPER_ACL_H_ */

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -22,7 +22,6 @@
 #include <netinet/in.h>
 
 #include <rte_ip.h>
-#include <rte_timer.h>
 
 #include "gatekeeper_mailbox.h"
 #include "gatekeeper_net.h"
@@ -201,7 +200,7 @@ struct lls_config {
 	struct lls_cache  nd_cache;
 
 	/* Timer to scan over LLS cache(s). */
-	struct rte_timer  timer;
+	struct rte_timer  scan_timer;
 
 	/* Receive and transmit queues for both interfaces. */
 	uint16_t          rx_queue_front;

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -23,8 +23,8 @@
 
 #include <rte_ip.h>
 
+#include "gatekeeper_acl.h"
 #include "gatekeeper_mailbox.h"
-#include "gatekeeper_net.h"
 
 /*
  * Maximum key length (in bytes) for an LLS map. It should be set
@@ -280,8 +280,9 @@ int hold_nd(lls_req_cb cb, void *arg, struct in6_addr *ip_be,
 	unsigned int lcore_id);
 int put_nd(struct in6_addr *ip_be, unsigned int lcore_id);
 
-/* Submit an ND packet to the LLS block. */
-int submit_nd(struct rte_mbuf *pkt, struct gatekeeper_if *iface);
+/* Submit ND packets to the LLS block. */
+int submit_nd(struct rte_mbuf **pkts, int num_pkts,
+	struct gatekeeper_if *iface);
 
 static inline int
 ipv6_addrs_equal(const uint8_t *addr1, const uint8_t *addr2)
@@ -290,9 +291,6 @@ ipv6_addrs_equal(const uint8_t *addr1, const uint8_t *addr2)
 	const uint64_t *paddr2 = (const uint64_t *)addr2;
 	return (paddr1[0] == paddr2[0]) && (paddr1[1] == paddr2[1]);
 }
-
-/* Returns whether this packet is an ND neighbor msg destined for us. */
-int pkt_is_nd(struct ipacket *packet, struct gatekeeper_if *iface);
 
 struct lls_config *get_lls_conf(void);
 int run_lls(struct net_config *net_conf, struct lls_config *lls_conf);

--- a/lib/acl.c
+++ b/lib/acl.c
@@ -1,0 +1,249 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gatekeeper_acl.h"
+#include "gatekeeper_lls.h"
+
+/* Maximum number of rules installed per ACL. */
+#define MAX_NUM_IPV6_ACL_RULES (32)
+
+/* Callback function for when there's no classification match. */
+static inline int
+drop_ipv6_acl_pkts(struct rte_mbuf **pkts, int num_pkts,
+	__attribute__((unused)) struct gatekeeper_if *iface)
+{
+	int i;
+	for (i = 0; i < num_pkts; i++)
+		rte_pktmbuf_free(pkts[i]);
+	return 0;
+}
+
+/*
+ * All IPv6 fields involved in classification; not all fields must
+ * be specified for every rule. Fields must be grouped into sets of
+ * four bytes, except for the first field.
+ */
+struct rte_acl_field_def ipv6_defs[NUM_FIELDS_IPV6] = {
+	{
+		.type = RTE_ACL_FIELD_TYPE_BITMASK,
+		.size = sizeof(uint8_t),
+		.field_index = PROTO_FIELD_IPV6,
+		.input_index = PROTO_FIELD_IPV6,
+		.offset = offsetof(struct ipv6_hdr, proto),
+	},
+	{
+		.type = RTE_ACL_FIELD_TYPE_MASK,
+		.size = sizeof(uint32_t),
+		.field_index = DST1_FIELD_IPV6,
+		.input_index = DST1_FIELD_IPV6,
+		.offset = offsetof(struct ipv6_hdr, dst_addr[0]),
+	},
+	{
+		.type = RTE_ACL_FIELD_TYPE_MASK,
+		.size = sizeof(uint32_t),
+		.field_index = DST2_FIELD_IPV6,
+		.input_index = DST2_FIELD_IPV6,
+		.offset = offsetof(struct ipv6_hdr, dst_addr[4]),
+	},
+	{
+		.type = RTE_ACL_FIELD_TYPE_MASK,
+		.size = sizeof(uint32_t),
+		.field_index = DST3_FIELD_IPV6,
+		.input_index = DST3_FIELD_IPV6,
+		.offset = offsetof(struct ipv6_hdr, dst_addr[8]),
+	},
+	{
+		.type = RTE_ACL_FIELD_TYPE_MASK,
+		.size = sizeof(uint32_t),
+		.field_index = DST4_FIELD_IPV6,
+		.input_index = DST4_FIELD_IPV6,
+		.offset = offsetof(struct ipv6_hdr, dst_addr[12]),
+	},
+	{
+		/* Enforce grouping into four bytes. */
+		.type = RTE_ACL_FIELD_TYPE_BITMASK,
+		.size = sizeof(uint32_t),
+		.field_index = TYPE_FIELD_ICMPV6,
+		.input_index = TYPE_FIELD_ICMPV6,
+		.offset = sizeof(struct ipv6_hdr) +
+			offsetof(struct icmpv6_hdr, type),
+	},
+};
+
+int
+register_ipv6_acl(struct ipv6_acl_rule *ipv6_rules, unsigned int num_rules,
+	acl_cb_func cb_f, struct gatekeeper_if *iface)
+{
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+
+	if (iface->acl_func_count == GATEKEEPER_IPV6_ACL_MAX) {
+		RTE_LOG(ERR, GATEKEEPER, "acl: cannot install more ACL types on the %s iface\n",
+			iface->name);
+		return -1;
+	}
+
+	/* Assign a new ID for this rule type. */
+	for (i = 0; i < num_rules; i++)
+		ipv6_rules[i].data.userdata = iface->acl_func_count;
+
+	for (i = 0; i < numa_nodes; i++) {
+		int ret = rte_acl_add_rules(iface->ipv6_acls[i],
+			(struct rte_acl_rule *)ipv6_rules, num_rules);
+		if (ret < 0) {
+			RTE_LOG(ERR, ACL, "Failed to add ACL rules on the %s interface on socket %d\n",
+				iface->name, i);
+			return ret;
+		}
+	}
+
+	iface->acl_funcs[iface->acl_func_count] = cb_f;
+	iface->acl_func_count++;
+
+	return 0;
+}
+
+int
+process_ipv6_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
+	struct acl_search *acl)
+{
+	struct rte_mbuf *pkts[iface->acl_func_count][GATEKEEPER_MAX_PKT_BURST];
+	int num_pkts[iface->acl_func_count];
+	unsigned int socket_id = rte_lcore_to_socket_id(lcore_id);
+	unsigned int i;
+	int ret;
+
+	if (unlikely(!ipv6_if_configured(iface))) {
+		drop_ipv6_acl_pkts(acl->mbufs, acl->num, iface);
+		acl->num = 0;
+		return 0;
+	}
+
+	ret = rte_acl_classify(iface->ipv6_acls[socket_id],
+		acl->data, acl->res, acl->num, 1);
+	if (unlikely(ret < 0)) {
+		RTE_LOG(ERR, ACL,
+			"invalid arguments given to rte_acl_classify()\n");
+		drop_ipv6_acl_pkts(acl->mbufs, acl->num, iface);
+		acl->num = 0;
+		return ret;
+	}
+
+	/* Split packets into separate buffers -- one for each type. */
+	memset(num_pkts, 0, sizeof(num_pkts));
+	for (i = 0; i < acl->num; i++) {
+		int type = acl->res[i];
+		pkts[type][num_pkts[type]++] = acl->mbufs[i];
+	}
+
+	/* Transmit separate buffers to registered ACL functions. */
+	for (i = 0; i < iface->acl_func_count; i++) {
+		if (num_pkts[i] == 0)
+			continue;
+
+		ret = iface->acl_funcs[i](pkts[i], num_pkts[i], iface);
+		if (unlikely(ret < 0)) {
+			/*
+			 * Each ACL function is responsible for
+			 * freeing packets not already handled.
+			 */
+			RTE_LOG(WARN, GATEKEEPER,
+				"acl: ACL function %d failed on %s iface\n",
+				i, iface->name);
+		}
+	}
+
+	acl->num = 0;
+	return 0;
+}
+
+int
+build_ipv6_acls(struct gatekeeper_if *iface)
+{
+	struct rte_acl_config acl_build_params;
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+
+	memset(&acl_build_params, 0, sizeof(acl_build_params));
+	acl_build_params.num_categories = 1;
+	acl_build_params.num_fields = RTE_DIM(ipv6_defs);
+	rte_memcpy(&acl_build_params.defs, ipv6_defs, sizeof(ipv6_defs));
+
+	for (i = 0; i < numa_nodes; i++) {
+		int ret = rte_acl_build(iface->ipv6_acls[i], &acl_build_params);
+		if (ret < 0) {
+			RTE_LOG(ERR, ACL,
+				"Failed to build IPv6 ACL for the %s iface\n",
+				iface->name);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+int
+init_ipv6_acls(struct gatekeeper_if *iface)
+{
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+
+	for (i = 0; i < numa_nodes; i++) {
+		char acl_name[64];
+		struct rte_acl_param acl_params = {
+			.socket_id = i,
+			.rule_size = RTE_ACL_RULE_SZ(RTE_DIM(ipv6_defs)),
+			.max_rule_num = MAX_NUM_IPV6_ACL_RULES,
+		};
+		int ret = snprintf(acl_name, sizeof(acl_name),
+			"%s_%u", iface->name, i);
+		RTE_VERIFY(ret > 0 && ret < (int)sizeof(acl_name));
+		acl_params.name = acl_name;
+
+		iface->ipv6_acls[i] = rte_acl_create(&acl_params);
+		if (iface->ipv6_acls[i] == NULL) {
+			unsigned int j;
+
+			RTE_LOG(ERR, ACL, "Failed to create IPv6 ACL for the %s iface on socket %d\n",
+				iface->name, i);
+			for (j = 0; j < i; j++) {
+				rte_acl_free(iface->ipv6_acls[i]);
+				iface->ipv6_acls[i] = NULL;
+			}
+			return -1;
+		}
+	}
+
+	/* Add drop function for packets that have no match. */
+	RTE_VERIFY(RTE_ACL_INVALID_USERDATA == 0);
+	iface->acl_funcs[RTE_ACL_INVALID_USERDATA] = drop_ipv6_acl_pkts;
+	iface->acl_func_count = 1;
+
+	return 0;
+}
+
+void
+destroy_ipv6_acls(struct gatekeeper_if *iface)
+{
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+	for (i = 0; i < numa_nodes; i++) {
+		rte_acl_free(iface->ipv6_acls[i]);
+		iface->ipv6_acls[i] = NULL;
+	}
+}

--- a/lls/cache.c
+++ b/lls/cache.c
@@ -321,8 +321,12 @@ lls_process_reqs(struct lls_config *lls_conf)
 			break;
 		case LLS_REQ_ND: {
 			struct lls_nd_req *nd = &reqs[i]->u.nd;
-			if (process_nd(lls_conf, nd->iface, nd->pkt) == -1)
-				rte_pktmbuf_free(nd->pkt);
+			int i;
+			for (i = 0; i < nd->num_pkts; i++) {
+				if (process_nd(lls_conf, nd->iface,
+						nd->pkts[i]) == -1)
+					rte_pktmbuf_free(nd->pkts[i]);
+			}
 			break;
 		}
 		default:

--- a/lls/cache.h
+++ b/lls/cache.h
@@ -48,10 +48,13 @@ struct lls_put_req {
 	unsigned int     lcore_id;
 };
 
-/* Information needed to submit an ND packet to the LLS block. */
+/* Information needed to submit ND packets to the LLS block. */
 struct lls_nd_req {
-	/* ND neighbor packet. */
-	struct rte_mbuf      *pkt;
+	/* ND neighbor packets. */
+	struct rte_mbuf      *pkts[GATEKEEPER_MAX_PKT_BURST];
+
+	/* Number of packets stored in @pkts. */
+	int                  num_pkts;
 
 	/* Interface that received @pkt. */
 	struct gatekeeper_if *iface;

--- a/lls/nd.c
+++ b/lls/nd.c
@@ -673,10 +673,6 @@ int
 process_nd(struct lls_config *lls_conf, struct gatekeeper_if *iface,
 	struct rte_mbuf *buf)
 {
-	/*
-	 * Checks to make sure this packet is of minimum required
-	 * length already done by pkt_is_nd().
-	 */
 	struct ether_hdr *eth_hdr = rte_pktmbuf_mtod(buf, struct ether_hdr *);
 	struct ipv6_hdr *ipv6_hdr = (struct ipv6_hdr *)&eth_hdr[1];
 	struct icmpv6_hdr *icmpv6_hdr = (struct icmpv6_hdr *)&ipv6_hdr[1];
@@ -687,6 +683,12 @@ process_nd(struct lls_config *lls_conf, struct gatekeeper_if *iface,
 	uint16_t pkt_len = rte_pktmbuf_data_len(buf);
 	uint16_t icmpv6_len = pkt_len - (sizeof(struct ether_hdr) +
 		sizeof(*ipv6_hdr));
+
+	if (pkt_len < ND_NEIGH_PKT_MIN_LEN) {
+		RTE_LOG(NOTICE, GATEKEEPER, "lls: ND packet received is %"PRIx16" bytes but should be at least %lu bytes\n",
+			pkt_len, ND_NEIGH_PKT_MIN_LEN);
+		return -1;
+	}
 
 	if (unlikely(!nd_pkt_valid(ipv6_hdr, icmpv6_hdr, icmpv6_len)))
 		return -1;

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -99,6 +99,17 @@ local ffi = require("ffi")
 -- Structs
 ffi.cdef[[
 
+enum bonding_modes {
+	/* Corresponding to the values in rte_eth_bond.h. */
+	BONDING_MODE_ROUND_ROBIN = 0,
+	BONDING_MODE_ACTIVE_BACKUP = 1,
+	BONDING_MODE_BALANCE = 2,
+	BONDING_MODE_BROADCAST = 3,
+	BONDING_MODE_8023AD = 4,
+	BONDING_MODE_TLB = 5,
+	BONDING_MODE_ALB = 6,
+};
+
 struct gatekeeper_if {
 	char     **pci_addrs;
 	uint8_t  num_ports;
@@ -107,6 +118,7 @@ struct gatekeeper_if {
 	uint16_t num_tx_queues;
 	uint32_t arp_cache_timeout_sec;
 	uint32_t nd_cache_timeout_sec;
+	uint32_t bonding_mode;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -1,3 +1,4 @@
+require "gatekeeper"
 return function (gatekeeper_server)
 
 	--
@@ -10,12 +11,14 @@ return function (gatekeeper_server)
 	local front_ips  = {"10.0.0.1/24", "2001:db8::1/32"}
 	local front_arp_cache_timeout_sec = 7200
 	local front_nd_cache_timeout_sec = 7200
+	local front_bonding_mode = gatekeeper.c.BONDING_MODE_ROUND_ROBIN
 
 	local back_iface_enabled = gatekeeper_server
 	local back_ports = {"enp133s0f1"}
 	local back_ips  = {"10.0.0.2/24", "2001:db8::2/32"}
 	local back_arp_cache_timeout_sec = 7200
 	local back_nd_cache_timeout_sec = 7200
+	local back_bonding_mode = gatekeeper.c.BONDING_MODE_ROUND_ROBIN
 
 	--
 	-- Code below this point should not need to be changed.
@@ -25,6 +28,7 @@ return function (gatekeeper_server)
 	local front_iface = gatekeeper.c.get_if_front(net_conf)
 	front_iface.arp_cache_timeout_sec = front_arp_cache_timeout_sec
 	front_iface.nd_cache_timeout_sec = front_nd_cache_timeout_sec
+	front_iface.bonding_mode = front_bonding_mode
 	local ret = gatekeeper.init_iface(front_iface, "front",
 		front_ports, front_ips)
 
@@ -33,6 +37,7 @@ return function (gatekeeper_server)
 		local back_iface = gatekeeper.c.get_if_back(net_conf)
 		back_iface.arp_cache_timeout_sec = back_arp_cache_timeout_sec
 		back_iface.nd_cache_timeout_sec = back_nd_cache_timeout_sec
+		back_iface.bonding_mode = back_bonding_mode
 		ret = gatekeeper.init_iface(back_iface, "back",
 			back_ports, back_ips)
 	end

--- a/main/main.c
+++ b/main/main.c
@@ -160,6 +160,16 @@ main(int argc, char **argv)
 		goto net;
 	}
 
+	/*
+	 * Finalize any network configuration, such as building ACL tries,
+	 * after blocks have had a chance to make use of network state
+	 * during stage 2. This is needed because there is no stage 3 for
+	 * the network configuration.
+	 */
+	ret = launch_at_stage2(finalize_stage2, NULL);
+	if (ret < 0)
+		goto net;
+
 	ret = launch_gatekeeper();
 	if (ret < 0)
 		exiting = true;


### PR DESCRIPTION
The first patch adds LACP, and takes steps to ensure its requirements are almost always met (but they are not always guaranteed). There is also an important TODO left in LACP, which is to not report dropped packets when LACP is configuring, and to warn the user when LACP configuration is taking too long. This turned out to be harder than I expected and I need to figure out a good way of doing it.

The second patch cleans up some configuration inconsistencies that I noticed in preparation for the third patch.

The third patch adds IPv6 ACLs to GK, GT, and LLS, so that ND packets (and eventually BGP packets) can be recognized quickly. This patch also reverses some changes that were previously made to recognize ND packets in those blocks.