### PR TITLE
Add support for IP variable headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ SRCS-y += sol/main.c
 
 # Libraries.
 SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c \
-	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c lib/acl.c
+	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c lib/acl.c lib/varip.c
 
 LDLIBS += $(LDIR) -Bstatic -lluajit-5.1 -Bdynamic -lm -lmnl
 CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include -I/usr/local/include/luajit-2.0/

--- a/gk/main.c
+++ b/gk/main.c
@@ -535,28 +535,28 @@ print_flow_err_msg(struct ip_flow *flow, const char *err_msg)
 
 	if (flow->proto == ETHER_TYPE_IPv4) {
 		if (inet_ntop(AF_INET, &flow->f.v4.src,
-				src, sizeof(struct in_addr)) == NULL) {
+				src, sizeof(src)) == NULL) {
 			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv4 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
 
 		if (inet_ntop(AF_INET, &flow->f.v4.dst,
-				dst, sizeof(struct in_addr)) == NULL) {
+				dst, sizeof(dst)) == NULL) {
 			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv4 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
 	} else if (likely(flow->proto == ETHER_TYPE_IPv6)) {
 		if (inet_ntop(AF_INET6, flow->f.v6.src,
-				src, sizeof(struct in6_addr)) == NULL) {
+				src, sizeof(src)) == NULL) {
 			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv6 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
 
 		if (inet_ntop(AF_INET6, flow->f.v6.dst,
-				dst, sizeof(struct in6_addr)) == NULL) {
+				dst, sizeof(dst)) == NULL) {
 			RTE_LOG(ERR, GATEKEEPER, "gk: %s: failed to convert a number to an IPv6 address (%s)\n",
 				__func__, strerror(errno));
 			return;

--- a/include/gatekeeper_acl.h
+++ b/include/gatekeeper_acl.h
@@ -55,7 +55,7 @@ void destroy_ipv6_acls(struct gatekeeper_if *iface);
 
 /* Register IPv6 ACL rules and callback functions. */
 int register_ipv6_acl(struct ipv6_acl_rule *rules, unsigned int num_rules,
-	acl_cb_func cb_f, struct gatekeeper_if *iface);
+	acl_cb_func cb_f, ext_cb_func ext_cb_f, struct gatekeeper_if *iface);
 
 /* Build the ACL trie. This should be invoked after all ACL rules are added. */
 int build_ipv6_acls(struct gatekeeper_if *iface);

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -76,6 +76,8 @@ struct gatekeeper_rss_config {
 struct gatekeeper_if *iface;
 typedef int (*acl_cb_func)(struct rte_mbuf **pkts, unsigned int num_pkts,
 	struct gatekeeper_if *iface);
+/* Format of function called when no rule matches in the IPv6 ACL. */
+typedef int (*ext_cb_func)(struct rte_mbuf *pkt, struct gatekeeper_if *iface);
 
 /*
  * A Gatekeeper interface is specified by a set of PCI addresses
@@ -212,6 +214,15 @@ struct gatekeeper_if {
 	 */
 	acl_cb_func        acl_funcs[GATEKEEPER_IPV6_ACL_MAX];
 
+	/*
+	 * Callback functions for each ACL rule type with
+	 * IPv6 extension headers.
+	 *
+	 * Returning values: 0 means a match and a negative value
+	 * means an error or that there was no match.
+	 */
+	ext_cb_func        ext_funcs[GATEKEEPER_IPV6_ACL_MAX];
+
 	/* Number of ACL types installed in @acl_funcs. */
 	unsigned int       acl_func_count;
 };
@@ -300,6 +311,7 @@ int get_ip_type(const char *ip_addr);
 int convert_str_to_ip(const char *ip_addr, struct ipaddr *res);
 int ethertype_filter_add(uint8_t port_id, uint16_t ether_type,
 	uint16_t queue_id);
+
 int ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
 	uint16_t src_port, uint16_t src_port_mask,
 	uint16_t dst_port, uint16_t dst_port_mask,

--- a/include/gatekeeper_varip.h
+++ b/include/gatekeeper_varip.h
@@ -1,0 +1,54 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_VARIP_H_
+#define _GATEKEEPER_VARIP_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * All functional blocks that parse packets beyond the IP header
+ * must be aware that variable IP headers are possible, and should
+ * use the functionality provided by this library.
+ */
+
+/*
+ * Skip any extension headers.
+ *
+ * This function parses (potentially truncated) extension headers.
+ * @nexthdrp should be a reference to the type of the header
+ * that comes after the IPv6 header, which may or may not be
+ * an IPv6 extension header.
+ *
+ * It skips all well-known exthdrs, and returns an offset to the start
+ * of the unparsable area i.e. the first header with unknown type.
+ * If it is not -1, *nexthdr is updated by type/protocol of this header.
+ *
+ * NOTES: - If packet terminated with NEXTHDR_NONE it returns -1.
+ *        - If packet is truncated, so that all parsed headers are skipped,
+ *	    it returns -1.
+ *        - First fragment header is skipped, not-first ones
+ *	    are considered as unparsable.
+ *        - ESP is unparsable for now and considered like
+ *	    normal payload protocol.
+ */
+int ipv6_skip_exthdr(const struct ipv6_hdr *ip6hdr,
+	int remaining_len, uint8_t *nexthdrp);
+
+#endif /* _GATEKEEPER_VARIP_H_ */

--- a/lib/varip.c
+++ b/lib/varip.c
@@ -1,0 +1,87 @@
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+
+#include "gatekeeper_varip.h"
+
+/* NextHeader field of IPv6 header. */
+
+/* Hop-by-hop option header. */
+#define NEXTHDR_HOP      (0)
+
+/* Routing header. */
+#define NEXTHDR_ROUTING  (43)
+
+/* Fragmentation/reassembly header. */
+#define NEXTHDR_FRAGMENT (44)
+
+/* Authentication header. */
+#define NEXTHDR_AUTH     (51)
+
+/* No next header. */
+#define NEXTHDR_NONE     (59)
+
+/* Destination options header. */
+#define NEXTHDR_DEST     (60)
+
+static inline bool
+ipv6_ext_hdr(uint8_t nexthdr)
+{
+	/* Find out if nexthdr is an extension header or a protocol. */
+	return (nexthdr == NEXTHDR_HOP) ||
+		(nexthdr == NEXTHDR_ROUTING) ||
+		(nexthdr == NEXTHDR_FRAGMENT) ||
+		(nexthdr == NEXTHDR_AUTH) ||
+		(nexthdr == NEXTHDR_NONE) ||
+		(nexthdr == NEXTHDR_DEST);
+}
+
+struct ipv6_opt_hdr {
+	uint8_t nexthdr;
+	uint8_t hdrlen;
+} __attribute__((packed));
+
+int
+ipv6_skip_exthdr(const struct ipv6_hdr *ip6hdr,
+	int remaining_len, uint8_t *nexthdrp)
+{
+	int start = sizeof(struct ipv6_hdr);
+	uint8_t nexthdr = ip6hdr->proto;
+
+	while (ipv6_ext_hdr(nexthdr)) {
+		int hdrlen;
+		const struct ipv6_opt_hdr *hp;
+
+		if (start + (int)sizeof(struct ipv6_opt_hdr) > remaining_len)
+			return -1;
+
+		hp = (const struct ipv6_opt_hdr *)
+			((const uint8_t *)ip6hdr + start);
+
+		switch (nexthdr) {
+		case NEXTHDR_NONE:
+			return -1;
+			break;
+
+		case NEXTHDR_FRAGMENT:
+			hdrlen = 8;
+			break;
+
+		case NEXTHDR_AUTH:
+			hdrlen = ((hp->hdrlen + 2) << 2);
+			break;
+
+		default:
+			hdrlen = ((hp->hdrlen + 1) << 3);
+			break;
+		}
+
+		nexthdr = hp->nexthdr;
+		start += hdrlen;
+
+		if (start > remaining_len)
+			return -1;
+	}
+
+	*nexthdrp = nexthdr;
+	return start;
+}


### PR DESCRIPTION
This pull request includes two patches: The first patch fixes a bug in GK block; the second patch adds support for the IP variable headers, including IPv4 option headers, and IPv6 extension headers. Notice that, I have verified that ntuple filters actually support IP variable headers. However, the ACL rules don't support IP variable headers, so for each ACL rule, we need to issue a match function to deal with IP variable headers.