### PR TITLE
Integrate the GT blocks with the LLS block

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -64,7 +64,7 @@ gk_lpm_add_ipv6_route(uint8_t *ip,
  * so we don't need a concurrencty mechanism here. However,
  * callers must ensure that the entry is not being used.
  */
-static int
+int
 clear_ether_cache(struct ether_cache *eth_cache)
 {
 	int ref_cnt;
@@ -364,7 +364,7 @@ lpm_del_route(struct ipaddr *ip_addr, int prefix_len, struct gk_lpm *ltbl)
 	return -1;
 }
 
-static int
+int
 setup_neighbor_tbl(unsigned int socket_id, int identifier,
 	int ip_ver, int ht_size, struct neighbor_hash_table *neigh)
 {

--- a/gk/main.c
+++ b/gk/main.c
@@ -285,7 +285,7 @@ drop_packet(struct rte_mbuf *pkt)
 /*
  * Return value indicates whether the cached Ethernet header is stale or not.
  */
-static int
+int
 pkt_copy_cached_eth_header(struct rte_mbuf *pkt, struct ether_cache *eth_cache)
 {
 	unsigned seq;

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -186,6 +186,9 @@ struct gk_lpm {
 
 struct gk_config;
 
+int clear_ether_cache(struct ether_cache *eth_cache);
+int setup_neighbor_tbl(unsigned int socket_id, int identifier,
+	int ip_ver, int ht_size, struct neighbor_hash_table *neigh);
 int setup_gk_lpm(struct gk_config *gk_conf, unsigned int socket_id);
 void destroy_neigh_hash_table(struct neighbor_hash_table *neigh);
 

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -146,6 +146,9 @@ int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
 struct mailbox *get_responsible_gk_mailbox(
 	const struct ip_flow *flow, const struct gk_config *gk_conf);
 
+int pkt_copy_cached_eth_header(
+	struct rte_mbuf *pkt, struct ether_cache *eth_cache);
+
 static inline void
 gk_conf_hold(struct gk_config *gk_conf)
 {

--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -26,19 +26,20 @@
 #include <rte_udp.h>
 #include <rte_atomic.h>
 
+#include "gatekeeper_fib.h"
 #include "gatekeeper_config.h"
 
 struct gt_packet_headers {
 	uint16_t outer_ip_ver;
 	uint16_t inner_ip_ver;
-	uint8_t l4_proto;
-	uint8_t priority;
-	uint8_t outer_ecn;
+	uint8_t  l4_proto;
+	uint8_t  priority;
+	uint8_t  outer_ecn;
 
-	void *l2_hdr;
-	void *outer_l3_hdr;
-	void *inner_l3_hdr;
-	void *l4_hdr;
+	void     *l2_hdr;
+	void     *outer_l3_hdr;
+	void     *inner_l3_hdr;
+	void     *l4_hdr;
 };
 
 /* Structures for each GT instance. */
@@ -51,6 +52,10 @@ struct gt_instance {
 
 	/* The lua state that belongs to the instance. */
 	lua_State     *lua_state;
+
+	/* The neighbor hash tables that stores the Ethernet cached headers. */
+	struct neighbor_hash_table neigh;
+	struct neighbor_hash_table neigh6;
 };
 
 /* Configuration for the GT functional block. */
@@ -58,6 +63,9 @@ struct gt_config {
 	/* The UDP source and destination port numbers for GK-GT Unit. */
 	uint16_t           ggu_src_port;
 	uint16_t           ggu_dst_port;
+
+	/* The maximum number of neighbor entries for the GT. */
+	int                max_num_ipv6_neighbors;
 
 	/*
 	 * The fields below are for internal use.

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -30,9 +30,9 @@
 
 #include "gatekeeper_flow.h"
 
-/* To mark whether Gatekeeper server configures IPv4 or IPv6. */
-#define GK_CONFIGURED_IPV4 (1)
-#define GK_CONFIGURED_IPV6 (2)
+/* To mark whether Gatekeeper/Grantor server configures IPv4 or IPv6. */
+#define CONFIGURED_IPV4 (1)
+#define CONFIGURED_IPV6 (2)
 
 #define IPv6_DEFAULT_VTC_FLOW   (0x60000000)
 #define IPv6_DEFAULT_HOP_LIMITS (0xFF)
@@ -330,13 +330,13 @@ bool ipv6_configured(struct net_config *net_conf);
 static inline bool
 ipv4_if_configured(struct gatekeeper_if *iface)
 {
-	return !!(iface->configured_proto & GK_CONFIGURED_IPV4);
+	return !!(iface->configured_proto & CONFIGURED_IPV4);
 }
 
 static inline bool
 ipv6_if_configured(struct gatekeeper_if *iface)
 {
-	return !!(iface->configured_proto & GK_CONFIGURED_IPV6);
+	return !!(iface->configured_proto & CONFIGURED_IPV6);
 }
 
 static inline int

--- a/lib/net.c
+++ b/lib/net.c
@@ -578,12 +578,12 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 		if (gk_type == AF_INET &&
 				inet_pton(AF_INET, ip_addr,
 				&iface->ip4_addr) == 1) {
-			iface->configured_proto |= GK_CONFIGURED_IPV4;
+			iface->configured_proto |= CONFIGURED_IPV4;
 		}
 		else if (gk_type == AF_INET6 &&
 				inet_pton(AF_INET6, ip_addr,
 				&iface->ip6_addr) == 1) {
-			iface->configured_proto |= GK_CONFIGURED_IPV6;
+			iface->configured_proto |= CONFIGURED_IPV6;
 		}
 		else
 			goto name;

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -155,6 +155,7 @@ struct lls_config {
 struct gt_config {
 	uint16_t     ggu_src_port;
 	uint16_t     ggu_dst_port;
+	int          max_num_ipv6_neighbors;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/gt.lua
+++ b/lua/gt.lua
@@ -16,6 +16,8 @@ return function (net_conf, numa_table)
 		n_lcores)
 	gatekeeper.gt_assign_lcores(gt_conf, gt_lcores)
 
+	gt_conf.max_num_ipv6_neighbors = 1024
+
 	-- Setup the GT functional block.
 	local ret = gatekeeper.c.run_gt(net_conf, gt_conf)
 	if ret < 0 then


### PR DESCRIPTION
This pull request includes two patches: the first one fixes a bug in GK block, and the second one integrates the GT blocks with the LLS block.

The basic idea for in the second patch is to keep one hash table per GT instance for caching Ethernet headers to the destinations in the data center protected by Gatekeeper, which avoids synchronization issues among different GT instances.