### PR TITLE
Implement the dynamic configuration block and integrate LLS into GK

### DIFF
--- a/config/dynamic.c
+++ b/config/dynamic.c
@@ -16,11 +16,548 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+#include <rte_log.h>
+#include <rte_lcore.h>
+#include <rte_cycles.h>
+#include <rte_malloc.h>
+
+#include "gatekeeper_net.h"
+#include "gatekeeper_main.h"
 #include "gatekeeper_config.h"
+#include "gatekeeper_launch.h"
+
+/* TODO Get the install path from the configuration file. */
+#define LUA_DY_BASE_DIR     "./lua"
+#define DYNAMIC_CONFIG_FILE "dylib.lua"
+
+/*
+ * The cast "(uint16_t)" is needed because of
+ * the strict compilation check of DPDK,
+ * without uint16_t, it pops an error message
+ * "error: large integer implicitly truncated to
+ * unsigned type [-Werror=overflow]."
+ */
+static const uint16_t MSG_MAX_LEN = (uint16_t)~0U;
+
+static struct dynamic_config config;
+
+/*
+ * Return values:
+ * 	0: Write @nbytes successfully.
+ * 	-1: Connection closed by the client.
+ */
+static int
+write_nbytes(int conn_fd, const char *msg_buff, int nbytes)
+{
+	int send_size;
+	int tot_size = 0;
+
+	if (nbytes == 0)
+		return 0;
+
+	while ((send_size = write(conn_fd, msg_buff + tot_size,
+			nbytes - tot_size)) > 0) {
+		tot_size += send_size;
+		if (tot_size >= nbytes)
+			break;
+	}
+
+	/* The connection with the client is closed. */
+	if (send_size == 0) {
+		RTE_LOG(WARNING, GATEKEEPER,
+			"dyn_cfg: Client disconnected\n");
+		return -1;
+	}
+
+	if (send_size < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to write data to the socket connection - (%s)\n",
+			strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+reply_client_message(int conn_fd, const char *reply_msg, uint16_t reply_len)
+{
+	int ret;
+	uint16_t nlen = htons(reply_len);
+
+	/* The first two bytes: the length of the message in network order. */
+	ret = write_nbytes(conn_fd, (char *)&nlen, sizeof(nlen));
+	if (ret != 0)
+		return -1;
+
+	/* Sending the message. */
+	ret = write_nbytes(conn_fd, reply_msg, reply_len);
+	if (ret != 0)
+		return -1;
+
+	return 0;
+}
+
+static int
+process_client_message(int conn_fd,
+	const char *msg, int msg_len, lua_State *lua_state)
+{
+	/*
+	 * TODO Implement the functionalities to process the clients' request.
+	 *
+	 * Gatekeeper: Adding, listing, and removing BP components;
+	 *
+	 * Gatekeeper: Adding, listing, removing IP ranges
+	 * handled by the global LPM table in GKs;
+	 *
+	 * Gatekeeper and Grantor: Listing the ARP and ND table.
+	 * This is important for network diagnosis.
+	 *
+	 * Grantor: Updating the policy GTs run.
+	 */
+
+	int ret;
+	size_t reply_len;
+	const char *reply_msg;
+	const char *CLIENT_EMPTY_ERROR =
+		"Dynamic configuration cannot process the request: the request is empty.";
+	const char *CLIENT_PROC_ERROR =
+		"Dynamic configuration: the reply was NULL.";
+
+	if (msg_len == 0) {
+		RTE_LOG(WARNING, LUA,
+			"dyn_cfg: the received message is an empty string\n");
+		return reply_client_message(conn_fd,
+			CLIENT_EMPTY_ERROR, strlen(CLIENT_EMPTY_ERROR));
+	}
+
+	/* Load the client's Lua chunk, and run it. */
+	ret = luaL_loadbuffer(lua_state, msg, msg_len, "message")
+		|| lua_pcall(lua_state, 0, 1, 0);
+	if (ret != 0) {
+		reply_msg = luaL_checklstring(lua_state, -1, &reply_len);
+
+		if (reply_len > MSG_MAX_LEN) {
+			char truncated_reply_msg[MSG_MAX_LEN];
+			strncpy(truncated_reply_msg, reply_msg, MSG_MAX_LEN);
+			truncated_reply_msg[MSG_MAX_LEN - 1] = '\0';
+
+			RTE_LOG(ERR, LUA, "dyn_cfg: %s!\n", truncated_reply_msg);
+
+			RTE_LOG(WARNING, LUA,
+				"dyn_cfg: The error message length (%lu) exceeds the limit!\n",
+				reply_len);
+
+			reply_len = MSG_MAX_LEN;
+		} else
+			RTE_LOG(ERR, LUA, "dyn_cfg: %s!\n", reply_msg);
+
+		return reply_client_message(conn_fd, reply_msg, reply_len);
+	}
+
+	reply_msg = luaL_checklstring(lua_state, -1, &reply_len);
+	if (reply_msg == NULL) {
+		RTE_LOG(ERR, LUA,
+			"dyn_cfg: The client request script returns a NULL string!\n");
+		return reply_client_message(conn_fd,
+			CLIENT_PROC_ERROR, strlen(CLIENT_PROC_ERROR));
+	}
+
+	if (reply_len > MSG_MAX_LEN) {
+		RTE_LOG(WARNING, LUA,
+			"dyn_cfg: The reply message length (%lu) exceeds the limit!\n",
+			reply_len);
+		reply_len = MSG_MAX_LEN;
+	}
+
+	return reply_client_message(conn_fd, reply_msg, reply_len);
+}
+
+/*
+ * Return values:
+ * 	0: Read @nbytes successfully.
+ * 	-1: The client closed the connection or an error occurred.
+ */
+static int
+read_nbytes(int conn_fd, char *msg_buff, int nbytes)
+{
+	int recv_size;
+	int tot_size = 0;
+
+	while ((recv_size = read(conn_fd, msg_buff + tot_size,
+			nbytes - tot_size)) > 0) {
+		tot_size += recv_size;
+		if (tot_size >= nbytes)
+			break;
+	}
+
+	/* The connection with the client is closed. */
+	if (recv_size == 0) {
+		RTE_LOG(WARNING, GATEKEEPER,
+			"dyn_cfg: Client disconnected\n");
+		return -1;
+	}
+
+	if (recv_size < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to read data from the socket connection - (%s)\n",
+			strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Return values:
+ * 	-1: Error happens.
+ * 	0: Command successfully processed, may need to process further commands.
+ */
+static int
+process_single_cmd(int conn_fd, lua_State *lua_state)
+{
+	int ret;
+	uint16_t msg_len;
+	char msg_buff[MSG_MAX_LEN];
+
+	/*
+	 * The protocol should be rather simple: two-byte,
+	 * unsigned integer in network order signal the size,
+	 * in bytes, of the message that follows that
+	 * first two bytes.
+	 */
+	ret = read_nbytes(conn_fd, (char *)&msg_len, 2);
+	if (ret != 0)
+		return -1;
+
+	msg_len = ntohs(msg_len);
+	RTE_VERIFY(msg_len <= MSG_MAX_LEN);
+
+	ret = read_nbytes(conn_fd, msg_buff, msg_len);
+	if (ret != 0)
+		return -1;
+
+	ret = process_client_message(
+		conn_fd, msg_buff, msg_len, lua_state);
+	if (ret < 0)
+		return -1;
+
+	return 0;
+}
+
+static void
+cleanup_dy(struct dynamic_config *dy_conf)
+{
+	int ret;
+
+	if (dy_conf->sock_fd != -1) {
+		ret = close(dy_conf->sock_fd);
+		if (ret < 0) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"dyn_cfg: Failed to close the server socket - (%s)\n",
+				strerror(errno));
+		}
+		dy_conf->sock_fd = -1;
+	}
+
+	if (dy_conf->server_path != NULL) {
+		ret = unlink(dy_conf->server_path);
+		if (ret != 0) {
+			RTE_LOG(WARNING, GATEKEEPER,
+				"dyn_cfg: Failed to unlink(%s) - (%s)\n",
+				dy_conf->server_path, strerror(errno));
+		}
+
+		rte_free(dy_conf->server_path);
+		dy_conf->server_path = NULL;
+	}
+}
+
+static int 
+setup_dy_lua(lua_State *lua_state)
+{
+	int ret;
+	char lua_entry_path[128];
+
+	ret = snprintf(lua_entry_path, sizeof(lua_entry_path),
+		"%s/%s", LUA_DY_BASE_DIR, DYNAMIC_CONFIG_FILE);
+	RTE_VERIFY(ret > 0 && ret < (int)sizeof(lua_entry_path));
+
+	luaL_openlibs(lua_state);
+	set_lua_path(lua_state, LUA_DY_BASE_DIR);
+	ret = luaL_loadfile(lua_state, lua_entry_path);
+	if (ret != 0) {
+		RTE_LOG(ERR, LUA,
+			"dyn_cfg: %s!\n", lua_tostring(lua_state, -1));
+		return -1;
+	}
+
+	ret = lua_pcall(lua_state, 0, 0, 0);
+	if (ret != 0) {
+		RTE_LOG(ERR, LUA,
+			"dyn_cfg: %s!\n", lua_tostring(lua_state, -1));
+		return -1;
+	}
+
+	return 0;
+}
+
+static void
+handle_client(int server_socket_fd, struct dynamic_config *dy_conf)
+{
+	int ret;
+	int conn_fd;
+	socklen_t len;
+	int rcv_buff_size;
+	struct sockaddr_un client_addr;
+
+	/* The lua state used to handle the dynamic configuration files. */
+	lua_State *lua_state;
+
+	len = sizeof(client_addr);
+	conn_fd = accept(server_socket_fd,
+		(struct sockaddr *)&client_addr, &len);
+	if (conn_fd < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to accept a new connection - (%s)\n",
+			strerror(errno));
+		return;
+	}
+
+	if (unlikely(client_addr.sun_family != AF_UNIX)) {
+		RTE_LOG(WARNING, GATEKEEPER,
+			"Unexpected condition: unknown client type %d at %s\n",
+			client_addr.sun_family, __func__);
+		goto close_fd;
+	}
+
+	/*
+	 * XXX The request must be received under a specified timeout,
+	 * or the request is aborted. This code needs further test.
+	 */
+	ret = setsockopt(conn_fd, SOL_SOCKET, SO_RCVTIMEO,
+		(const char*)&dy_conf->rcv_time_out, sizeof(struct timeval));
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to call setsockopt(SO_RCVTIMEO) - (%s)\n",
+			strerror(errno));
+		goto close_fd;
+	}
+
+	rcv_buff_size = MSG_MAX_LEN;
+	ret = setsockopt(conn_fd, SOL_SOCKET,
+		SO_RCVBUF, &rcv_buff_size, sizeof(rcv_buff_size));
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to call setsockopt(SO_RCVBUF) with size = %d - (%s)\n",
+			rcv_buff_size, strerror(errno));
+		goto close_fd;
+	}
+
+	lua_state = luaL_newstate();
+	if (lua_state == NULL) {
+		RTE_LOG(ERR, LUA,
+			"dyn_cfg: failed to create new Lua state!\n");
+		goto close_fd;
+	}
+
+	/* Set up the Lua state while there is a connection. */
+	ret = setup_dy_lua(lua_state);
+	if (ret < 0) {
+		RTE_LOG(ERR, LUA,
+			"dyn_cfg: Failed to set up the lua state\n");
+		goto close_lua;
+	}
+
+	while (1) {
+		ret = process_single_cmd(conn_fd, lua_state);
+		if (ret != 0)
+			break;
+	}
+
+close_lua:
+	lua_close(lua_state);
+
+close_fd:
+	ret = close(conn_fd);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to close the connection socket - (%s)\n",
+			strerror(errno));
+	}
+}
+
+static int
+dyn_cfg_proc(void *arg)
+{
+	int ret = 0;
+	struct dynamic_config *dy_conf = arg;
+	uint32_t lcore = dy_conf->lcore_id;
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"dyn_cfg: the Dynamic Config block is running at lcore = %u\n", lcore);
+
+	while (likely(!exiting)) {
+		fd_set fds;
+		struct timeval stv;
+ 
+		FD_ZERO(&fds);
+		FD_SET(dy_conf->sock_fd, &fds);
+ 
+		/*
+		 * 10000 usecs' timeout for the select() function.
+		 * This parameter can prevent the select() function
+		 * from blocking forever. So, the whole program can
+		 * exit when receiving a quitting signal.
+		 */
+		stv.tv_sec = 0;
+		stv.tv_usec = 10000;
+
+		ret = select(dy_conf->sock_fd + 1, &fds, NULL, NULL, &stv);
+		if (ret < 0 && errno != EINTR) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"dyn_cfg: Failed to call the select() function - (%s)\n",
+				strerror(errno));
+			break;
+		} else if (likely(ret <= 0)) {
+			if (unlikely(ret < 0))
+				RTE_VERIFY(errno == EINTR);
+			continue;
+		}
+
+		/*
+		 * The config component accepts only one connection at a time.
+		 */
+		RTE_VERIFY(FD_ISSET(dy_conf->sock_fd, &fds));
+		handle_client(dy_conf->sock_fd, dy_conf);
+	}
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"dyn_cfg: the Dynamic Config block at lcore = %u is exiting\n", lcore);
+
+	cleanup_dy(dy_conf);
+
+	return ret;
+}
+
+struct dynamic_config *
+get_dy_conf(void)
+{
+	return &config;
+}
+
+void
+set_dyc_timeout(unsigned int sec,
+	unsigned int usec, struct dynamic_config *dy_conf)
+{
+	dy_conf->rcv_time_out.tv_sec = sec;
+	dy_conf->rcv_time_out.tv_usec = usec;
+}
 
 int
-run_dynamic_config(__attribute__((unused)) const struct dynamic_config *dy_conf)
+run_dynamic_config(const char *server_path, struct dynamic_config *dy_conf)
 {
-	/* TODO Initialize and run Dynamic Config functional block. */
+	int ret;
+	struct sockaddr_un server_addr;
+
+	if (server_path == NULL || dy_conf == NULL) {
+		ret = -1;
+		goto out;
+	}
+
+	dy_conf->sock_fd = -1;
+
+	dy_conf->server_path = rte_malloc(
+		"server_path", strlen(server_path) + 1, 0);
+	if (dy_conf->server_path == NULL) {
+		ret = -1;
+		goto out;
+	}
+	strcpy(dy_conf->server_path, server_path);
+
+	/*
+	 * Remove any old socket and create an unnamed socket for the server.
+	 */
+	ret = unlink(dy_conf->server_path);
+	if (ret != 0 && errno != ENOENT) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to unlink(%s) - (%s)\n",
+			dy_conf->server_path, strerror(errno));
+		ret = -1;
+		goto free_path;
+	}
+
+	/* Init the server socket. */
+    	dy_conf->sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (dy_conf->sock_fd < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to initialize the server socket - (%s)\n",
+			strerror(errno));
+		ret = -1;
+		goto free_path;
+	}
+
+	/* Name the socket. */
+    	memset(&server_addr, 0, sizeof(server_addr));
+    	server_addr.sun_family = AF_UNIX;
+
+	if (sizeof(server_addr.sun_path) <= strlen(dy_conf->server_path)) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: the server path (%s) exceeds the length limit %lu\n",
+			dy_conf->server_path, sizeof(server_addr.sun_path));
+		ret = -1;
+		goto free_sock;
+	}
+
+    	strcpy(server_addr.sun_path, dy_conf->server_path);
+
+    	ret = bind(dy_conf->sock_fd,
+		(struct sockaddr *)&server_addr, sizeof(server_addr));
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to bind the server socket - (%s)\n",
+			strerror(errno));
+		ret = -1;
+		goto free_sock;
+	}
+
+	/*
+	 * The Dynamic config component listens to a Unix socket
+	 * for request from the local host.
+	 */
+    	ret = listen(dy_conf->sock_fd, 10);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"dyn_cfg: Failed to listen on the server socket - (%s)\n",
+			strerror(errno));
+		ret = -1;
+		goto free_sock;
+	}
+
+	ret = launch_at_stage3("dynamic_conf",
+		dyn_cfg_proc, dy_conf, dy_conf->lcore_id);
+	if (ret < 0)
+		goto free_sock;
+
 	return 0;
+
+free_sock:
+	close(dy_conf->sock_fd);
+	dy_conf->sock_fd = -1;
+
+free_path:
+	rte_free(dy_conf->server_path);
+	dy_conf->server_path = NULL;
+
+out:
+	return ret;
 }

--- a/config/static.c
+++ b/config/static.c
@@ -271,7 +271,7 @@ config_gatekeeper(void)
 
 	lua_state = luaL_newstate();
 	if (!lua_state) {
-		RTE_LOG(ERR, GATEKEEPER,
+		RTE_LOG(ERR, LUA,
 			"config: failed to create new Lua state!\n");
 		return -1;
 	}
@@ -281,7 +281,7 @@ config_gatekeeper(void)
 	set_lua_path(lua_state, LUA_BASE_DIR);
 	ret = luaL_loadfile(lua_state, lua_entry_path);
 	if (ret != 0) {
-		RTE_LOG(ERR, GATEKEEPER,
+		RTE_LOG(ERR, LUA,
 			"config: %s!\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
@@ -299,7 +299,7 @@ config_gatekeeper(void)
 	 */
 	ret = lua_pcall(lua_state, 0, 0, 0);
 	if (ret != 0) {
-		RTE_LOG(ERR, GATEKEEPER,
+		RTE_LOG(ERR, LUA,
 			"config: %s!\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
@@ -309,7 +309,7 @@ config_gatekeeper(void)
 	lua_getglobal(lua_state, "gatekeeper_init");
 	ret = lua_pcall(lua_state, 0, 1, 0);
 	if (ret != 0) {
-		RTE_LOG(ERR, GATEKEEPER,
+		RTE_LOG(ERR, LUA,
 			"config: %s!\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
@@ -317,7 +317,7 @@ config_gatekeeper(void)
 
 	ret = luaL_checkinteger(lua_state, -1);
 	if (ret < 0)
-		RTE_LOG(ERR, GATEKEEPER,
+		RTE_LOG(ERR, LUA,
 			"config: gatekeeper_init() return value is %d!\n",
 			ret);
 

--- a/include/gatekeeper_config.h
+++ b/include/gatekeeper_config.h
@@ -17,6 +17,7 @@
  */
 
 #include <lua.h>
+#include <sys/time.h>
 
 #ifndef _GATEKEEPER_CONFIG_H_
 #define _GATEKEEPER_CONFIG_H_
@@ -83,11 +84,31 @@
 
 /* Configuration for the Dynamic Config functional block. */
 struct dynamic_config {
-	unsigned int	lcore_id;
+
+	/* The lcore id that the block is running on. */
+	unsigned int   lcore_id;
+
+	/*
+	 * The fields below are for internal use.
+	 * Configuration files should not refer to them.
+	 */
+
+	/* The server socket descriptor. */
+	int            sock_fd;
+
+	/* The file path that the Unix socket will use. */
+	char           *server_path;
+
+	/* Specify the receiving timeouts until reporting an error. */
+	struct timeval rcv_time_out;
 };
 
 int config_gatekeeper(void);
 int set_lua_path(lua_State *l, const char *path);
-int run_dynamic_config(const struct dynamic_config *dy_conf);
+struct dynamic_config *get_dy_conf(void);
+void set_dyc_timeout(unsigned sec, unsigned usec,
+	struct dynamic_config *dy_conf);
+int run_dynamic_config(const char *server_path,
+	struct dynamic_config *dy_conf);
 
 #endif /* _GATEKEEPER_CONFIG_H_ */

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -28,6 +28,13 @@
  */
 #define RTE_LOGTYPE_GATEKEEPER RTE_LOGTYPE_USER1
 
+/*
+ * Custom log type for Lua-related log entries.
+ * When using this logtype, the log string should include
+ * the name of the relevant functional block, library, etc.
+ */
+#define RTE_LOGTYPE_LUA RTE_LOGTYPE_USER2
+
 #define GATEKEEPER_MAX_PKT_BURST (32)
 
 extern volatile int exiting;

--- a/lua/dylib.lua
+++ b/lua/dylib.lua
@@ -1,0 +1,6 @@
+-- TODO Add support for other operations. For example:
+-- Functions to add/del/list the GK FIB entries.
+-- Functions to list the ARP table.
+-- Functions to list the ND table.
+-- Functions to process the GT policies.
+-- ......

--- a/lua/dyn_cfg.lua
+++ b/lua/dyn_cfg.lua
@@ -1,0 +1,22 @@
+return function (numa_table)
+
+	-- Init the dynamic configuration structure.
+	local dy_conf = gatekeeper.c.get_dy_conf()
+	if dy_conf == nil then
+		error("Failed to allocate dy_conf")
+	end
+
+	local server_path = "/tmp/dyn_cfg.socket"
+
+	dy_conf.lcore_id = gatekeeper.alloc_an_lcore(numa_table)
+
+	gatekeeper.c.set_dyc_timeout(30, 0, dy_conf)
+
+	-- Setup the dynamic config functional block.
+	local ret = gatekeeper.c.run_dynamic_config(server_path, dy_conf)
+	if ret < 0 then
+		error("Failed to run dynamic config block")
+	end
+
+	return dy_conf
+end

--- a/lua/example_of_dynamic_config_request.lua
+++ b/lua/example_of_dynamic_config_request.lua
@@ -1,0 +1,8 @@
+-- TODO Add examples for other operations. For example:
+-- Functions to add/del/list the GK FIB entries.
+-- Functions to list the ARP table.
+-- Functions to list the ND table.
+-- Functions to process the GT policies.
+-- ......
+
+return "A default message from the dynamic configuration block!"

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -162,6 +162,11 @@ struct cps_config {
 	/* This struct has hidden fields. */
 };
 
+struct dynamic_config {
+	unsigned int   lcore_id;
+	/* This struct has hidden fields. */
+};
+
 ]]
 
 -- Functions and wrappers
@@ -194,6 +199,11 @@ int run_gt(struct net_config *net_conf, struct gt_config *gt_conf);
 struct cps_config *get_cps_conf(void);
 int run_cps(struct net_config *net_conf, struct cps_config *cps_conf,
 	struct lls_config *lls_conf, const char *kni_kmod_path);
+struct dynamic_config *get_dy_conf(void);
+void set_dyc_timeout(unsigned sec, unsigned usec,
+	struct dynamic_config *dy_conf);
+int run_dynamic_config(const char *server_path,
+	struct dynamic_config *dy_conf);
 
 ]]
 

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -36,5 +36,8 @@ function gatekeeper_init()
 	local cpsf = require("cps")
 	local cps_conf = cpsf(net_conf, lls_conf, numa_table)
 
+	local dyf = require("dyn_cfg")
+	local dy_conf = dyf(numa_table)
+
 	return 0
 end


### PR DESCRIPTION
This pull request includes three patches:

The first patch implements a simple dynamic config block. Basically, the dynamic configuration will open one socket, and listens on a configured port. It receives Lua configuration files from clients, and then calls the corresponding functions to list, add, or delete the entries in other functional blocks.

The second patch implements the functionalities to edit LPM table, including add a FIB entry, and delete a FIB entry. Once a FIB entry with action ``GK_FWD_GRANTOR`` is deleted, then it will notify all the GK instances to flush its flow table who has a reference to that FIB entry.

The third patch integrates LLS to the GK blocks using sequential locks. The sequential lock was mainly taken from the Linux kernel, and the original spin lock used to implement sequential lock was replaced by the spin lock in DPDK library.