### PR TITLE
gk/gt: maintain ECN bits

### DIFF
--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -33,6 +33,7 @@ struct gt_packet_headers {
 	uint16_t inner_ip_ver;
 	uint8_t l4_proto;
 	uint8_t priority;
+	uint8_t outer_ecn;
 
 	void *l2_hdr;
 	void *outer_l3_hdr;


### PR DESCRIPTION
Since Gatekeeper tunnels packets between Gatekeeper and Grantor servers, it should maintain the ECN bits so that congestion management is kept between the source and destination.
    
To do so, Gatekeeper implements the Full-functionality Option of maintaining the ECN bits for IP-in-IP packets (RFC 3168, 9.1.1).