### PR TITLE
Remove requirements for hardware filters

### DIFF
--- a/ggu/main.c
+++ b/ggu/main.c
@@ -26,13 +26,24 @@
 #include <rte_ethdev.h>
 #include <rte_atomic.h>
 
+#include "gatekeeper_acl.h"
 #include "gatekeeper_ggu.h"
 #include "gatekeeper_gk.h"
-#include "gatekeeper_net.h"
 #include "gatekeeper_main.h"
 #include "gatekeeper_config.h"
 #include "gatekeeper_launch.h"
 #include "gatekeeper_varip.h"
+
+/* XXX Sample parameter, needs to be tested for better performance. */
+#define GGU_REQ_BURST_SIZE (32)
+
+static struct ggu_config *ggu_conf;
+
+static inline const char *
+filter_name(const struct gatekeeper_if *iface)
+{
+	return iface->hw_filter_ntuple ? "ntuple filter" : "ACL";
+}
 
 static void
 process_single_policy(const struct ggu_policy *policy, const struct ggu_config *ggu_conf)
@@ -87,18 +98,6 @@ process_single_policy(const struct ggu_policy *policy, const struct ggu_config *
 	mb_send_entry(mb, entry);
 }
 
-static inline uint8_t
-ipv4_hdr_len(struct ipv4_hdr *ip4hdr)
-{
-	return ((ip4hdr->version_ihl & 0xf) << 2);
-}
-
-static inline uint8_t *
-ipv4_skip_exthdr(struct ipv4_hdr *ip4hdr)
-{
-	return ((uint8_t *)ip4hdr + ipv4_hdr_len(ip4hdr));
-}
-
 static void
 process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 {
@@ -114,6 +113,7 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 	uint16_t expected_payload_len;
 	struct ggu_policy policy;
 	uint16_t minimum_size = sizeof(struct ether_hdr);
+	struct gatekeeper_if *back = &ggu_conf->net->back;
 
 	eth_hdr = rte_pktmbuf_mtod(pkt, struct ether_hdr *);
 	ether_type = rte_be_to_cpu_16(eth_hdr->ether_type);
@@ -133,13 +133,15 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 			struct ipv4_hdr *, sizeof(struct ether_hdr));
 		if (ip4hdr->next_proto_id != IPPROTO_UDP) {
 			RTE_LOG(ERR, GATEKEEPER,
-				"ggu: received non-UDP packets, IPv4 ntuple filter bug!\n");
+				"ggu: received non-UDP packets, IPv4 %s bug!\n",
+				filter_name(back));
 			goto free_packet;
 		}
 
-		if (ip4hdr->dst_addr != ggu_conf->net->back.ip4_addr.s_addr) {
+		if (ip4hdr->dst_addr != back->ip4_addr.s_addr) {
 			RTE_LOG(ERR, GATEKEEPER,
-				"ggu: received packets not destined to the Gatekeeper server, IPv4 ntuple filter bug!\n");
+				"ggu: received packets not destined to the Gatekeeper server, IPv4 %s bug!\n",
+				filter_name(back));
 			goto free_packet;
 		}
 
@@ -152,7 +154,7 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 		}
 
 		/*
-		 * The ntuple filter supports IPv4 variable headers.
+		 * The ntuple filter/ACL supports IPv4 variable headers.
 		 * The following code parses IPv4 variable headers.
 		 */
 		udphdr = (struct udp_hdr *)ipv4_skip_exthdr(ip4hdr);
@@ -176,7 +178,7 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 		}
 
 		/*
-		 * The ntuple filter supports IPv6 variable headers.
+		 * The ntuple filter/ACL supports IPv6 variable headers.
 		 * The following code parses IPv6 variable headers.
 		 */
 		ip6hdr = rte_pktmbuf_mtod_offset(pkt, 
@@ -188,8 +190,8 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 		 * If the IPv6 packet is not destined to
 		 * the Gatekeeper server, redirect the packet properly.
 		 */
-		if (memcmp(ip6hdr->dst_addr,
-				ggu_conf->net->back.ip6_addr.s6_addr,
+		if (back->hw_filter_ntuple && memcmp(ip6hdr->dst_addr,
+				back->ip6_addr.s6_addr,
 				sizeof(ip6hdr->dst_addr)) != 0) {
 			RTE_LOG(NOTICE, GATEKEEPER,
 				"ggu: received an IPv6 packet destinated to other host!\n");
@@ -206,7 +208,8 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 
 		if (nexthdr != IPPROTO_UDP) {
 			RTE_LOG(ERR, GATEKEEPER,
-				"ggu: received non-UDP packets, IPv6 ntuple filter bug!\n");
+				"ggu: received non-UDP packets, IPv6 %s bug!\n",
+				filter_name(back));
 			goto free_packet;
 		}
 
@@ -233,9 +236,10 @@ process_single_packet(struct rte_mbuf *pkt, const struct ggu_config *ggu_conf)
 	if (udphdr->src_port != ggu_conf->ggu_src_port ||
 			udphdr->dst_port != ggu_conf->ggu_dst_port) {
 		RTE_LOG(ERR, GATEKEEPER,
-			"ggu: unknown udp src port %hu, dst port %hu, ntuple filter bug!\n",
+			"ggu: unknown udp src port %hu, dst port %hu, %s bug!\n",
 			rte_be_to_cpu_16(udphdr->src_port),
-			rte_be_to_cpu_16(udphdr->dst_port));
+			rte_be_to_cpu_16(udphdr->dst_port),
+			filter_name(back));
 		goto free_packet;
 	}
 
@@ -321,6 +325,52 @@ free_packet:
 	rte_pktmbuf_free(pkt);
 }
 
+/* Information needed to submit GGU packets to the GGU block. */
+struct ggu_request {
+	/* GT-GK Unit packets. */
+	struct rte_mbuf *pkts[GATEKEEPER_MAX_PKT_BURST];
+
+	/* Number of packets stored in @pkts. */
+	unsigned int    num_pkts;
+};
+
+static int
+submit_ggu(struct rte_mbuf **pkts, unsigned int num_pkts,
+	__attribute__((unused)) struct gatekeeper_if *iface)
+{
+	struct ggu_request *req = mb_alloc_entry(&ggu_conf->mailbox);
+	unsigned int i;
+	int ret;
+
+	RTE_VERIFY(num_pkts <= RTE_DIM(req->pkts));
+
+	if (req == NULL) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"ggu: %s: allocation of mailbox message failed\n",
+			__func__);
+		ret = -ENOMEM;
+		goto free_pkts;
+	}
+
+	req->num_pkts = num_pkts;
+	rte_memcpy(req->pkts, pkts, sizeof(*req->pkts) * num_pkts);
+
+	ret = mb_send_entry(&ggu_conf->mailbox, req);
+	if (ret < 0) {
+		RTE_LOG(ERR, GATEKEEPER,
+			"ggu: %s: failed to enqueue message to mailbox\n",
+			__func__);
+		goto free_pkts;
+	}
+
+	return 0;
+
+free_pkts:
+	for (i = 0; i < num_pkts; i++)
+		rte_pktmbuf_free(pkts[i]);
+	return ret;
+}
+
 static int
 ggu_proc(void *arg)
 {
@@ -328,23 +378,45 @@ ggu_proc(void *arg)
 	struct ggu_config *ggu_conf = (struct ggu_config *)arg;
 	uint8_t port_in = ggu_conf->net->back.id;
 	uint16_t rx_queue = ggu_conf->rx_queue_back;
+	unsigned int i;
 
 	RTE_LOG(NOTICE, GATEKEEPER,
 		"ggu: the GK-GT unit is running at lcore = %u\n", lcore);
 
-	while (likely(!exiting)) {
-		uint16_t i;
-		uint16_t num_rx;
-		struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
+	/*
+	 * Load a set of GK-GT packets from the back NIC
+	 * or from the GGU mailbox.
+	 */
+	if (ggu_conf->net->back.hw_filter_ntuple) {
+		while (likely(!exiting)) {
+			struct rte_mbuf *bufs[GATEKEEPER_MAX_PKT_BURST];
+			uint16_t num_rx = rte_eth_rx_burst(port_in, rx_queue,
+				bufs, GATEKEEPER_MAX_PKT_BURST);
 
-		/* Load a set of GK-GT packets from the back NIC. */
-		num_rx = rte_eth_rx_burst(port_in, rx_queue, bufs,
-			GATEKEEPER_MAX_PKT_BURST);
-		if (unlikely(num_rx == 0))
-			continue;
+			if (unlikely(num_rx == 0))
+				continue;
 
-		for (i = 0; i < num_rx; i++)
-			process_single_packet(bufs[i], ggu_conf);
+			for (i = 0; i < num_rx; i++)
+				process_single_packet(bufs[i], ggu_conf);
+		}
+	} else {
+		while (likely(!exiting)) {
+			struct ggu_request *reqs[GGU_REQ_BURST_SIZE];
+			unsigned int num_reqs =
+				mb_dequeue_burst(&ggu_conf->mailbox,
+				(void **)reqs, GGU_REQ_BURST_SIZE);
+
+			if (unlikely(num_reqs == 0))
+				continue;
+
+			for (i = 0; i < num_reqs; i++) {
+				unsigned int j;
+				for (j = 0; j < reqs[i]->num_pkts; j++) {
+					process_single_packet(reqs[i]->pkts[j],
+						ggu_conf);
+				}
+			}
+		}
 	}
 
 	RTE_LOG(NOTICE, GATEKEEPER,
@@ -353,7 +425,7 @@ ggu_proc(void *arg)
 }
 
 static int
-ggu_state1(void *arg)
+ggu_stage1(void *arg)
 {
 	struct ggu_config *ggu_conf = arg;
 	int ret = get_queue_id(&ggu_conf->net->back, QUEUE_TYPE_RX,
@@ -367,20 +439,103 @@ ggu_state1(void *arg)
 	return 0;
 }
 
+static void
+fill_ggu4_rule(struct ipv4_acl_rule *rule, struct ggu_config *ggu_conf)
+{
+	rule->data.category_mask = 0x1;
+	rule->data.priority = 1;
+	/* Userdata is filled in in register_ipv4_acl(). */
+
+	rule->field[PROTO_FIELD_IPV4].value.u8 = IPPROTO_UDP;
+	rule->field[PROTO_FIELD_IPV4].mask_range.u8 = 0xFF;
+
+	rule->field[DST_FIELD_IPV4].value.u32 =
+		rte_be_to_cpu_32(ggu_conf->net->back.ip4_addr.s_addr);
+	rule->field[DST_FIELD_IPV4].mask_range.u32 = 32;
+
+	rule->field[SRCP_FIELD_IPV4].value.u16 = ggu_conf->ggu_src_port;
+	rule->field[SRCP_FIELD_IPV4].mask_range.u16 = 0xFFFF;
+	rule->field[DSTP_FIELD_IPV4].value.u16 = ggu_conf->ggu_dst_port;
+	rule->field[DSTP_FIELD_IPV4].mask_range.u16 = 0xFFFF;
+}
+
+static void
+fill_ggu6_rule(struct ipv6_acl_rule *rule, struct ggu_config *ggu_conf)
+{
+	uint32_t *ptr32 = (uint32_t *)&ggu_conf->net->back.ip6_addr.s6_addr;
+	int i;
+
+	rule->data.category_mask = 0x1;
+	rule->data.priority = 1;
+	/* Userdata is filled in in register_ipv6_acl(). */
+
+	rule->field[PROTO_FIELD_IPV6].value.u8 = IPPROTO_UDP;
+	rule->field[PROTO_FIELD_IPV6].mask_range.u8 = 0xFF;
+
+	for (i = DST1_FIELD_IPV6; i <= DST4_FIELD_IPV6; i++) {
+		rule->field[i].value.u32 = rte_be_to_cpu_32(*ptr32);
+		rule->field[i].mask_range.u32 = 32;
+		ptr32++;
+	}
+
+	rule->field[SRCP_FIELD_IPV6].value.u16 = ggu_conf->ggu_src_port;
+	rule->field[SRCP_FIELD_IPV6].mask_range.u16 = 0xFFFF;
+	rule->field[DSTP_FIELD_IPV6].value.u16 = ggu_conf->ggu_dst_port;
+	rule->field[DSTP_FIELD_IPV6].mask_range.u16 = 0xFFFF;
+}
+
 static int
-ggu_state2(void *arg)
+ggu_stage2(void *arg)
 {
 	struct ggu_config *ggu_conf = arg;
+	bool ipv4_configured = ipv4_if_configured(&ggu_conf->net->back);
+	bool ipv6_configured = ipv6_if_configured(&ggu_conf->net->back);
+	struct ipv4_acl_rule ipv4_rule = { };
+	struct ipv6_acl_rule ipv6_rule = { };
+	int ret;
 
 	/*
 	 * Setup the ntuple filters that assign the GK-GT packets
 	 * to its queue for both IPv4 and IPv6 addresses.
 	 */
-	return ntuple_filter_add(ggu_conf->net->back.id,
-		ggu_conf->net->back.ip4_addr.s_addr,
-		ggu_conf->ggu_src_port, UINT16_MAX,
-		ggu_conf->ggu_dst_port, UINT16_MAX,
-		IPPROTO_UDP, ggu_conf->rx_queue_back, false);
+	if (ggu_conf->net->back.hw_filter_ntuple) {
+		return ntuple_filter_add(ggu_conf->net->back.id,
+			ggu_conf->net->back.ip4_addr.s_addr,
+			ggu_conf->ggu_src_port, UINT16_MAX,
+			ggu_conf->ggu_dst_port, UINT16_MAX,
+			IPPROTO_UDP, ggu_conf->rx_queue_back,
+			ipv4_configured, ipv6_configured);
+	}
+
+	/*
+	 * ntuple filter is not supported, so add ACL rules
+	 * to capture GGU packets. Since the channel that
+	 * GGU packets are sent through is controlled by
+	 * Gatekeeper, GGU packets won't have variable
+	 * headers, so we don't need a match function.
+	 */
+
+	if (ipv4_configured) {
+		fill_ggu4_rule(&ipv4_rule, ggu_conf);
+		ret = register_ipv4_acl(&ipv4_rule, 1,
+			submit_ggu, NULL, &ggu_conf->net->back);
+		if (ret < 0) {
+			RTE_LOG(ERR, GATEKEEPER, "ggu: could not register IPv4 GGU ACL on back iface\n");
+			return ret;
+		}
+	}
+
+	if (ipv6_configured) {
+		fill_ggu6_rule(&ipv6_rule, ggu_conf);
+		ret = register_ipv6_acl(&ipv6_rule, 1,
+			submit_ggu, NULL, &ggu_conf->net->back);
+		if (ret < 0) {
+			RTE_LOG(ERR, GATEKEEPER, "ggu: could not register IPv6 GGU ACL on back iface\n");
+			return ret;
+		}
+	}
+
+	return 0;
 }
 
 int
@@ -400,11 +555,11 @@ run_ggu(struct net_config *net_conf,
 		goto out;
 	}
 
-	ret = net_launch_at_stage1(net_conf, 0, 0, 1, 0, ggu_state1, ggu_conf);
+	ret = net_launch_at_stage1(net_conf, 0, 0, 1, 0, ggu_stage1, ggu_conf);
 	if (ret < 0)
 		goto out;
 
-	ret = launch_at_stage2(ggu_state2, ggu_conf);
+	ret = launch_at_stage2(ggu_stage2, ggu_conf);
 	if (ret < 0)
 		goto stage1;
 
@@ -423,9 +578,15 @@ run_ggu(struct net_config *net_conf,
 	ggu_conf->ggu_src_port = rte_cpu_to_be_16(ggu_conf->ggu_src_port);
 	ggu_conf->ggu_dst_port = rte_cpu_to_be_16(ggu_conf->ggu_dst_port);
 
-	ret = 0;
-	goto out;
+	ret = init_mailbox("ggu_mb", MAILBOX_MAX_ENTRIES,
+		sizeof(struct ggu_request), ggu_conf->lcore_id,
+		&ggu_conf->mailbox);
+	if (ret < 0)
+		goto stage3;
 
+	goto out;
+stage3:
+	pop_n_at_stage3(1);
 stage2:
 	pop_n_at_stage2(1);
 stage1:
@@ -443,9 +604,11 @@ alloc_ggu_conf(void)
 {
 	static rte_atomic16_t num_ggu_conf_alloc = RTE_ATOMIC16_INIT(0);
 
-	if (rte_atomic16_test_and_set(&num_ggu_conf_alloc) == 1)
-		return rte_calloc("ggu_config", 1, sizeof(struct ggu_config), 0);
-	else {
+	if (rte_atomic16_test_and_set(&num_ggu_conf_alloc) == 1) {
+		ggu_conf = rte_calloc("ggu_config", 1,
+			sizeof(struct ggu_config), 0);
+		return ggu_conf;
+	} else {
 		RTE_LOG(ERR, GATEKEEPER,
 			"ggu: trying to allocate the second instance of struct ggu_config\n");
 		return NULL;
@@ -455,6 +618,7 @@ alloc_ggu_conf(void)
 int
 cleanup_ggu(struct ggu_config *ggu_conf)
 {
+	destroy_mailbox(&ggu_conf->mailbox);
 	ggu_conf->net = NULL;
 	gk_conf_put(ggu_conf->gk);
 	ggu_conf->gk = NULL;

--- a/gt/main.c
+++ b/gt/main.c
@@ -35,6 +35,7 @@
 #include "gatekeeper_ipip.h"
 #include "gatekeeper_gk.h"
 #include "gatekeeper_gt.h"
+#include "gatekeeper_lls.h"
 #include "gatekeeper_main.h"
 #include "gatekeeper_net.h"
 #include "gatekeeper_launch.h"
@@ -81,10 +82,10 @@ gt_parse_incoming_pkt(struct rte_mbuf *pkt, struct gt_packet_headers *info)
 	struct ipv6_hdr *inner_ipv6_hdr = NULL;
 
 	info->l2_hdr = eth_hdr;
-	info->outer_ip_ver = rte_be_to_cpu_16(eth_hdr->ether_type);
+	info->outer_ethertype = rte_be_to_cpu_16(eth_hdr->ether_type);
 	info->outer_l3_hdr = &eth_hdr[1];
 
-	switch (info->outer_ip_ver) {
+	switch (info->outer_ethertype) {
 	case ETHER_TYPE_IPv4:
 		if (pkt->data_len < parsed_len + sizeof(struct ipv4_hdr))
 			return -1;
@@ -191,12 +192,12 @@ static inline bool
 is_valid_dest_addr(struct gt_config *gt_conf,
 	struct gt_packet_headers *pkt_info)
 {
-	return (pkt_info->outer_ip_ver == ETHER_TYPE_IPv4 &&
+	return (pkt_info->outer_ethertype == ETHER_TYPE_IPv4 &&
 			((struct ipv4_hdr *)
 			pkt_info->outer_l3_hdr)->dst_addr
 			== gt_conf->net->front.ip4_addr.s_addr)
 			||
-			(pkt_info->outer_ip_ver == ETHER_TYPE_IPv6 &&
+			(pkt_info->outer_ethertype == ETHER_TYPE_IPv6 &&
 			memcmp(((struct ipv6_hdr *)
 			pkt_info->outer_l3_hdr)->dst_addr,
 			gt_conf->net->front.ip6_addr.s6_addr,
@@ -209,7 +210,7 @@ print_ip_err_msg(struct gt_packet_headers *pkt_info)
 	char src[128];
 	char dst[128];
 
-	if (pkt_info->outer_ip_ver == ETHER_TYPE_IPv4) {
+	if (pkt_info->outer_ethertype == ETHER_TYPE_IPv4) {
 		if (inet_ntop(AF_INET, &((struct ipv4_hdr *)
 				pkt_info->outer_l3_hdr)->src_addr,
 				src, sizeof(struct in_addr)) == NULL) {
@@ -507,7 +508,7 @@ decap_and_fill_eth(struct rte_mbuf *m, struct gt_config *gt_conf,
 	} else
 		return -1;
 
-	if (pkt_info->outer_ip_ver == ETHER_TYPE_IPv4)
+	if (pkt_info->outer_ethertype == ETHER_TYPE_IPv4)
 		outer_ip_len = sizeof(struct ipv4_hdr);
 	else
 		outer_ip_len = sizeof(struct ipv6_hdr);
@@ -536,7 +537,7 @@ fill_eth_hdr_reverse(struct ether_hdr *eth_hdr,
 	struct ether_hdr *raw_eth = (struct ether_hdr *)pkt_info->l2_hdr;
 	ether_addr_copy(&raw_eth->s_addr, &eth_hdr->d_addr);
 	ether_addr_copy(&raw_eth->d_addr, &eth_hdr->s_addr);
-	eth_hdr->ether_type = rte_cpu_to_be_16(pkt_info->outer_ip_ver);
+	eth_hdr->ether_type = rte_cpu_to_be_16(pkt_info->outer_ethertype);
 }
 
 static struct rte_mbuf *
@@ -544,7 +545,7 @@ alloc_and_fill_notify_pkt(unsigned int socket, struct ggu_policy *policy,
 	struct gt_packet_headers *pkt_info, struct gt_config *gt_conf)
 {
 	uint8_t *data;
-	uint16_t ethertype = pkt_info->outer_ip_ver;
+	uint16_t ethertype = pkt_info->outer_ethertype;
 	struct ether_hdr *notify_eth;
 	struct ipv4_hdr *notify_ipv4;
 	struct ipv6_hdr *notify_ipv6;
@@ -735,8 +736,10 @@ gt_proc(void *arg)
 		uint16_t num_rx;
 		uint16_t num_tx = 0;
 		uint16_t num_tx_succ;
+		uint16_t num_arp = 0;
 		struct rte_mbuf *rx_bufs[GATEKEEPER_MAX_PKT_BURST];
 		struct rte_mbuf *tx_bufs[GATEKEEPER_MAX_PKT_BURST];
+		struct rte_mbuf *arp_bufs[GATEKEEPER_MAX_PKT_BURST];
 		IPV6_ACL_SEARCH_DEF(acl);
 
 		/* Load a set of packets from the front NIC. */
@@ -762,8 +765,12 @@ gt_proc(void *arg)
 			 */
 			ret = gt_parse_incoming_pkt(m, &pkt_info);
 			if (ret < 0) {
-				if (pkt_info.outer_ip_ver == ETHER_TYPE_IPv6) {
+				switch (pkt_info.outer_ethertype) {
+				case ETHER_TYPE_IPv6:
 					add_pkt_ipv6_acl(&acl, m);
+					continue;
+				case ETHER_TYPE_ARP:
+					arp_bufs[num_arp++] = m;
 					continue;
 				}
 
@@ -837,6 +844,9 @@ gt_proc(void *arg)
 			for (i = num_tx_succ; i < num_tx; i++)
 				rte_pktmbuf_free(tx_bufs[i]);
 		}
+
+		if (num_arp > 0)
+			submit_arp(arp_bufs, num_arp, &gt_conf->net->front);
 
 		process_pkts_ipv6_acl(&gt_conf->net->front, lcore, &acl);
 	}

--- a/include/gatekeeper_acl.h
+++ b/include/gatekeeper_acl.h
@@ -22,6 +22,86 @@
 #include "gatekeeper_config.h"
 #include "gatekeeper_net.h"
 
+struct acl_search {
+	/* References to the start of the IP header in each packet. */
+	const uint8_t   *data[GATEKEEPER_MAX_PKT_BURST];
+	/* References to each packet's mbuf. */
+	struct rte_mbuf *mbufs[GATEKEEPER_MAX_PKT_BURST];
+	/* The classification results for each packet. */
+	uint32_t        res[GATEKEEPER_MAX_PKT_BURST];
+	/* The number of packets held for classification. */
+	unsigned int    num;
+};
+
+#define ACL_SEARCH_DEF(name) struct acl_search name = { .num = 0, }
+
+/* Classify batches of packets in @acl and invoke callback functions. */
+int process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
+	struct acl_search *acl, struct acl_state *astate,
+	bool proto_if_configured, const char *proto_name);
+/* Free ACLs. */
+void destroy_acls(struct acl_state *astate);
+
+/* This function expects that the mbuf includes the Ethernet header. */
+static inline void
+add_pkt_acl(struct acl_search *acl, struct rte_mbuf *pkt)
+{
+	acl->data[acl->num] = rte_pktmbuf_mtod_offset(pkt, uint8_t *,
+		sizeof(struct ether_hdr));
+	acl->mbufs[acl->num] = pkt;
+	acl->num++;
+}
+
+static inline int
+process_pkts_acl(struct gatekeeper_if *iface, unsigned int lcore,
+	struct acl_search *acl, uint16_t proto)
+{
+	if (acl->num == 0)
+		return 0;
+
+	switch (proto) {
+	case ETHER_TYPE_IPv4:
+		return process_acl(iface, lcore, acl, &iface->ipv4_acls,
+			ipv4_if_configured(iface), "IPv4");
+	case ETHER_TYPE_IPv6:
+		return process_acl(iface, lcore, acl, &iface->ipv6_acls,
+			ipv6_if_configured(iface), "IPv6");
+	default:
+		rte_panic("%s: called on unknown protocol %hu\n",
+			__func__, proto);
+	}
+}
+
+/*
+ * IPv4 ACLs.
+ */
+
+/* Fields that can be checked in an IPv4 ACL rule. */
+enum {
+	PROTO_FIELD_IPV4,
+	DST_FIELD_IPV4,
+	SRCP_FIELD_IPV4,
+	DSTP_FIELD_IPV4,
+	NUM_FIELDS_IPV4,
+};
+
+extern struct rte_acl_field_def ipv4_defs[NUM_FIELDS_IPV4];
+RTE_ACL_RULE_DEF(ipv4_acl_rule, RTE_DIM(ipv4_defs));
+
+/* Allocate IPv4 ACLs. */
+int init_ipv4_acls(struct gatekeeper_if *iface);
+
+/* Register IPv4 ACL rules and callback functions. */
+int register_ipv4_acl(struct ipv4_acl_rule *rules, unsigned int num_rules,
+	acl_cb_func cb_f, ext_cb_func ext_cb_f, struct gatekeeper_if *iface);
+
+/* Build the ACL trie. This should be invoked after all ACL rules are added. */
+int build_ipv4_acls(struct gatekeeper_if *iface);
+
+/*
+ * IPv6 ACLs.
+ */
+
 /* Fields that can be checked in an IPv6 ACL rule. */
 enum {
 	PROTO_FIELD_IPV6,
@@ -38,20 +118,8 @@ enum {
 extern struct rte_acl_field_def ipv6_defs[NUM_FIELDS_IPV6];
 RTE_ACL_RULE_DEF(ipv6_acl_rule, RTE_DIM(ipv6_defs));
 
-struct acl_search {
-	/* References to the start of the IPv6 header in each packet. */
-	const uint8_t   *data[GATEKEEPER_MAX_PKT_BURST];
-	/* References to each packet's mbuf. */
-	struct rte_mbuf *mbufs[GATEKEEPER_MAX_PKT_BURST];
-	/* The classification results for each packet. */
-	uint32_t        res[GATEKEEPER_MAX_PKT_BURST];
-	/* The number of packets held for classification. */
-	unsigned int    num;
-};
-
-/* Allocate and free IPv6 ACLs. */
+/* Allocate IPv6 ACLs. */
 int init_ipv6_acls(struct gatekeeper_if *iface);
-void destroy_ipv6_acls(struct gatekeeper_if *iface);
 
 /* Register IPv6 ACL rules and callback functions. */
 int register_ipv6_acl(struct ipv6_acl_rule *rules, unsigned int num_rules,
@@ -59,32 +127,5 @@ int register_ipv6_acl(struct ipv6_acl_rule *rules, unsigned int num_rules,
 
 /* Build the ACL trie. This should be invoked after all ACL rules are added. */
 int build_ipv6_acls(struct gatekeeper_if *iface);
-
-/* Classify batches of packets in @acl and invoke callback functions. */
-int process_ipv6_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
-	struct acl_search *acl);
-
-/* Definitions for blocks making use of the IPv6 ACLs. */
-
-#define IPV6_ACL_SEARCH_DEF(name) struct acl_search name = { .num = 0, }
-
-/* This function expects that the mbuf includes the Ethernet header. */
-static inline void
-add_pkt_ipv6_acl(struct acl_search *acl, struct rte_mbuf *pkt)
-{
-	acl->data[acl->num] = rte_pktmbuf_mtod_offset(pkt, uint8_t *,
-		sizeof(struct ether_hdr));
-	acl->mbufs[acl->num] = pkt;
-	acl->num++;
-}
-
-static inline int
-process_pkts_ipv6_acl(struct gatekeeper_if *iface, unsigned int lcore,
-	struct acl_search *acl)
-{
-	if (acl->num == 0)
-		return 0;
-	return process_ipv6_acl(iface, lcore, acl);
-}
 
 #endif /* _GATEKEEPER_ACL_H_ */

--- a/include/gatekeeper_ggu.h
+++ b/include/gatekeeper_ggu.h
@@ -19,6 +19,7 @@
 #ifndef _GATEKEEPER_GGU_H_
 #define _GATEKEEPER_GGU_H_
 
+#include "gatekeeper_mailbox.h"
 #include "gatekeeper_net.h"
 #include "gatekeeper_flow.h"
 
@@ -41,6 +42,9 @@ struct ggu_config {
 	uint16_t          rx_queue_back;
 	struct net_config *net;
 	struct gk_config  *gk;
+
+	/* Mailbox to hold requests from other blocks. */
+	struct mailbox    mailbox;
 };
 
 /*

--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -30,7 +30,7 @@
 #include "gatekeeper_config.h"
 
 struct gt_packet_headers {
-	uint16_t outer_ip_ver;
+	uint16_t outer_ethertype;
 	uint16_t inner_ip_ver;
 	uint8_t  l4_proto;
 	uint8_t  priority;

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -47,7 +47,9 @@ enum lls_req_ty {
 	 * be invoked again.
 	 */
 	LLS_REQ_PUT,
-	/* Request to handle an ND packet received from another block. */
+	/* Request to handle ARP packets received from another block. */
+	LLS_REQ_ARP,
+	/* Request to handle ND packets received from another block. */
 	LLS_REQ_ND,
 };
 
@@ -372,6 +374,10 @@ ipv6_addrs_equal(const uint8_t *addr1, const uint8_t *addr2)
 	const uint64_t *paddr2 = (const uint64_t *)addr2;
 	return (paddr1[0] == paddr2[0]) && (paddr1[1] == paddr2[1]);
 }
+
+/* Submit ARP packets to the LLS block (hardware filtering is not available). */
+void submit_arp(struct rte_mbuf **pkts, unsigned int num_pkts,
+	struct gatekeeper_if *iface);
 
 struct lls_config *get_lls_conf(void);
 int run_lls(struct net_config *net_conf, struct lls_config *lls_conf);

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -225,6 +225,9 @@ struct gatekeeper_if {
 
 	/* Number of ACL types installed in @acl_funcs. */
 	unsigned int       acl_func_count;
+
+	/* Whether the EtherType filter can be used on this interface. */
+	bool               hw_filter_eth;
 };
 
 /*

--- a/include/gatekeeper_varip.h
+++ b/include/gatekeeper_varip.h
@@ -28,6 +28,18 @@
  * use the functionality provided by this library.
  */
 
+static inline uint8_t
+ipv4_hdr_len(struct ipv4_hdr *ip4hdr)
+{
+	return ((ip4hdr->version_ihl & 0xf) << 2);
+}
+
+static inline uint8_t *
+ipv4_skip_exthdr(struct ipv4_hdr *ip4hdr)
+{
+	return ((uint8_t *)ip4hdr + ipv4_hdr_len(ip4hdr));
+}
+
 /*
  * Skip any extension headers.
  *

--- a/lib/acl.c
+++ b/lib/acl.c
@@ -20,7 +20,309 @@
 #include "gatekeeper_lls.h"
 
 /* Maximum number of rules installed per ACL. */
-#define MAX_NUM_IPV6_ACL_RULES (32)
+#define MAX_NUM_ACL_RULES (32)
+
+/* Callback function for when there's no classification match. */
+static int
+drop_unmatched_pkts(struct rte_mbuf **pkts, unsigned int num_pkts,
+	__attribute__((unused)) struct gatekeeper_if *iface)
+{
+	unsigned int i;
+	for (i = 0; i < num_pkts; i++) {
+		/*
+		 * WARNING
+		 *   A packet has reached a Gatekeeper server,
+		 *   and Gatekeeper doesn't know what to do with
+		 *   this packet. If attackers are able to send
+		 *   these packets, they may be able to slow
+		 *   Gatekeeper down since Gatekeeper does a lot of
+		 *   processing to eventually discard these packets.
+		 */
+		RTE_LOG(WARNING, GATEKEEPER,
+			"acl: a packet failed to match any ACL rules, the whole packet is dumped below:\n");
+		/*
+		 * XXX The default output used DPDK logging system
+		 * is stderr. The stream should be consistent with
+		 * the DPDK logging system.
+		 */
+		rte_pktmbuf_dump(stderr, pkts[i], pkts[i]->pkt_len);
+		rte_pktmbuf_free(pkts[i]);
+	}
+
+	return 0;
+}
+
+int
+process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
+	struct acl_search *acl, struct acl_state *astate,
+	bool proto_if_configured, const char *proto_name)
+{
+	struct rte_mbuf *pkts[astate->func_count][GATEKEEPER_MAX_PKT_BURST];
+	int num_pkts[astate->func_count];
+	unsigned int socket_id = rte_lcore_to_socket_id(lcore_id);
+	unsigned int i;
+	int ret;
+
+	if (unlikely(!proto_if_configured)) {
+		ret = 0;
+		goto drop_acl_pkts;
+	}
+
+	ret = rte_acl_classify(astate->acls[socket_id],
+		acl->data, acl->res, acl->num, 1);
+	if (unlikely(ret < 0)) {
+		RTE_LOG(ERR, ACL,
+			"invalid arguments given to %s rte_acl_classify()\n",
+			proto_name);
+		goto drop_acl_pkts;
+	}
+
+	/* Split packets into separate buffers -- one for each type. */
+	memset(num_pkts, 0, sizeof(num_pkts));
+	for (i = 0; i < acl->num; i++) {
+		int type = acl->res[i];
+		if (type == RTE_ACL_INVALID_USERDATA) {
+			unsigned int j;
+			/*
+			 * @j starts at 1 to skip RTE_ACL_INVALID_USERDATA,
+			 * which has no matching function.
+			 */
+			for (j = 1; j < astate->func_count; j++) {
+				/* Skip over ACLs without matching function. */
+				if (astate->ext_funcs[j] == NULL)
+					continue;
+				ret = astate->ext_funcs[j](
+					acl->mbufs[i], iface);
+				if (ret == 0) {
+					type = j;
+					break;
+				}
+			}
+		}
+
+		pkts[type][num_pkts[type]++] = acl->mbufs[i];
+	}
+
+	/* Transmit separate buffers to registered ACL functions. */
+	for (i = 0; i < astate->func_count; i++) {
+		if (num_pkts[i] == 0)
+			continue;
+
+		ret = astate->funcs[i](pkts[i], num_pkts[i], iface);
+		if (unlikely(ret < 0)) {
+			/*
+			 * Each ACL function is responsible for
+			 * freeing packets not already handled.
+			 */
+			RTE_LOG(WARNING, GATEKEEPER,
+				"acl: %s ACL function %d failed on %s iface\n",
+				proto_name, i, iface->name);
+		}
+	}
+
+	ret = 0;
+	goto out;
+
+drop_acl_pkts:
+
+	for (i = 0; i < acl->num; i++)
+		rte_pktmbuf_free(acl->mbufs[i]);
+
+out:
+	acl->num = 0;
+	return ret;
+}
+
+void
+destroy_acls(struct acl_state *astate)
+{
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+	for (i = 0; i < numa_nodes; i++) {
+		rte_acl_free(astate->acls[i]);
+		astate->acls[i] = NULL;
+	}
+}
+
+/*
+ * IPv4 ACLs.
+ */
+
+/*
+ * Input indices for the IPv4-related ACL fields. Fields are given
+ * unique identifiers, but since the DPDK ACL library processes
+ * each packet in four-byte chunks, the fields need to be grouped
+ * into four-byte input indices. Therefore, adjacent fields may
+ * share the same input index. For example, TCP and UDP ports are
+ * two-byte contiguous fields forming four consecutive bytes, so
+ * they could have the same input index.
+ */
+enum {
+	PROTO_INPUT_IPV4,
+	DST_INPUT_IPV4,
+	/* Source/destination ports are grouped together. */
+	PORTS_INPUT_IPV4,
+	NUM_INPUTS_IPV4,
+};
+
+/*
+ * All IPv4 fields involved in classification; not all fields must
+ * be specified for every rule. Fields must be grouped into sets of
+ * four bytes, except for the first field.
+ */
+struct rte_acl_field_def ipv4_defs[NUM_FIELDS_IPV4] = {
+	{
+		.type = RTE_ACL_FIELD_TYPE_BITMASK,
+		.size = sizeof(uint8_t),
+		.field_index = PROTO_FIELD_IPV4,
+		.input_index = PROTO_INPUT_IPV4,
+		.offset = offsetof(struct ipv4_hdr, next_proto_id),
+	},
+	{
+		.type = RTE_ACL_FIELD_TYPE_MASK,
+		.size = sizeof(uint32_t),
+		.field_index = DST_FIELD_IPV4,
+		.input_index = DST_INPUT_IPV4,
+		.offset = offsetof(struct ipv4_hdr, dst_addr),
+	},
+	/*
+	 * The source and destination ports are the first and second
+	 * fields in TCP and UDP, so they are the four bytes directly
+	 * following the IPv4 header.
+	 */
+	{
+		.type = RTE_ACL_FIELD_TYPE_BITMASK,
+		.size = sizeof(uint16_t),
+		.field_index = SRCP_FIELD_IPV4,
+		.input_index = PORTS_INPUT_IPV4,
+		.offset = sizeof(struct ipv4_hdr),
+	},
+	{
+		.type = RTE_ACL_FIELD_TYPE_BITMASK,
+		.size = sizeof(uint16_t),
+		.field_index = DSTP_FIELD_IPV4,
+		.input_index = PORTS_INPUT_IPV4,
+		.offset = sizeof(struct ipv4_hdr) + sizeof(uint16_t),
+	},
+};
+
+/*
+ * For each ACL rule set, register a match function that parses
+ * the unmatched IPv4 packets, and direct them to the corresponding
+ * blocks or drop them. This functionality is for the ext_cb_f parameter
+ * and that it's necessary because of variable IP headers that
+ * may not match the ACLs.
+ *
+ * WARNING
+ *   You must only register filters that are not subject to
+ *   the control of attackers. Otherwise, attackers can overwhelm
+ *   Gatekeeper servers since the current implementation of these filters
+ *   is not very efficient due to the variable header of IP.
+ */
+int
+register_ipv4_acl(struct ipv4_acl_rule *ipv4_rules, unsigned int num_rules,
+	acl_cb_func cb_f, ext_cb_func ext_cb_f, struct gatekeeper_if *iface)
+{
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+
+	if (iface->ipv4_acls.func_count == GATEKEEPER_ACL_MAX) {
+		RTE_LOG(ERR, GATEKEEPER, "acl: cannot install more IPv4 ACL types on the %s iface\n",
+			iface->name);
+		return -1;
+	}
+
+	/* Assign a new ID for this rule type. */
+	for (i = 0; i < num_rules; i++)
+		ipv4_rules[i].data.userdata = iface->ipv4_acls.func_count;
+
+	for (i = 0; i < numa_nodes; i++) {
+		int ret = rte_acl_add_rules(iface->ipv4_acls.acls[i],
+			(struct rte_acl_rule *)ipv4_rules, num_rules);
+		if (ret < 0) {
+			RTE_LOG(ERR, ACL, "Failed to add IPv4 ACL rules on the %s interface on socket %d\n",
+				iface->name, i);
+			return ret;
+		}
+	}
+
+	iface->ipv4_acls.funcs[iface->ipv4_acls.func_count] = cb_f;
+	iface->ipv4_acls.ext_funcs[iface->ipv4_acls.func_count] = ext_cb_f;
+	iface->ipv4_acls.func_count++;
+
+	return 0;
+}
+
+int
+build_ipv4_acls(struct gatekeeper_if *iface)
+{
+	struct rte_acl_config acl_build_params;
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+
+	memset(&acl_build_params, 0, sizeof(acl_build_params));
+	acl_build_params.num_categories = 1;
+	acl_build_params.num_fields = RTE_DIM(ipv4_defs);
+	rte_memcpy(&acl_build_params.defs, ipv4_defs, sizeof(ipv4_defs));
+
+	for (i = 0; i < numa_nodes; i++) {
+		int ret = rte_acl_build(iface->ipv4_acls.acls[i],
+			&acl_build_params);
+		if (ret < 0) {
+			RTE_LOG(ERR, ACL,
+				"Failed to build IPv4 ACL for the %s iface\n",
+				iface->name);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+int
+init_ipv4_acls(struct gatekeeper_if *iface)
+{
+	unsigned int numa_nodes = get_net_conf()->numa_nodes;
+	unsigned int i;
+
+	for (i = 0; i < numa_nodes; i++) {
+		char acl_name[64];
+		struct rte_acl_param acl_params = {
+			.socket_id = i,
+			.rule_size = RTE_ACL_RULE_SZ(RTE_DIM(ipv4_defs)),
+			.max_rule_num = MAX_NUM_ACL_RULES,
+		};
+		int ret = snprintf(acl_name, sizeof(acl_name),
+			"%s_%u_v4", iface->name, i);
+		RTE_VERIFY(ret > 0 && ret < (int)sizeof(acl_name));
+		acl_params.name = acl_name;
+
+		iface->ipv4_acls.acls[i] = rte_acl_create(&acl_params);
+		if (iface->ipv4_acls.acls[i] == NULL) {
+			unsigned int j;
+
+			RTE_LOG(ERR, ACL, "Failed to create IPv4 ACL for the %s iface on socket %d\n",
+				iface->name, i);
+			for (j = 0; j < i; j++) {
+				rte_acl_free(iface->ipv4_acls.acls[i]);
+				iface->ipv4_acls.acls[i] = NULL;
+			}
+			return -1;
+		}
+	}
+
+	/* Add drop function for packets that cannot be classified. */
+	RTE_VERIFY(RTE_ACL_INVALID_USERDATA == 0);
+	iface->ipv4_acls.funcs[RTE_ACL_INVALID_USERDATA] = drop_unmatched_pkts;
+	iface->ipv4_acls.ext_funcs[RTE_ACL_INVALID_USERDATA] = NULL;
+	iface->ipv4_acls.func_count = 1;
+
+	return 0;
+}
+
+/*
+ * IPv6 ACLs.
+ */
 
 /*
  * Input indices for the IPv6-related ACL fields. Fields are given
@@ -42,36 +344,6 @@ enum {
 	TYPE_INPUT_ICMPV6,
 	NUM_INPUTS_IPV6,
 };
-
-/* Callback function for when there's no classification match. */
-static int
-drop_unmatched_ipv6_pkts(struct rte_mbuf **pkts, unsigned int num_pkts,
-	__attribute__((unused)) struct gatekeeper_if *iface)
-{
-	unsigned int i;
-	for (i = 0; i < num_pkts; i++) {
-		/*
-		 * WARNING
-		 *   A packet has reached a Gatekeeper server,
-		 *   and Gatekeeper doesn't know what to do with
-		 *   this packet. If attackers are able to send
-		 *   these packets, they may be able to slow
-		 *   Gatekeeper down since Gatekeeper does a lot of
-		 *   processing to eventually discard these packets.
-		 */
-		RTE_LOG(WARNING, GATEKEEPER,
-			"acl: an IPv6 packet failed to match any IPv6 ACL rules, the whole packet is dumped below:\n");
-		/*
-		 * XXX The default output used DPDK logging system
-		 * is stderr. The stream should be consistent with
-		 * the DPDK logging system.
-		 */
-		rte_pktmbuf_dump(stderr, pkts[i], pkts[i]->pkt_len);
-		rte_pktmbuf_free(pkts[i]);
-	}
-
-	return 0;
-}
 
 /*
  * All IPv6 fields involved in classification; not all fields must
@@ -164,107 +436,31 @@ register_ipv6_acl(struct ipv6_acl_rule *ipv6_rules, unsigned int num_rules,
 	unsigned int numa_nodes = get_net_conf()->numa_nodes;
 	unsigned int i;
 
-	if (iface->acl_func_count == GATEKEEPER_IPV6_ACL_MAX) {
-		RTE_LOG(ERR, GATEKEEPER, "acl: cannot install more ACL types on the %s iface\n",
+	if (iface->ipv6_acls.func_count == GATEKEEPER_ACL_MAX) {
+		RTE_LOG(ERR, GATEKEEPER, "acl: cannot install more IPv6 ACL types on the %s iface\n",
 			iface->name);
 		return -1;
 	}
 
 	/* Assign a new ID for this rule type. */
 	for (i = 0; i < num_rules; i++)
-		ipv6_rules[i].data.userdata = iface->acl_func_count;
+		ipv6_rules[i].data.userdata = iface->ipv6_acls.func_count;
 
 	for (i = 0; i < numa_nodes; i++) {
-		int ret = rte_acl_add_rules(iface->ipv6_acls[i],
+		int ret = rte_acl_add_rules(iface->ipv6_acls.acls[i],
 			(struct rte_acl_rule *)ipv6_rules, num_rules);
 		if (ret < 0) {
-			RTE_LOG(ERR, ACL, "Failed to add ACL rules on the %s interface on socket %d\n",
+			RTE_LOG(ERR, ACL, "Failed to add IPv6 ACL rules on the %s interface on socket %d\n",
 				iface->name, i);
 			return ret;
 		}
 	}
 
-	iface->acl_funcs[iface->acl_func_count] = cb_f;
-	iface->ext_funcs[iface->acl_func_count] = ext_cb_f;
-	iface->acl_func_count++;
+	iface->ipv6_acls.funcs[iface->ipv6_acls.func_count] = cb_f;
+	iface->ipv6_acls.ext_funcs[iface->ipv6_acls.func_count] = ext_cb_f;
+	iface->ipv6_acls.func_count++;
 
 	return 0;
-}
-
-int
-process_ipv6_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
-	struct acl_search *acl)
-{
-	struct rte_mbuf *pkts[iface->acl_func_count][GATEKEEPER_MAX_PKT_BURST];
-	int num_pkts[iface->acl_func_count];
-	unsigned int socket_id = rte_lcore_to_socket_id(lcore_id);
-	unsigned int i;
-	int ret;
-
-	if (unlikely(!ipv6_if_configured(iface))) {
-		ret = 0;
-		goto drop_ipv6_acl_pkts;
-	}
-
-	ret = rte_acl_classify(iface->ipv6_acls[socket_id],
-		acl->data, acl->res, acl->num, 1);
-	if (unlikely(ret < 0)) {
-		RTE_LOG(ERR, ACL,
-			"invalid arguments given to rte_acl_classify()\n");
-		goto drop_ipv6_acl_pkts;
-	}
-
-	/* Split packets into separate buffers -- one for each type. */
-	memset(num_pkts, 0, sizeof(num_pkts));
-	for (i = 0; i < acl->num; i++) {
-		int type = acl->res[i];
-		if (type == RTE_ACL_INVALID_USERDATA) {
-			unsigned int j;
-			/*
-			 * @j starts at 1 to skip RTE_ACL_INVALID_USERDATA,
-			 * which has no matching function.
-			 */
-			for (j = 1; j < iface->acl_func_count; j++) {
-				int ret = iface->ext_funcs[j](
-					acl->mbufs[i], iface);
-				if (ret == 0) {
-					type = j;
-					break;
-				}
-			}
-		}
-
-		pkts[type][num_pkts[type]++] = acl->mbufs[i];
-	}
-
-	/* Transmit separate buffers to registered ACL functions. */
-	for (i = 0; i < iface->acl_func_count; i++) {
-		if (num_pkts[i] == 0)
-			continue;
-
-		ret = iface->acl_funcs[i](pkts[i], num_pkts[i], iface);
-		if (unlikely(ret < 0)) {
-			/*
-			 * Each ACL function is responsible for
-			 * freeing packets not already handled.
-			 */
-			RTE_LOG(WARNING, GATEKEEPER,
-				"acl: ACL function %d failed on %s iface\n",
-				i, iface->name);
-		}
-	}
-
-	ret = 0;
-	goto out;
-
-drop_ipv6_acl_pkts:
-
-	for (i = 0; i < acl->num; i++)
-		rte_pktmbuf_free(acl->mbufs[i]);
-
-out:
-	acl->num = 0;
-	return ret;
 }
 
 int
@@ -280,7 +476,8 @@ build_ipv6_acls(struct gatekeeper_if *iface)
 	rte_memcpy(&acl_build_params.defs, ipv6_defs, sizeof(ipv6_defs));
 
 	for (i = 0; i < numa_nodes; i++) {
-		int ret = rte_acl_build(iface->ipv6_acls[i], &acl_build_params);
+		int ret = rte_acl_build(iface->ipv6_acls.acls[i],
+			&acl_build_params);
 		if (ret < 0) {
 			RTE_LOG(ERR, ACL,
 				"Failed to build IPv6 ACL for the %s iface\n",
@@ -303,22 +500,22 @@ init_ipv6_acls(struct gatekeeper_if *iface)
 		struct rte_acl_param acl_params = {
 			.socket_id = i,
 			.rule_size = RTE_ACL_RULE_SZ(RTE_DIM(ipv6_defs)),
-			.max_rule_num = MAX_NUM_IPV6_ACL_RULES,
+			.max_rule_num = MAX_NUM_ACL_RULES,
 		};
 		int ret = snprintf(acl_name, sizeof(acl_name),
-			"%s_%u", iface->name, i);
+			"%s_%u_v6", iface->name, i);
 		RTE_VERIFY(ret > 0 && ret < (int)sizeof(acl_name));
 		acl_params.name = acl_name;
 
-		iface->ipv6_acls[i] = rte_acl_create(&acl_params);
-		if (iface->ipv6_acls[i] == NULL) {
+		iface->ipv6_acls.acls[i] = rte_acl_create(&acl_params);
+		if (iface->ipv6_acls.acls[i] == NULL) {
 			unsigned int j;
 
 			RTE_LOG(ERR, ACL, "Failed to create IPv6 ACL for the %s iface on socket %d\n",
 				iface->name, i);
 			for (j = 0; j < i; j++) {
-				rte_acl_free(iface->ipv6_acls[i]);
-				iface->ipv6_acls[i] = NULL;
+				rte_acl_free(iface->ipv6_acls.acls[i]);
+				iface->ipv6_acls.acls[i] = NULL;
 			}
 			return -1;
 		}
@@ -326,20 +523,9 @@ init_ipv6_acls(struct gatekeeper_if *iface)
 
 	/* Add drop function for packets that cannot be classified. */
 	RTE_VERIFY(RTE_ACL_INVALID_USERDATA == 0);
-	iface->acl_funcs[RTE_ACL_INVALID_USERDATA] = drop_unmatched_ipv6_pkts;
-	iface->ext_funcs[RTE_ACL_INVALID_USERDATA] = NULL;
-	iface->acl_func_count = 1;
+	iface->ipv6_acls.funcs[RTE_ACL_INVALID_USERDATA] = drop_unmatched_pkts;
+	iface->ipv6_acls.ext_funcs[RTE_ACL_INVALID_USERDATA] = NULL;
+	iface->ipv6_acls.func_count = 1;
 
 	return 0;
-}
-
-void
-destroy_ipv6_acls(struct gatekeeper_if *iface)
-{
-	unsigned int numa_nodes = get_net_conf()->numa_nodes;
-	unsigned int i;
-	for (i = 0; i < numa_nodes; i++) {
-		rte_acl_free(iface->ipv6_acls[i]);
-		iface->ipv6_acls[i] = NULL;
-	}
 }

--- a/lls/cache.h
+++ b/lls/cache.h
@@ -48,6 +48,18 @@ struct lls_put_req {
 	unsigned int     lcore_id;
 };
 
+/* Information needed to submit ARP packets to the LLS block. */
+struct lls_arp_req {
+	/* ARP neighbor packets. */
+	struct rte_mbuf      *pkts[GATEKEEPER_MAX_PKT_BURST];
+
+	/* Number of packets stored in @pkts. */
+	int                  num_pkts;
+
+	/* Interface that received @pkt. */
+	struct gatekeeper_if *iface;
+};
+
 /* Information needed to submit ND packets to the LLS block. */
 struct lls_nd_req {
 	/* ND neighbor packets. */
@@ -94,6 +106,8 @@ struct lls_request {
 		struct lls_hold_req hold;
 		/* If @ty is LLS_REQ_PUT, use @put. */
 		struct lls_put_req  put;
+		/* If @ty is LLS_REQ_ARP, use @arp. */
+		struct lls_arp_req  arp;
 		/* If @ty is LLS_REQ_ND, use @nd. */
 		struct lls_nd_req   nd;
 	} u;

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -17,6 +17,12 @@ function gatekeeper_init()
 	local netf = require("net")
 	local net_conf = netf(gatekeeper_server)
 
+	-- LLS should be the first block initialized, since it should have
+	-- queue IDs of 0 so that when ARP filters are not supported ARP
+	-- packets are steered to the LLS block by the NIC. This occurs because
+	-- many NICs direct non-IP packets to queue 0. This is not necessary
+	-- when running Gatekeeper on Amazon, since the ENA distributes non-IP
+	-- packets to the first queue configured for RSS.
 	local llsf = require("lls")
 	local lls_conf = llsf(net_conf, numa_table)
 

--- a/lua/policylib.lua
+++ b/lua/policylib.lua
@@ -64,7 +64,7 @@ struct udp_hdr {
 } __attribute__((__packed__));
 
 struct gt_packet_headers {
-	uint16_t outer_ip_ver;
+	uint16_t outer_ethertype;
 	uint16_t inner_ip_ver;
 	uint8_t l4_proto;
 


### PR DESCRIPTION
Before these patches, Gatekeeper NICs were required to support EtherType and ntuple filters for hardware filters. These patches lift this requirement so that other NICs (such as the Amazon ENA) can still run Gatekeeper by filtering packets in software.