### PR TITLE
net: verify that EtherType filters are little endian

### DIFF
--- a/lib/net.c
+++ b/lib/net.c
@@ -88,7 +88,11 @@ static struct rte_eth_conf gatekeeper_port_conf = {
  * EType register's value should be in little endian, according to
  * the 82599 datasheet.
  *
- * XXX Does the endianness change with other NICs?
+ * Does the endianness change with other NICs?
+ * 	We have checked the source code of three DPDK networking drivers:
+ *	i40e, ixgbe, e1000. And all of them use little endian order.
+ *	However, we didn't find the parts for other drivers. We tried to
+ *	ask help from the DPDK mailinglist, but didn't get reply.
  */
 int
 ethertype_filter_add(uint8_t port_id, uint16_t ether_type, uint16_t queue_id)


### PR DESCRIPTION
For the 82599 NIC, the EtherType value of each EtherType filter should be passed in little endian order according to the 82599 datasheet. This patch verifies that whether this is the case with all NICs that support the EtherType filter, and removes the relevant ```XXX``` in ```lib/net.c```.