### PR TITLE
gk: add queues and Solicitor block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ SRCS-y += ggu/main.c
 SRCS-y += gk/main.c
 SRCS-y += gt/main.c
 SRCS-y += lls/main.c lls/cache.c lls/arp.c lls/nd.c
+SRCS-y += sol/main.c
 
 # Libraries.
 SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c \

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -26,6 +26,7 @@
 #include "gatekeeper_ggu.h"
 #include "gatekeeper_mailbox.h"
 #include "gatekeeper_lpm.h"
+#include "gatekeeper_sol.h"
 
 /*
  * The LPM reserves 24-bit for the next-hop field.
@@ -232,6 +233,8 @@ struct gk_config {
 
 	struct gk_instance *instances;
 	struct net_config  *net;
+	struct sol_config  *sol_conf;
+
 	/*
 	 * The LPM table used by the GK instances.
 	 * We assume that all the GK instances are
@@ -265,7 +268,8 @@ struct gk_cmd_entry {
 
 struct gk_config *alloc_gk_conf(void);
 int gk_conf_put(struct gk_config *gk_conf);
-int run_gk(struct net_config *net_conf, struct gk_config *gk_conf);
+int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
+	struct sol_config *sol_conf);
 struct mailbox *get_responsible_gk_mailbox(
 	const struct ip_flow *flow, const struct gk_config *gk_conf);
 

--- a/include/gatekeeper_sol.h
+++ b/include/gatekeeper_sol.h
@@ -1,0 +1,136 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_SOL_H_
+#define _GATEKEEPER_SOL_H_
+
+#include <rte_approx.h>
+#include <rte_cycles.h>
+#include <rte_reciprocal.h>
+
+#include "list.h"
+
+struct priority_req {
+	/* Doubly-linked list node. */
+	struct list_head    list;
+	/* The packet for this request. */
+	struct rte_mbuf     *pkt;
+	/* The priority of this request. */
+	uint8_t             priority;
+};
+
+/*
+ * The maximum priority that a packet can be assigned.
+ *
+ * Packets are assigned priorities [0, 63] due to
+ * the limits of the IP DSCP field.
+ */
+#define GK_MAX_REQ_PRIORITY (63)
+
+/*
+ * XXX The DPDK packet scheduler uses __rte_cache_aligned
+ * on member @memory and on the struct as a whole. Should
+ * it be used here?
+ */
+struct req_queue {
+	/* Length of the priority queue. */
+	uint32_t              len;
+	/* The highest priority of any packet currently in the queue. */
+	uint16_t              highest_priority;
+	/* The lowest priority of any packet currently in the queue. */
+	uint16_t              lowest_priority;
+
+	/*
+	 * The head of the priority queue, referencing the node
+	 * that contains the packet with the highest priority.
+	 */
+	struct list_head      head;
+	/* Array of pointers to packets of each priority. */
+	struct priority_req   *priorities[GK_MAX_REQ_PRIORITY + 1];
+
+	/*
+	 * Token bucket algorithm state.
+	 */
+
+	/* Capacity of the token bucket (the max number of credits). */
+	uint64_t              tb_max_credit_bytes;
+
+	/* Number of credits currently in the token bucket. */
+	uint64_t              tb_credit_bytes;
+
+	/*
+	 * CPU cycles per byte for the request queue,
+	 * approximated as a rational a/b.
+	 */
+	uint64_t              cycles_per_byte_a;
+	uint64_t              cycles_per_byte_b;
+
+	/*
+	 * The floor function of CPU cycles per byte, which is useful
+	 * to quickly determine whether we have enough cycles to
+	 * add some number of credits before executing a division.
+	 */
+	uint64_t              cycles_per_byte_floor;
+
+	/* Current CPU time measured in CPU cyles. */
+	uint64_t              time_cpu_cycles;
+};
+
+/* Configuration for the Solicitor functional block. */
+struct sol_config {
+	unsigned int       lcore_id;
+
+	/* Maximum number of requests to store in priority queue at once. */
+	unsigned int       pri_req_max_len;
+
+	/*
+	 * Bandwidth limit for the priority queue of requests,
+	 * as a percentage of the capacity of the link. Must
+	 * be > 0 and < 1.
+	 */
+	double             req_bw_rate;
+
+	/* Maximum request enqueue/dequeue size. */
+	unsigned int       enq_burst_size;
+	unsigned int       deq_burst_size;
+
+	/*
+	 * The fields below are for internal use.
+	 * Configuration files should not refer to them.
+	 */
+
+	/* Priority queue for request packets. */
+	struct req_queue   req_queue;
+
+	/*
+	 * Mailbox into which GK instances enqueue request packets
+	 * to be serviced and sent out by the Solicitor.
+	 */
+	struct mailbox     mb;
+
+	/* TX queue on the back interface. */
+	uint16_t           tx_queue_back;
+	struct net_config  *net;
+};
+
+struct sol_config *alloc_sol_conf(void);
+int run_sol(struct net_config *net_conf, struct sol_config *sol_conf);
+int gk_solicitor_enqueue(struct sol_config *sol_conf, struct rte_mbuf *pkt,
+	uint8_t priority);
+
+#endif /* _GATEKEEPER_SOL_H_ */

--- a/include/list.h
+++ b/include/list.h
@@ -82,6 +82,22 @@ INIT_LIST_HEAD(struct list_head *list)
 	list_entry((ptr)->prev, type, member)
 
 /**
+ * list_next_entry - get the next element in list
+ * @pos:	the type * to cursor
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_next_entry(pos, member) \
+	list_entry((pos)->member.next, typeof(*(pos)), member)
+
+/**
+ * list_prev_entry - get the prev element in list
+ * @pos:	the type * to cursor
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_prev_entry(pos, member) \
+	list_entry((pos)->member.prev, typeof(*(pos)), member)
+
+/**
  * list_for_each_entry	-	iterate over list of given type
  * @pos:	the type * to use as a loop cursor.
  * @head:	the head for your list.

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -167,6 +167,15 @@ struct dynamic_config {
 	/* This struct has hidden fields. */
 };
 
+struct sol_config {
+	unsigned int lcore_id;
+	unsigned int pri_req_max_len;
+	double       req_bw_rate;
+	unsigned int enq_burst_size;
+	unsigned int deq_burst_size;
+	/* This struct has hidden fields. */
+};
+
 ]]
 
 -- Functions and wrappers
@@ -183,7 +192,8 @@ struct gatekeeper_if *get_if_back(struct net_config *net_conf);
 int gatekeeper_init_network(struct net_config *net_conf);
 
 struct gk_config *alloc_gk_conf(void);
-int run_gk(struct net_config *net_conf, struct gk_config *gk_conf);
+int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
+	struct sol_config *sol_conf);
 
 struct ggu_config *alloc_ggu_conf(void);
 int run_ggu(struct net_config *net_conf,
@@ -204,6 +214,9 @@ void set_dyc_timeout(unsigned sec, unsigned usec,
 	struct dynamic_config *dy_conf);
 int run_dynamic_config(const char *server_path,
 	struct dynamic_config *dy_conf);
+
+struct sol_config *alloc_sol_conf(void);
+int run_sol(struct net_config *net_conf, struct sol_config *sol_conf);
 
 ]]
 

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -21,8 +21,19 @@ function gatekeeper_init()
 	local lls_conf = llsf(net_conf, numa_table)
 
 	if gatekeeper_server == true then
+		-- n_lcores + 2 on same NUMA: for GK-GT Unit and Solicitor.
+		local n_lcores = 2
+		local gk_lcores =
+			gatekeeper.alloc_lcores_from_same_numa(numa_table,
+				n_lcores + 2)
+		local sol_lcore = table.remove(gk_lcores)
+		local ggu_lcore = table.remove(gk_lcores)
+
+		local solf = require("sol")
+		local sol_conf = solf(net_conf, sol_lcore)
+
 		local gkf = require("gk")
-		local gk_conf, ggu_lcore = gkf(net_conf, numa_table)
+		local gk_conf = gkf(net_conf, sol_conf, gk_lcores)
 
 		local gguf = require("ggu")
 		local ggu_conf = gguf(net_conf, gk_conf, ggu_lcore)

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -1,4 +1,4 @@
-return function (net_conf, numa_table)
+return function (net_conf, sol_conf, gk_lcores)
 
 	-- Init the GK configuration structure.
 	local gk_conf = gatekeeper.c.alloc_gk_conf()
@@ -8,11 +8,7 @@ return function (net_conf, numa_table)
 	
 	-- Change these parameters to configure the Gatekeeper.
 	gk_conf.flow_ht_size = 1024
-	local n_lcores = 2
 
-	local gk_lcores = gatekeeper.alloc_lcores_from_same_numa(numa_table,
-		n_lcores + 1)
-	local ggu_lcore = table.remove(gk_lcores)
 	gatekeeper.gk_assign_lcores(gk_conf, gk_lcores)
 
 	gk_conf.max_num_ipv4_rules = 1024
@@ -23,10 +19,10 @@ return function (net_conf, numa_table)
  	-- TODO Edit of the FIB table.
 
 	-- Setup the GK functional block.
-	local ret = gatekeeper.c.run_gk(net_conf, gk_conf)
+	local ret = gatekeeper.c.run_gk(net_conf, gk_conf, sol_conf)
 	if ret < 0 then
 		error("Failed to run gk block(s)")
 	end
 
-	return gk_conf, ggu_lcore
+	return gk_conf
 end

--- a/lua/sol.lua
+++ b/lua/sol.lua
@@ -1,0 +1,25 @@
+return function (net_conf, lcore)
+
+	-- Init the Solicitor configuration structure.
+	local sol_conf = gatekeeper.c.alloc_sol_conf()
+	if sol_conf == nil then
+		error("Failed to allocate sol_conf")
+	end
+
+	sol_conf.lcore_id = lcore
+	sol_conf.pri_req_max_len = 1024
+	sol_conf.req_bw_rate = 0.05
+	-- These values should likely be set in accordance with
+	-- GATEKEEPER_MAX_PKT_BURST and should be tested to find
+	-- optimal values.
+	sol_conf.enq_burst_size = 32
+	sol_conf.deq_burst_size = 32
+
+	-- Setup the sol functional block.
+	local ret = gatekeeper.c.run_sol(net_conf, sol_conf)
+	if ret < 0 then
+		error("Failed to run sol block")
+	end
+
+	return sol_conf
+end

--- a/sol/main.c
+++ b/sol/main.c
@@ -1,0 +1,568 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <math.h>
+
+#include <rte_sched.h>
+
+#include "gatekeeper_gk.h"
+#include "gatekeeper_launch.h"
+#include "gatekeeper_sol.h"
+
+/*
+ * Gatekeeper request priority queue implementation.
+ *
+ * To implement the request priority queue, we maintain a linked list of
+ * packets listed in order of highest priority to lowest priority. We keep
+ * an array where each index represents a priority, and each element of
+ * that array holds a reference to the last packet of that priority.
+ * This allows us to quickly insert new packets of any priority into
+ * the linked list and drop the packet of lowest priority if necessary.
+ */
+
+static void
+insert_new_priority_req(struct req_queue *req_queue, struct priority_req *pr,
+	uint8_t priority)
+{
+	uint8_t next;
+
+	/* This should be the first request of @priority. */
+	RTE_VERIFY(req_queue->priorities[priority] == NULL);
+
+	req_queue->priorities[priority] = pr;
+
+	/* This is the first packet in the queue. */
+	if (req_queue->len == 0) {
+		list_add(&pr->list, &req_queue->head);
+		req_queue->highest_priority = priority;
+		req_queue->lowest_priority = priority;
+		return;
+	}
+
+	/* Not the first packet, but still insert at the head of the queue. */
+	if (priority > req_queue->highest_priority) {
+		list_add(&pr->list, &req_queue->head);
+		req_queue->highest_priority = priority;
+		return;
+	}
+
+	/*
+	 * Insert in middle or end of queue.
+	 */
+
+	if (priority < req_queue->lowest_priority)
+		req_queue->lowest_priority = priority;
+
+	/*
+	 * This function only inserts a request for a priority that
+	 * does not currently exist, and there is at least one
+	 * request of a higher priority already in the queue.
+	 */
+	RTE_VERIFY(priority != req_queue->highest_priority);
+	for (next = priority + 1; next <= req_queue->highest_priority; next++) {
+		if (req_queue->priorities[next] != NULL) {
+			list_add(&pr->list, &req_queue->priorities[next]->list);
+			return;
+		}
+	}
+
+	rte_panic("sol: %s failed to insert a request of a new priority\n",
+		__func__);
+}
+
+static void
+drop_lowest_priority_pkt(struct sol_config *sol_conf,
+	struct req_queue *req_queue)
+{
+	struct priority_req *lowest_pr = list_last_entry(&req_queue->head,
+		struct priority_req, list);
+	struct priority_req *next_lowest_pr;
+
+	RTE_VERIFY(req_queue->len > 0);
+
+	if (unlikely(req_queue->len == 1)) {
+		req_queue->priorities[lowest_pr->priority] = NULL;
+		req_queue->highest_priority = 0;
+		req_queue->lowest_priority = GK_MAX_REQ_PRIORITY;
+		goto drop;
+	}
+
+	next_lowest_pr = list_prev_entry(lowest_pr, list);
+
+	/* The lowest priority packet was the only one of that priority. */
+	if (lowest_pr->priority != next_lowest_pr->priority) {
+		req_queue->priorities[lowest_pr->priority] = NULL;
+		req_queue->lowest_priority = next_lowest_pr->priority;
+		goto drop;
+	}
+
+	req_queue->priorities[lowest_pr->priority] = next_lowest_pr;
+
+drop:
+	list_del(&lowest_pr->list);
+	rte_pktmbuf_free(lowest_pr->pkt);
+	mb_free_entry(&sol_conf->mb, lowest_pr);
+	req_queue->len--;
+}
+
+static void
+enqueue_req(struct sol_config *sol_conf, struct priority_req *req)
+{
+	struct req_queue *req_queue = &sol_conf->req_queue;
+	uint8_t priority = req->priority;
+
+	if (req_queue->len == sol_conf->pri_req_max_len) {
+		/* New packet is lowest priority, so drop it. */
+		if (req_queue->lowest_priority >= priority) {
+			rte_pktmbuf_free(req->pkt);
+			mb_free_entry(&sol_conf->mb, req);
+			return;
+		}
+		drop_lowest_priority_pkt(sol_conf, req_queue);
+	}
+
+	if (req_queue->priorities[priority] == NULL) {
+		/* Insert request of a priority we don't yet have. */
+		insert_new_priority_req(req_queue, req, priority);
+	} else {
+		/* Append request to end of the appropriate priority. */
+		list_add(&req->list, &req_queue->priorities[priority]->list);
+		req_queue->priorities[priority] = req;
+	}
+
+	req_queue->len++;
+}
+
+static void
+enqueue_reqs(struct sol_config *sol_conf)
+{
+	struct priority_req *req_nodes[sol_conf->enq_burst_size];
+	int num_reqs = mb_dequeue_burst(&sol_conf->mb,
+		(void **)req_nodes, sol_conf->enq_burst_size);
+	int i;
+	for (i = 0; i < num_reqs; i++)
+		enqueue_req(sol_conf, req_nodes[i]);
+}
+
+static inline void
+credits_update(struct req_queue *req_queue)
+{
+	uint64_t curr_cycles = rte_rdtsc();
+	uint64_t avail_cycles = curr_cycles - req_queue->time_cpu_cycles;
+#if __WORDSIZE == 64
+	ldiv_t avail_bytes;
+#elif __WORDSIZE == 32
+	lldiv_t avail_bytes;
+#else
+	#error "unexpected value for __WORDSIZE macro"
+#endif
+
+	/* Not enough cycles have passed to update the number of credits. */
+	if (avail_cycles <= req_queue->cycles_per_byte_floor)
+		return;
+
+#if __WORDSIZE == 64
+	avail_bytes = ldiv(avail_cycles * req_queue->cycles_per_byte_a,
+		req_queue->cycles_per_byte_b);
+#elif __WORDSIZE == 32
+	avail_bytes = lldiv(avail_cycles * req_queue->cycles_per_byte_a,
+		req_queue->cycles_per_byte_b);
+#else
+	#error "unexpected value for __WORDSIZE macro"
+#endif
+
+	req_queue->tb_credit_bytes += avail_bytes.quot;
+	if (req_queue->tb_credit_bytes > req_queue->tb_max_credit_bytes)
+		req_queue->tb_credit_bytes = req_queue->tb_max_credit_bytes;
+
+	/*
+	 * If there are spare cycles (that were not converted to credits
+	 * because of rounding), keep them for the next iteration.
+	 */
+	req_queue->time_cpu_cycles = curr_cycles - avail_bytes.rem;
+}
+
+static inline int
+credits_check(struct req_queue *req_queue, struct rte_mbuf *pkt)
+{
+	/* Need to include Ethernet frame overhead (preamble, gap, etc.) */
+	uint32_t pkt_len = pkt->pkt_len + RTE_SCHED_FRAME_OVERHEAD_DEFAULT;
+	if (pkt_len > req_queue->tb_credit_bytes)
+		return false;
+	req_queue->tb_credit_bytes -= pkt_len;
+	return true;
+}
+
+static void
+dequeue_reqs(struct sol_config *sol_conf, uint8_t tx_port)
+{
+	struct req_queue *req_queue = &sol_conf->req_queue;
+	struct priority_req *entry, *next;
+
+	struct rte_mbuf *pkts_out[sol_conf->deq_burst_size];
+	uint32_t nb_pkts_out = 0;
+	uint16_t total_sent = 0;
+
+	/* Get an up-to-date view of our credits. */
+	credits_update(req_queue);
+
+	list_for_each_entry_safe(entry, next, &req_queue->head, list) {
+		struct rte_mbuf *pkt = entry->pkt;
+
+		if (!credits_check(req_queue, pkt)) {
+			/*
+			 * XXX When under an attack, we may not want to
+			 * log this because it could become expensive.
+			 */
+			RTE_LOG(NOTICE, GATEKEEPER,
+				"sol: out of request bandwidth\n");
+			goto out;
+		}
+
+		if (req_queue->len == 1 || (entry->priority != next->priority))
+			req_queue->priorities[entry->priority] = NULL;
+		list_del(&entry->list);
+		mb_free_entry(&sol_conf->mb, entry);
+		req_queue->len--;
+
+		pkts_out[nb_pkts_out++] = pkt;
+
+		if (nb_pkts_out >= sol_conf->deq_burst_size)
+			break;
+	}
+
+out:
+	if (list_empty(&req_queue->head)) {
+		req_queue->highest_priority = 0;
+		req_queue->lowest_priority = GK_MAX_REQ_PRIORITY;
+	} else {
+		struct priority_req *first = list_first_entry(&req_queue->head,
+			struct priority_req, list);
+		req_queue->highest_priority = first->priority;
+	}
+
+	/* We cannot drop the packets, so re-send. */
+	while (nb_pkts_out > 0) {
+		uint16_t sent = rte_eth_tx_burst(tx_port,
+			sol_conf->tx_queue_back,
+			pkts_out + total_sent, nb_pkts_out);
+		total_sent += sent;
+		nb_pkts_out -= sent;
+	}
+}
+
+/*
+ * Retrieve the link speed of a Gatekeeper interface. If it
+ * is a bonded interface, the link speeds are summed.
+ */
+static int
+iface_speed_bytes(struct gatekeeper_if *iface, uint64_t *link_speed_bytes)
+{
+	uint64_t link_speed_mbits = 0;
+	uint8_t i;
+
+	RTE_VERIFY(link_speed_bytes != NULL);
+
+	for (i = 0; i < iface->num_ports; i++) {
+		struct rte_eth_link link;
+		rte_eth_link_get(iface->ports[i], &link);
+
+		if (link.link_speed == ETH_SPEED_NUM_NONE) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"sol: link speed for port %hhu on the back interface is undefined\n",
+				iface->ports[i]);
+			return -1;
+		}
+
+		link_speed_mbits += link.link_speed;
+	}
+
+	/* Convert to bytes per second. */
+	*link_speed_bytes = link_speed_mbits * (1000 * 1000 / 8);
+	return 0;
+}
+
+/* Token bucket rate approximation error. */
+#define GATEKEEPER_TB_RATE_CONFIG_ERR (1e-7)
+
+/*
+ * @sol_conf is allocated using rte_calloc(), so initializations
+ * to 0 are not strictly necessary in this function.
+ */
+static int
+req_queue_init(struct sol_config *sol_conf)
+{
+	struct req_queue *req_queue = &sol_conf->req_queue;
+	uint64_t link_speed_bytes;
+	double max_credit_bytes_precise;
+	double cycles_per_byte_precise;
+	uint32_t a, b;
+	int ret;
+
+	req_queue->len = 0;
+	req_queue->highest_priority = 0;
+	req_queue->lowest_priority = GK_MAX_REQ_PRIORITY;
+
+	/* Find link speed in bytes, even for a bonded interface. */
+	ret = iface_speed_bytes(&sol_conf->net->back, &link_speed_bytes);
+	if (ret < 0)
+		return ret;
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"sol: back interface link speed: %"PRIu64" bytes per second\n",
+		link_speed_bytes);
+
+	/* Keep maximum number of bytes as a float for later calculations. */
+	max_credit_bytes_precise = sol_conf->req_bw_rate * link_speed_bytes;
+
+	/* Initialize token bucket as full. */
+	req_queue->tb_max_credit_bytes = round(max_credit_bytes_precise);
+	req_queue->tb_credit_bytes = req_queue->tb_max_credit_bytes;
+
+	/*
+	 * Compute the number of cycles needed to credit the request queue
+	 * with bytes. Represent this ratio of cycles per byte using two
+	 * numbers -- a numerator and denominator.
+	 *
+	 * The function rte_approx() can only approximate a floating-point
+	 * number between (0, 1). Therefore, approximate only the fractional
+	 * part of the cycles per byte using rte_approx(), and then add
+	 * the integer number of cycles per byte to the numerator.
+	 */
+	cycles_per_byte_precise = cycles_per_sec / max_credit_bytes_precise;
+	req_queue->cycles_per_byte_floor = cycles_per_byte_precise;
+	ret = rte_approx(
+		cycles_per_byte_precise - req_queue->cycles_per_byte_floor,
+		GATEKEEPER_TB_RATE_CONFIG_ERR, &a, &b);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: could not approximate the request queue's allocated bandwidth\n");
+		return ret;
+	}
+	req_queue->cycles_per_byte_a = a;
+	req_queue->cycles_per_byte_b = b;
+
+	/* Add integer number of cycles per byte to numerator. */
+	req_queue->cycles_per_byte_a +=
+		req_queue->cycles_per_byte_floor * req_queue->cycles_per_byte_b;
+
+	RTE_LOG(NOTICE, GATEKEEPER, "sol: cycles per byte (%f) represented as a rational: %"PRIu64" / %"PRIu64"\n",
+		cycles_per_byte_precise,
+		req_queue->cycles_per_byte_a, req_queue->cycles_per_byte_b);
+
+	req_queue->time_cpu_cycles = rte_rdtsc();
+	return 0;
+}
+
+static int
+cleanup_sol(struct sol_config *sol_conf)
+{
+	struct req_queue *req_queue = &sol_conf->req_queue;
+	struct priority_req *entry, *next;
+
+	list_for_each_entry_safe(entry, next, &req_queue->head, list) {
+		rte_pktmbuf_free(entry->pkt);
+		list_del(&entry->list);
+		mb_free_entry(&sol_conf->mb, entry);
+		req_queue->len--;
+	}
+
+	if (req_queue->len > 0)
+		RTE_LOG(NOTICE, GATEKEEPER, "sol: bug: removing all requests from the priority queue on cleanup leaves the queue length at %"PRIu32"\n",
+			req_queue->len);
+
+	destroy_mailbox(&sol_conf->mb);
+	rte_free(sol_conf);
+	return 0;
+}
+
+static int
+sol_proc(void *arg)
+{
+	struct sol_config *sol_conf = (struct sol_config *)arg;
+	unsigned int lcore = sol_conf->lcore_id;
+	uint8_t tx_port_back = sol_conf->net->back.id;
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"sol: the Solicitor block is running at lcore = %u\n", lcore);
+
+	while (likely(!exiting)) {
+		enqueue_reqs(sol_conf);
+		dequeue_reqs(sol_conf, tx_port_back);
+	}
+
+	RTE_LOG(NOTICE, GATEKEEPER,
+		"sol: the Solicitor block at lcore = %u is exiting\n", lcore);
+
+	return cleanup_sol(sol_conf);
+}
+
+static int
+sol_stage1(void *arg)
+{
+	struct sol_config *sol_conf = arg;
+	int ret = get_queue_id(&sol_conf->net->back, QUEUE_TYPE_TX,
+		sol_conf->lcore_id);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: cannot assign a TX queue for the back interface for lcore %u\n",
+			sol_conf->lcore_id);
+		goto cleanup;
+	}
+	sol_conf->tx_queue_back = ret;
+
+	return 0;
+
+cleanup:
+	cleanup_sol(sol_conf);
+	return -1;
+}
+
+static int
+sol_stage2(void *arg)
+{
+	struct sol_config *sol_conf = arg;
+	int ret = req_queue_init(sol_conf);
+	if (ret < 0)
+		goto cleanup;
+
+	return 0;
+
+cleanup:
+	cleanup_sol(sol_conf);
+	return ret;
+}
+
+int
+run_sol(struct net_config *net_conf, struct sol_config *sol_conf)
+{
+	int ret;
+
+	if (net_conf == NULL || sol_conf == NULL) {
+		ret = -1;
+		goto out;
+	}
+
+	if (!net_conf->back_iface_enabled) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: back interface is required\n");
+		ret = -1;
+		goto out;
+	}
+
+	if (sol_conf->pri_req_max_len == 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"sol: priority queue max len must be greater than 0\n");
+		ret = -1;
+		goto out;
+	}
+
+	if (sol_conf->enq_burst_size == 0 || sol_conf->deq_burst_size == 0) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: priority queue enqueue and dequeue sizes must both be greater than 0\n");
+		ret = -1;
+		goto out;
+	}
+
+	if (sol_conf->deq_burst_size > sol_conf->pri_req_max_len ||
+			sol_conf->enq_burst_size > sol_conf->pri_req_max_len) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: request queue enqueue and dequeue sizes must be less than the max length of the request queue\n");
+		ret = -1;
+		goto out;
+	}
+
+	if (sol_conf->req_bw_rate <= 0 || sol_conf->req_bw_rate >= 1) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"sol: request queue bandwidth must be in range (0, 1), but it has been specified as %f\n",
+			sol_conf->req_bw_rate);
+		ret = -1;
+		goto out;
+	}
+
+	ret = init_mailbox("sol_reqs", 2 * sol_conf->pri_req_max_len,
+		sizeof(struct priority_req), sol_conf->lcore_id,
+		&sol_conf->mb);
+	if (ret < 0)
+		goto out;
+
+	ret = net_launch_at_stage1(net_conf, 0, 0, 0, 1, sol_stage1, sol_conf);
+	if (ret < 0)
+		goto mb;
+
+	ret = launch_at_stage2(sol_stage2, sol_conf);
+	if (ret < 0)
+		goto stage1;
+
+	ret = launch_at_stage3("sol", sol_proc, sol_conf, sol_conf->lcore_id);
+	if (ret < 0)
+		goto stage2;
+
+	sol_conf->net = net_conf;
+
+	ret = 0;
+	goto out;
+
+stage2:
+	pop_n_at_stage2(1);
+stage1:
+	pop_n_at_stage1(1);
+mb:
+	destroy_mailbox(&sol_conf->mb);
+out:
+	return ret;
+}
+
+/*
+ * There should be only one sol_config instance.
+ * Return an error if trying to allocate the second instance.
+ *
+ * Use rte_calloc() to zero-out the instance and initialize the
+ * request queue list to guarantee that cleanup_sol() won't fail
+ * during initialization.
+ */
+struct sol_config *
+alloc_sol_conf(void)
+{
+	struct sol_config *sol_conf;
+	static rte_atomic16_t num_sol_conf_alloc = RTE_ATOMIC16_INIT(0);
+	if (rte_atomic16_test_and_set(&num_sol_conf_alloc) > 1) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: trying to allocate the second instance of struct sol_config\n");
+		return NULL;
+	}
+	sol_conf = rte_calloc("sol_config", 1, sizeof(struct sol_config), 0);
+	INIT_LIST_HEAD(&sol_conf->req_queue.head);
+	return sol_conf;
+}
+
+int
+gk_solicitor_enqueue(struct sol_config *sol_conf, struct rte_mbuf *pkt,
+	uint8_t priority)
+{
+	struct priority_req *req_node;
+
+	if (priority > GK_MAX_REQ_PRIORITY) {
+		RTE_LOG(ERR, GATEKEEPER, "sol: trying to enqueue a request with priority %hhu, but should be in range [0, %d]\n",
+			priority, GK_MAX_REQ_PRIORITY);
+		return -1;
+	}
+
+	req_node = mb_alloc_entry(&sol_conf->mb);
+	if (req_node == NULL)
+		return -1;
+
+	INIT_LIST_HEAD(&req_node->list);
+	req_node->pkt = pkt;
+	req_node->priority = priority;
+
+	return mb_send_entry(&sol_conf->mb, req_node);
+}


### PR DESCRIPTION
Add the two types of queues needed for a Gatekeeper server: a
priority request queue that is serviced by a Solicitor block,
and granted queues for each GK instance.