### PR TITLE
gk: add support for pruning the flow tables

### DIFF
--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -59,7 +59,7 @@ struct gk_instance {
 /* Configuration for the GK functional block. */
 struct gk_config {
 	/* Specify the size of the flow hash table. */
-	unsigned int	   flow_ht_size;
+	unsigned int       flow_ht_size;
 
 	/*
 	 * DPDK LPM library implements the DIR-24-8 algorithm
@@ -88,10 +88,17 @@ struct gk_config {
 	unsigned int       gk_max_num_ipv4_fib_entries;
 	unsigned int       gk_max_num_ipv6_fib_entries;
 
+	/* Time for scanning the whole flow table in ms. */
+	unsigned int       flow_table_full_scan_ms;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */
+
+	/* Timeout in cycles used to prune the expired request flow entries. */
+	uint64_t           request_timeout_cycles;
+
 	rte_atomic32_t     ref_cnt;
 
 	/* The lcore ids at which each instance runs. */
@@ -140,6 +147,8 @@ struct gk_cmd_entry {
 };
 
 struct gk_config *alloc_gk_conf(void);
+void set_gk_request_timeout(unsigned int request_timeout_sec,
+	struct gk_config *gk_conf);
 int gk_conf_put(struct gk_config *gk_conf);
 int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
 	struct sol_config *sol_conf);

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -137,6 +137,7 @@ struct gk_config {
 	unsigned int max_num_ipv6_neighbors;
 	unsigned int gk_max_num_ipv4_fib_entries;
 	unsigned int gk_max_num_ipv6_fib_entries;
+	unsigned int flow_table_full_scan_ms;
 	/* This struct has hidden fields. */
 };
 
@@ -205,6 +206,8 @@ struct gatekeeper_if *get_if_back(struct net_config *net_conf);
 int gatekeeper_init_network(struct net_config *net_conf);
 
 struct gk_config *alloc_gk_conf(void);
+void set_gk_request_timeout(unsigned int request_timeout_sec,
+	struct gk_config *gk_conf);
 int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
 	struct sol_config *sol_conf);
 

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -16,9 +16,15 @@ return function (net_conf, sol_conf, gk_lcores)
 	gk_conf.max_num_ipv6_rules = 1024
 	gk_conf.num_ipv6_tbl8s = 65536
 
+	-- 48h.
+	gatekeeper.c.set_gk_request_timeout(48 * 60 * 60, gk_conf)
+
 	gk_conf.max_num_ipv6_neighbors = 65536
 	gk_conf.gk_max_num_ipv4_fib_entries = 256
 	gk_conf.gk_max_num_ipv6_fib_entries = 65536
+
+	-- Scan the whole flow table in 10 minutes.
+	gk_conf.flow_table_full_scan_ms = 10 * 60 * 1000
 
 	--
 	-- Code below this point should not need to be changed.


### PR DESCRIPTION
This patch periodically scans the GK flow tables, and reclaims the expired entries. Moreover, when the table is full, we use a simple solution to alleviate memory pressure by doubling the flow table. Since there is no functions in DPDK hash table to double the hash table size, we have to manually do it.