### PR TITLE
gk/net: remove TODOs that are already finished

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -263,23 +263,6 @@ initialize_flow_entry(struct flow_entry *fe,
 	fe->u.request.last_packet_seen_at = rte_rdtsc();
 	fe->u.request.last_priority = START_PRIORITY;
 	fe->u.request.allowance = START_ALLOWANCE - 1;
-
-	/*
-	 * TODO Flow entries should maintain the reference counter of
-	 * the grantor FIB entry to avoid the entry to go away before the flow.
-	 *
-	 * Notice that all GK blocks are calling this function, so a solution
-	 * needs to deal with concurrency.
-	 *
-	 * Moreover, the chose solution must be very efficient due to
-	 * the impact on the throughout of the GK blocks. For example,
-	 * a simple atomic counter will slow down all GK blocks;
-	 * especially if there is only one grantor FIB entry.
-	 *
-	 * Ideas for solution: trade the need to maintain the reference counter
-	 * of the grantor FIB entry for some expensive operation that is only
-	 * needed while editing the FIB table.
-	 */
 	fe->grantor_fib = grantor_fib;
 }
 

--- a/lib/net.c
+++ b/lib/net.c
@@ -57,8 +57,6 @@ uint8_t default_rss_key[GATEKEEPER_RSS_KEY_LEN] = {
 /* To support the optimized implementation of generic RSS hash function. */
 uint8_t rss_key_be[RTE_DIM(default_rss_key)];
 
-/* TODO Implement the configuration for Flow Director. */
-
 /*
  * TODO Add support for VLAN tags.
  *


### PR DESCRIPTION
This removes the `TODO` specified in issue #59 because it was already completed by merged pull request #45.