### PR TITLE
cps: support editing the routing table of the GK blocks

### DIFF
--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -21,6 +21,8 @@
 
 #include <rte_timer.h>
 
+#include "gatekeeper_gk.h"
+#include "gatekeeper_gt.h"
 #include "gatekeeper_mailbox.h"
 #include "list.h"
 
@@ -66,6 +68,9 @@ struct cps_config {
 
 	/* Socket for receiving routing table updates. */
 	struct mnl_socket *nl;
+
+	struct gk_config  *gk;
+	struct gt_config  *gt;
 };
 
 /* Information needed to submit IPv6 BGP packets to the CPS block. */
@@ -126,20 +131,35 @@ struct cps_request {
 
 struct route_update {
 	/* Type of update: RTM_NEWROUTE or RTM_DELROUTE. */
-	int type;
+	int      type;
 
 	/* Address family of update: AF_INET or AF_INET6. */
-	int family;
+	int      family;
 
 	/*
 	 * Whether this update has all the fields and attributes
 	 * necessary to update the LPM table.
 	 */
-	int valid;
+	int      valid;
+
+	uint8_t  prefix_len;
+
+	uint32_t oif_index;
+
+	union {
+		struct in_addr  v4;
+		struct in6_addr v6;
+	} ip;
+
+	union {
+		struct in_addr  v4;
+		struct in6_addr v6;
+	} gw;
 };
 
 struct cps_config *get_cps_conf(void);
-int run_cps(struct net_config *net_conf, struct cps_config *cps_conf,
+int run_cps(struct net_config *net_conf, struct gk_config *gk_conf,
+	struct gt_config *gt_conf, struct cps_config *cps_conf,
 	struct lls_config *lls_conf, const char *kni_kmod_path);
 
 #endif /* _GATEKEEPER_CPS_H_ */

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -189,6 +189,12 @@ struct gk_lpm {
 	struct gk_fib   *fib_tbl6;
 };
 
+struct ip_prefix {
+	const char    *str;
+	struct ipaddr addr;
+	int           len;
+};
+
 struct gk_config;
 
 int clear_ether_cache(struct ether_cache *eth_cache);
@@ -200,8 +206,13 @@ void destroy_neigh_hash_table(struct neighbor_hash_table *neigh);
 /*
  * TODO Add support for listing GK FIB entries.
  */
+int add_fib_entry_numerical(struct ip_prefix *prefix_info,
+	struct ipaddr *gt_addr, struct ipaddr *gw_addr,
+	enum gk_fib_action action, struct gk_config *gk_conf);
 int add_fib_entry(const char *prefix, const char *gt_ip, const char *gw_ip,
 	enum gk_fib_action action, struct gk_config *gk_conf);
+int del_fib_entry_numerical(
+	struct ip_prefix *prefix_info, struct gk_config *gk_conf);
 int del_fib_entry(const char *ip_prefix, struct gk_config *gk_conf);
 
 /* TODO Customize the hash function for IPv4. */

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -1,4 +1,4 @@
-return function (net_conf, lls_conf, numa_table)
+return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	--
 	-- These parameters should not need to be changed after initial setup.
 	--
@@ -17,8 +17,8 @@ return function (net_conf, lls_conf, numa_table)
 	cps_conf.tcp_port_bgp = tcp_port_bgp
 	cps_conf.debug = false
 
-	local ret = gatekeeper.c.run_cps(net_conf, cps_conf, lls_conf,
-		kni_kmod_path)
+	local ret = gatekeeper.c.run_cps(net_conf, gk_conf, gt_conf,
+		cps_conf, lls_conf, kni_kmod_path)
 	if ret < 0 then
 		error("Failed to run cps block")
 	end

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -220,7 +220,8 @@ struct gt_config *alloc_gt_conf(void);
 int run_gt(struct net_config *net_conf, struct gt_config *gt_conf);
 
 struct cps_config *get_cps_conf(void);
-int run_cps(struct net_config *net_conf, struct cps_config *cps_conf,
+int run_cps(struct net_config *net_conf, struct gk_config *gk_conf,
+	struct gt_config *gt_conf, struct cps_config *cps_conf,
 	struct lls_config *lls_conf, const char *kni_kmod_path);
 struct dynamic_config *get_dy_conf(void);
 void set_dyc_timeout(unsigned sec, unsigned usec,

--- a/lua/gatekeeper_config.lua
+++ b/lua/gatekeeper_config.lua
@@ -27,6 +27,7 @@ function gatekeeper_init()
 	local lls_conf = llsf(net_conf, numa_table)
 
 	local gk_conf
+	local gt_conf
 
 	if gatekeeper_server == true then
 		-- n_lcores + 2 on same NUMA: for GK-GT Unit and Solicitor.
@@ -47,13 +48,13 @@ function gatekeeper_init()
 		local ggu_conf = gguf(net_conf, gk_conf, ggu_lcore)
 	else
 		local gtf = require("gt")
-		local gt_conf = gtf(net_conf, numa_table)
+		gt_conf = gtf(net_conf, numa_table)
 	end
 
 	-- Allocate CPS after to increase the change that the LLS block is
 	-- allocated in the same NUMA node as the GK/GT/GK-GT-unit blocks.
 	local cpsf = require("cps")
-	local cps_conf = cpsf(net_conf, lls_conf, numa_table)
+	local cps_conf = cpsf(net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 
 	local dyf = require("dyn_cfg")
 	local dy_conf = dyf(gk_conf, numa_table)


### PR DESCRIPTION
This patch allows the CPS block to support editing the routing table of the GK blocks. Basically, this patch takes the routing table updates and passes the useful information to the GK block to update the LPM table. We use functions ``add_fib_entry()`` and ``del_fib_entry()`` to edit GK's routing table.