### PR TITLE
add support for VLAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ SRCS-y += sol/main.c
 
 # Libraries.
 SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c \
-	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c lib/acl.c lib/varip.c
+	lib/luajit-ffi-cdata.c lib/launch.c lib/lpm.c lib/acl.c lib/varip.c \
+	lib/l2.c
 
 LDLIBS += $(LDIR) -Bstatic -lluajit-5.1 -Bdynamic -lm -lmnl
 CFLAGS += $(WERROR_FLAGS) -I${GATEKEEPER}/include -I/usr/local/include/luajit-2.0/

--- a/cps/kni.c
+++ b/cps/kni.c
@@ -996,9 +996,9 @@ kni_process_nd(struct cps_config *cps_conf, struct gatekeeper_if *iface,
 		goto out;
 	}
 
-	if (pkt_len < ND_NEIGH_PKT_MIN_LEN) {
+	if (pkt_len < ND_NEIGH_PKT_MIN_LEN(sizeof(*eth_hdr))) {
 		RTE_LOG(NOTICE, GATEKEEPER, "cps: ND packet received is %"PRIx16" bytes but should be at least %lu bytes\n",
-			pkt_len, ND_NEIGH_PKT_MIN_LEN);
+			pkt_len, ND_NEIGH_PKT_MIN_LEN(sizeof(*eth_hdr)));
 		goto out;
 	}
 

--- a/cps/main.c
+++ b/cps/main.c
@@ -157,8 +157,8 @@ send_nd_reply_kni(struct cps_config *cps_conf, struct cps_nd_req *nd)
 	}
 
 	/* Advertisement will include target link layer address. */
-	created_pkt->data_len = ND_NEIGH_PKT_LLADDR_MIN_LEN;
-	created_pkt->pkt_len = ND_NEIGH_PKT_LLADDR_MIN_LEN;
+	created_pkt->data_len = ND_NEIGH_PKT_LLADDR_MIN_LEN(sizeof(*eth_hdr));
+	created_pkt->pkt_len = created_pkt->data_len;
 
 	/*
 	 * Set-up Ethernet header. The Ethernet address of the KNI is the
@@ -173,7 +173,7 @@ send_nd_reply_kni(struct cps_config *cps_conf, struct cps_nd_req *nd)
 	/* Set-up IPv6 header. */
 	ipv6_hdr = (struct ipv6_hdr *)&eth_hdr[1];
 	ipv6_hdr->vtc_flow = rte_cpu_to_be_32(IPv6_DEFAULT_VTC_FLOW);
-	ipv6_hdr->payload_len = rte_cpu_to_be_16(ND_NEIGH_PKT_LLADDR_MIN_LEN -
+	ipv6_hdr->payload_len = rte_cpu_to_be_16(created_pkt->data_len -
 		(sizeof(*eth_hdr) + sizeof(*ipv6_hdr)));
 	ipv6_hdr->proto = IPPROTO_ICMPV6;
 	ipv6_hdr->hop_limits = IPv6_DEFAULT_HOP_LIMITS;
@@ -296,15 +296,59 @@ static void
 process_ingress(struct gatekeeper_if *iface, struct rte_kni *kni,
 	uint16_t rx_queue)
 {
-	struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
-	uint16_t num_rx = rte_eth_rx_burst(iface->id, rx_queue, bufs,
+	struct rte_mbuf *rx_bufs[GATEKEEPER_MAX_PKT_BURST];
+	uint16_t num_rx = rte_eth_rx_burst(iface->id, rx_queue, rx_bufs,
 		GATEKEEPER_MAX_PKT_BURST);
-	unsigned int num_tx = rte_kni_tx_burst(kni, bufs, num_rx);
+	uint16_t num_kni;
+	uint16_t num_tx;
+	uint16_t i;
 
-	if (unlikely(num_tx < num_rx)) {
-		uint16_t i;
-		for (i = num_tx; i < num_rx; i++)
-			rte_pktmbuf_free(bufs[i]);
+	if (!iface->vlan_insert) {
+		num_kni = num_rx;
+		goto kni_tx;
+	}
+
+	/* Remove any VLAN headers before passing to the KNI. */
+	num_kni = 0;
+	for (i = 0; i < num_rx; i++) {
+		struct ether_hdr *eth_hdr =
+			rte_pktmbuf_mtod(rx_bufs[i], struct ether_hdr *);
+		struct vlan_hdr *vlan_hdr;
+
+		RTE_VERIFY(num_kni <= i);
+
+		if (unlikely(eth_hdr->ether_type !=
+				rte_cpu_to_be_16(ETHER_TYPE_VLAN))) {
+			RTE_LOG(WARNING, GATEKEEPER,
+				"cps: %s iface is configured for VLAN but received a non-VLAN packet\n",
+				iface->name);
+			goto to_kni;
+		}
+
+		/* Copy Ethernet header over VLAN header. */
+		vlan_hdr = (struct vlan_hdr *)&eth_hdr[1];
+		eth_hdr->ether_type = vlan_hdr->eth_proto;
+		memmove((uint8_t *)eth_hdr + sizeof(struct vlan_hdr), eth_hdr,
+			sizeof(*eth_hdr));
+
+		/* Remove the unneeded bytes from the front of the buffer. */
+		if (unlikely(rte_pktmbuf_adj(rx_bufs[i],
+				sizeof(struct vlan_hdr)) == NULL)) {
+			RTE_LOG(ERR, GATEKEEPER,
+				"cps: can't remove VLAN header\n");
+			rte_pktmbuf_free(rx_bufs[i]);
+			continue;
+		}
+to_kni:
+		if (unlikely(num_kni < i))
+			rx_bufs[num_kni++] = rx_bufs[i];
+	}
+
+kni_tx:
+	num_tx = rte_kni_tx_burst(kni, rx_bufs, num_kni);
+	if (unlikely(num_tx < num_kni)) {
+		for (i = num_tx; i < num_kni; i++)
+			rte_pktmbuf_free(rx_bufs[i]);
 	}
 }
 
@@ -316,7 +360,7 @@ pkt_is_nd(struct gatekeeper_if *iface, struct ether_hdr *eth_hdr,
 	struct icmpv6_hdr *icmpv6_hdr;
 
 	if (pkt_len < (sizeof(*eth_hdr) + sizeof(*ipv6_hdr) +
-			sizeof(icmpv6_hdr)))
+			sizeof(*icmpv6_hdr)))
 		return false;
 
 	ipv6_hdr = (struct ipv6_hdr *)&eth_hdr[1];
@@ -356,6 +400,7 @@ process_egress(struct cps_config *cps_conf, struct gatekeeper_if *iface,
 		return;
 
 	for (i = 0; i < num_rx; i++) {
+		/* Packets sent by the KNI do not have VLAN headers. */
 		struct ether_hdr *eth_hdr = rte_pktmbuf_mtod(bufs[i],
 			struct ether_hdr *);
 		switch (rte_be_to_cpu_16(eth_hdr->ether_type)) {
@@ -373,10 +418,34 @@ process_egress(struct cps_config *cps_conf, struct gatekeeper_if *iface,
 			}
 		}
 			/* FALLTHROUGH */
-		default:
-			/* Forward all other packets to the interface. */
+		default: {
+			/*
+			 * Forward all other packets to the interface,
+			 * adding a VLAN header if necessary.
+			 */
+			struct ether_hdr *new_eth_hdr;
+
+			if (!iface->vlan_insert)
+				goto to_eth;
+
+			/* Need to make room for a VLAN header. */
+			new_eth_hdr = (struct ether_hdr *)
+				rte_pktmbuf_prepend(bufs[i],
+					sizeof(struct vlan_hdr));
+			if (unlikely(new_eth_hdr == NULL)) {
+				RTE_LOG(ERR, GATEKEEPER,
+					"cps: can't add a VLAN header\n");
+				rte_pktmbuf_free(bufs[i]);
+				continue;
+			}
+
+			memmove(new_eth_hdr, eth_hdr, sizeof(*new_eth_hdr));
+			fill_vlan_hdr(new_eth_hdr, iface->vlan_tag_be,
+				rte_be_to_cpu_16(eth_hdr->ether_type));
+to_eth:
 			forward_bufs[num_forward++] = bufs[i];
 			break;
+		}
 		}
 	}
 
@@ -786,11 +855,13 @@ match_bgp6(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 		rte_pktmbuf_mtod(pkt, struct ether_hdr *);
 	struct ipv6_hdr *ip6hdr;
 	struct tcp_hdr *tcp_hdr;
-	uint16_t minimum_size = sizeof(*eth_hdr) +
+	uint16_t ether_type_be = pkt_in_skip_l2(pkt, eth_hdr, (void **)&ip6hdr);
+	size_t l2_len = pkt_in_l2_hdr_len(pkt);
+	uint16_t minimum_size = l2_len +
 		sizeof(struct ipv6_hdr) + sizeof(struct tcp_hdr);
 	uint16_t cps_bgp_port = rte_cpu_to_be_16(get_cps_conf()->tcp_port_bgp);
 
-	if (unlikely(eth_hdr->ether_type != BE_ETHER_TYPE_IPv6))
+	if (unlikely(ether_type_be != BE_ETHER_TYPE_IPv6))
 		return -ENOENT;
 
 	if (pkt->data_len < minimum_size) {
@@ -799,14 +870,11 @@ match_bgp6(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 		return -ENOENT;
 	}
 
-	ip6hdr = (struct ipv6_hdr *)&eth_hdr[1];
-
 	if ((memcmp(ip6hdr->dst_addr, &iface->ip6_addr,
 			sizeof(iface->ip6_addr)) != 0))
 		return -ENOENT;
 
-	tcp_offset = ipv6_skip_exthdr(ip6hdr, pkt->data_len -
-		sizeof(*eth_hdr), &nexthdr);
+	tcp_offset = ipv6_skip_exthdr(ip6hdr, pkt->data_len - l2_len, &nexthdr);
 	if (tcp_offset < 0 || nexthdr != IPPROTO_TCP)
 		return -ENOENT;
 

--- a/cps/main.c
+++ b/cps/main.c
@@ -383,7 +383,6 @@ process_egress(struct cps_config *cps_conf, struct gatekeeper_if *iface,
 	num_tx = rte_eth_tx_burst(iface->id, tx_queue,
 		forward_bufs, num_forward);
 	if (unlikely(num_tx < num_forward)) {
-		uint16_t i;
 		for (i = num_tx; i < num_forward; i++)
 			rte_pktmbuf_free(forward_bufs[i]);
 	}

--- a/include/gatekeeper_acl.h
+++ b/include/gatekeeper_acl.h
@@ -20,6 +20,7 @@
 #define _GATEKEEPER_ACL_H_
 
 #include "gatekeeper_config.h"
+#include "gatekeeper_l2.h"
 #include "gatekeeper_net.h"
 
 struct acl_search {
@@ -46,8 +47,9 @@ void destroy_acls(struct acl_state *astate);
 static inline void
 add_pkt_acl(struct acl_search *acl, struct rte_mbuf *pkt)
 {
+	/* pkt_in_skip_l2() was already called by GK or GT. */
 	acl->data[acl->num] = rte_pktmbuf_mtod_offset(pkt, uint8_t *,
-		sizeof(struct ether_hdr));
+		pkt_in_l2_hdr_len(pkt));
 	acl->mbufs[acl->num] = pkt;
 	acl->num++;
 }

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -102,8 +102,13 @@ struct ether_cache {
 	/* The IP address of the nexthop. */
 	struct ipaddr    ip_addr;
 
-	/* The whole Ethernet header. */
-	struct ether_hdr eth_hdr;
+	/* The whole link-layer header. */
+	struct {
+		/* Ethernet header (required). */
+		struct ether_hdr eth_hdr;
+		/* VLAN header (optional). */
+		struct vlan_hdr  vlan_hdr;
+	} __attribute__((packed)) l2_hdr;
 };
 
 struct neighbor_hash_table {

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -146,8 +146,8 @@ int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
 struct mailbox *get_responsible_gk_mailbox(
 	const struct ip_flow *flow, const struct gk_config *gk_conf);
 
-int pkt_copy_cached_eth_header(
-	struct rte_mbuf *pkt, struct ether_cache *eth_cache);
+int pkt_copy_cached_eth_header(struct rte_mbuf *pkt,
+	struct ether_cache *eth_cache, size_t l2_len_out);
 
 static inline void
 gk_conf_hold(struct gk_config *gk_conf)

--- a/include/gatekeeper_ipip.h
+++ b/include/gatekeeper_ipip.h
@@ -34,17 +34,9 @@
 #define IP_DN_FRAGMENT_FLAG     (0x0040)
 
 /*
- * TODO The encapsulation function should not add the Ethernet header.
- * This way we can compose the Ethernet header copying it from a cache,
- * or by setting his fields.
- * Implement a way to add the Ethernet header.
- * Also, the function to add Ethernet header
- * needs to set the @outer_l2_len field of the packet.
- *
- * Notice that, the original packet should contain the Ethernet header,
- * while the function shouldn't add an Ethernet header.
- * When allocating space for the outer IP header,
- * it only needs to allocate the extra needed space.
+ * Encapsulates the packet to send to Grantor with the given
+ * priority. Adjusts the size of the Ethernet header, if
+ * needed, for a VLAN header.
  */
 int encapsulate(struct rte_mbuf *pkt, uint8_t priority,
 	struct gatekeeper_if *iface, struct ipaddr *gt_addr);

--- a/include/gatekeeper_l2.h
+++ b/include/gatekeeper_l2.h
@@ -90,4 +90,7 @@ fill_vlan_hdr(struct ether_hdr *eth_hdr, uint16_t vlan_tag_be,
 struct ether_hdr *adjust_pkt_len(struct rte_mbuf *pkt,
 	struct gatekeeper_if *iface, int bytes_to_add);
 
+int verify_l2_hdr(struct gatekeeper_if *iface, struct ether_hdr *eth_hdr,
+	uint32_t l2_type, const char *proto_name);
+
 #endif /* _GATEKEEPER_L2_H_ */

--- a/include/gatekeeper_l2.h
+++ b/include/gatekeeper_l2.h
@@ -1,0 +1,93 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_L2_H_
+#define _GATEKEEPER_L2_H_
+
+#include <rte_ether.h>
+#include <rte_mbuf.h>
+#include <rte_mbuf_ptype.h>
+
+#include "gatekeeper_net.h"
+
+/*
+ * Return the L2 header length of a received packet.
+ *
+ * WARNING
+ *	Note that in order to use this function, @pkt must have first gone
+ *	through pkt_in_skip_l2() or another function to set its packet type.
+ */
+static inline size_t
+pkt_in_l2_hdr_len(struct rte_mbuf *pkt)
+{
+	return pkt->l2_type != RTE_PTYPE_L2_ETHER_VLAN
+		? sizeof(struct ether_hdr)
+		: sizeof(struct ether_hdr) + sizeof(struct vlan_hdr);
+}
+
+/*
+ * Skip the L2 header of the packet, skipping over any VLAN
+ * headers if present. A pointer to the next header is returned.
+ */
+static inline void *
+pkt_out_skip_l2(struct gatekeeper_if *iface, struct ether_hdr *eth_hdr)
+{
+	return ((uint8_t *)eth_hdr) + iface->l2_len_out;
+}
+
+/*
+ * Skip the L2 header of the packet, skipping over any VLAN
+ * headers if present. The EtherType of the next header is returned
+ * (in network order).
+ */
+static inline uint16_t
+pkt_in_skip_l2(struct rte_mbuf *pkt, struct ether_hdr *eth_hdr, void **next_hdr)
+{
+	RTE_VERIFY(next_hdr != NULL);
+
+	if (likely(eth_hdr->ether_type != rte_cpu_to_be_16(ETHER_TYPE_VLAN))) {
+		*next_hdr = &eth_hdr[1];
+		pkt->l2_type = RTE_PTYPE_UNKNOWN;
+		return eth_hdr->ether_type;
+	} else {
+		struct vlan_hdr *vlan_hdr = (struct vlan_hdr *)&eth_hdr[1];
+		*next_hdr = &vlan_hdr[1];
+		pkt->l2_type = RTE_PTYPE_L2_ETHER_VLAN;
+		return vlan_hdr->eth_proto;
+	}
+}
+
+/*
+ * Given an Ethernet header and room to put a VLAN header,
+ * set the EtherType field and the VLAN header fields
+ * using the given VLAN tag.
+ */
+static inline void
+fill_vlan_hdr(struct ether_hdr *eth_hdr, uint16_t vlan_tag_be,
+	uint16_t eth_proto)
+{
+	struct vlan_hdr *vlan_hdr = (struct vlan_hdr *)&eth_hdr[1];
+	eth_hdr->ether_type = rte_cpu_to_be_16(ETHER_TYPE_VLAN);
+	vlan_hdr->vlan_tci = vlan_tag_be;
+	vlan_hdr->eth_proto = rte_cpu_to_be_16(eth_proto);
+}
+
+struct ether_hdr *adjust_pkt_len(struct rte_mbuf *pkt,
+	struct gatekeeper_if *iface, int bytes_to_add);
+
+#endif /* _GATEKEEPER_L2_H_ */

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -322,12 +322,12 @@ struct nd_opt_lladdr {
 
 #define ND_NEIGH_HDR_MIN_LEN (sizeof(struct nd_neigh_msg))
 
-#define ND_NEIGH_PKT_MIN_LEN (sizeof(struct ether_hdr) + \
+#define ND_NEIGH_PKT_MIN_LEN(l2_len) (l2_len + \
 	sizeof(struct ipv6_hdr) + sizeof(struct icmpv6_hdr) + \
 	ND_NEIGH_HDR_MIN_LEN)
 
 /* Minimum size of a Neighbor Discovery packet with a link-layer option. */
-#define ND_NEIGH_PKT_LLADDR_MIN_LEN (ND_NEIGH_PKT_MIN_LEN + \
+#define ND_NEIGH_PKT_LLADDR_MIN_LEN(l2_len) (ND_NEIGH_PKT_MIN_LEN(l2_len) + \
 	sizeof(struct nd_opt_lladdr))
 
 /* Flags for Neighbor Advertisements. */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -130,10 +130,19 @@ struct gatekeeper_if {
 	/* The type of bonding used for this interface, if needed. */
 	uint32_t        bonding_mode;
 
+	/* Whether @vlan_tag should be applied to egress traffic. */
+	int             vlan_insert;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */
+
+	/* Link layer header length for egress packets from this interface. */
+	size_t          l2_len_out;
+
+	/* VLAN tag to be applied to all outbound packets, in network order. */
+	uint16_t        vlan_tag_be;
 
 	/* Ethernet address of this interface. */
 	struct ether_addr eth_addr;
@@ -316,7 +325,7 @@ lacp_enabled(struct net_config *net, struct gatekeeper_if *iface)
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_cidrs, uint8_t num_ip_cidrs);
+	const char **ip_cidrs, uint8_t num_ip_cidrs, uint16_t vlan_tag);
 void lua_free_iface(struct gatekeeper_if *iface);
 
 int get_ip_type(const char *ip_addr);

--- a/lib/l2.c
+++ b/lib/l2.c
@@ -1,0 +1,80 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gatekeeper_l2.h"
+
+/*
+ * Return the difference in the size of the L2 header between
+ * packet received (@pkt) and a packet that will be transmitted
+ * on @iface. This determines what changes have to be made to the
+ * L2 space of the packet.
+ *
+ * A negative number indicates that bytes need to be removed from
+ * the L2 space, and a positive number indicates that bytes need to
+ * be added to the L2 space.
+ *
+ * WARNING
+ *	Note that in order to use this function, @pkt must have first gone
+ *	through pkt_in_skip_l2() or another function to set its packet type.
+ */
+static inline int
+in_to_out_l2_diff(struct gatekeeper_if *iface, struct rte_mbuf *pkt)
+{
+	return iface->l2_len_out - pkt_in_l2_hdr_len(pkt);
+}
+
+/*
+ * Adjust a packet's length.
+ *
+ * The parameter @bytes_to_add represents the number of bytes to add for higher
+ * layers, if any, such as for an encapsulating network header. The function
+ * then also takes into account how many bytes are necessary for the L2 header.
+ * If @bytes_to_add is negative, bytes are removed from the packet.
+ */
+struct ether_hdr *
+adjust_pkt_len(struct rte_mbuf *pkt, struct gatekeeper_if *iface,
+	int bytes_to_add)
+{
+	struct ether_hdr *eth_hdr;
+
+	bytes_to_add += in_to_out_l2_diff(iface, pkt);
+	if (bytes_to_add > 0) {
+		eth_hdr = (struct ether_hdr *)rte_pktmbuf_prepend(pkt,
+			bytes_to_add);
+		if (eth_hdr == NULL) {
+			RTE_LOG(ERR, MBUF,
+				"Not enough headroom space in the first segment!\n");
+			return NULL;
+		}
+	} else if (bytes_to_add < 0) {
+		/*
+		 * @bytes_to_add is negative, so its magnitude is
+		 * the number of bytes we need to *remove*.
+		 */
+		eth_hdr = (struct ether_hdr *)rte_pktmbuf_adj(pkt,
+			-bytes_to_add);
+		if (eth_hdr == NULL) {
+			RTE_LOG(ERR, MBUF,
+				"Could not remove headroom space!\n");
+			return NULL;
+		}
+	} else
+		eth_hdr = rte_pktmbuf_mtod(pkt, struct ether_hdr *);
+
+	return eth_hdr;
+}

--- a/lib/net.c
+++ b/lib/net.c
@@ -504,7 +504,7 @@ convert_str_to_ip(const char *ip_addr, struct ipaddr *res)
 int
 lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_cidrs, uint8_t num_ip_cidrs)
+	const char **ip_cidrs, uint8_t num_ip_cidrs, uint16_t vlan_tag)
 {
 	uint8_t i, j;
 
@@ -638,6 +638,12 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 			}
 			iface->ip6_addr_plen = prefix_len;
 		}
+	}
+
+	iface->l2_len_out = sizeof(struct ether_hdr);
+	if (iface->vlan_insert) {
+		iface->vlan_tag_be = rte_cpu_to_be_16(vlan_tag);
+		iface->l2_len_out += sizeof(struct vlan_hdr);
 	}
 
 	return 0;

--- a/lib/net.c
+++ b/lib/net.c
@@ -57,16 +57,6 @@ uint8_t default_rss_key[GATEKEEPER_RSS_KEY_LEN] = {
 /* To support the optimized implementation of generic RSS hash function. */
 uint8_t rss_key_be[RTE_DIM(default_rss_key)];
 
-/*
- * TODO Add support for VLAN tags.
- *
- * Assume for now that hardware support is available for
- * VLAN stripping -- then only this configuration needs
- * to be changed.
- *
- * For VLAN insertion, hardware support can't be
- * assumed, so it must be added in software.
- */
 static struct rte_eth_conf gatekeeper_port_conf = {
 	.rxmode = {
 		.mq_mode = ETH_MQ_RX_RSS,

--- a/lls/arp.h
+++ b/lls/arp.h
@@ -43,7 +43,8 @@ void xmit_arp_req(struct gatekeeper_if *iface, const uint8_t *ip_be,
  * -1 if it does not need to be transmitted (and needs to be freed).
  */
 int process_arp(struct lls_config *lls_conf, struct gatekeeper_if *iface,
-	uint16_t tx_queue, struct rte_mbuf *buf, struct ether_hdr *eth_hdr);
+	uint16_t tx_queue, struct rte_mbuf *buf, struct ether_hdr *eth_hdr,
+	struct arp_hdr *arp_hdr);
 
 /* Print an ARP record. */
 void print_arp_record(struct lls_cache *cache, struct lls_record *record);

--- a/lls/cache.c
+++ b/lls/cache.c
@@ -320,11 +320,18 @@ lls_process_reqs(struct lls_config *lls_conf)
 				: lls_conf->tx_queue_back;
 			int i;
 			for (i = 0; i < arp->num_pkts; i++) {
+				struct rte_mbuf *pkt = arp->pkts[i];
+				struct ether_hdr *eth_hdr =
+					rte_pktmbuf_mtod(pkt,
+						struct ether_hdr *);
+				struct arp_hdr *arp_hdr =
+					rte_pktmbuf_mtod_offset(pkt,
+						struct arp_hdr *,
+						pkt_in_l2_hdr_len(pkt));
 				if (process_arp(lls_conf, arp->iface,
-						tx_queue, arp->pkts[i],
-						rte_pktmbuf_mtod(arp->pkts[i],
-						    struct ether_hdr *)) == -1)
-					rte_pktmbuf_free(arp->pkts[i]);
+						tx_queue, pkt,
+						eth_hdr, arp_hdr) == -1)
+					rte_pktmbuf_free(pkt);
 			}
 			break;
 		}

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -119,6 +119,7 @@ struct gatekeeper_if {
 	uint32_t arp_cache_timeout_sec;
 	uint32_t nd_cache_timeout_sec;
 	uint32_t bonding_mode;
+	int      vlan_insert;
 	/* This struct has hidden fields. */
 };
 
@@ -188,7 +189,7 @@ ffi.cdef[[
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_cidrs, uint8_t num_ip_cidrs);
+	const char **ip_cidrs, uint8_t num_ip_cidrs, uint16_t vlan_tag);
 void lua_free_iface(struct gatekeeper_if *iface);
 
 bool ipv4_configured(struct net_config *net_conf);
@@ -235,7 +236,7 @@ c = ffi.C
 
 local ifaces = require("if_map")
 
-function init_iface(iface, name, ports, cidrs)
+function init_iface(iface, name, ports, cidrs, vlan_tag)
 	local pci_strs = ffi.new("const char *[" .. #ports .. "]")
 	for i, v in ipairs(ports) do
 		local pci_addr = ifaces[v]
@@ -251,7 +252,7 @@ function init_iface(iface, name, ports, cidrs)
 	end
 
 	local ret = c.lua_init_iface(iface, name, pci_strs, #ports,
-		ip_cidrs, #cidrs)
+		ip_cidrs, #cidrs, vlan_tag)
 	if ret < 0 then
 		error("Failed to initilialize " .. name .. " interface")
 	end

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -12,6 +12,8 @@ return function (gatekeeper_server)
 	local front_arp_cache_timeout_sec = 7200
 	local front_nd_cache_timeout_sec = 7200
 	local front_bonding_mode = gatekeeper.c.BONDING_MODE_ROUND_ROBIN
+	local front_vlan_tag = 0x1234
+	local front_vlan_insert = true
 
 	local back_iface_enabled = gatekeeper_server
 	local back_ports = {"enp133s0f1"}
@@ -19,6 +21,8 @@ return function (gatekeeper_server)
 	local back_arp_cache_timeout_sec = 7200
 	local back_nd_cache_timeout_sec = 7200
 	local back_bonding_mode = gatekeeper.c.BONDING_MODE_ROUND_ROBIN
+	local back_vlan_tag = 0x5678
+	local back_vlan_insert = true
 
 	--
 	-- Code below this point should not need to be changed.
@@ -29,8 +33,9 @@ return function (gatekeeper_server)
 	front_iface.arp_cache_timeout_sec = front_arp_cache_timeout_sec
 	front_iface.nd_cache_timeout_sec = front_nd_cache_timeout_sec
 	front_iface.bonding_mode = front_bonding_mode
+	front_iface.vlan_insert = front_vlan_insert
 	local ret = gatekeeper.init_iface(front_iface, "front",
-		front_ports, front_ips)
+		front_ports, front_ips, front_vlan_tag)
 
 	net_conf.back_iface_enabled = back_iface_enabled
 	if back_iface_enabled then
@@ -38,8 +43,9 @@ return function (gatekeeper_server)
 		back_iface.arp_cache_timeout_sec = back_arp_cache_timeout_sec
 		back_iface.nd_cache_timeout_sec = back_nd_cache_timeout_sec
 		back_iface.bonding_mode = back_bonding_mode
+		back_iface.vlan_insert = back_vlan_insert
 		ret = gatekeeper.init_iface(back_iface, "back",
-			back_ports, back_ips)
+			back_ports, back_ips, back_vlan_tag)
 	end
 
 	-- Initialize the network.


### PR DESCRIPTION
These patches erase the assumption that the link-layer header is always just an Ethernet header, adding the possibility of a VLAN header as well.

I split up the work into two patches because it is a lot of small changes to many files that could be overwhelming to review at once.

The only piece missing is to fill-in the function that crafts the netlink message that adds a VLAN ID to the KNI. The code that I've written for it hasn't worked yet (keep getting operation not supported from the kernel), but it is pretty isolated from the bulk of the patches so a review can be started now if it's convenient.