### PR TITLE
ggu: extending the GK-GT protocol to support flushing policy decisions

### DIFF
--- a/include/gatekeeper_ggu.h
+++ b/include/gatekeeper_ggu.h
@@ -73,6 +73,10 @@ enum {
 	GGU_DEC_IPV4_GRANTED,
 	/* Grant an IPv6 flow. */
 	GGU_DEC_IPV6_GRANTED,
+	/* Flush an IPv4 prefix. */
+	GGU_DEC_IPV4_FLUSHED,
+	/* Flush an IPv6 prefix. */
+	GGU_DEC_IPV6_FLUSHED,
 	__MAX_GGU_DEC
 };
 
@@ -165,8 +169,19 @@ struct ggu_declined {
 	uint32_t expire_sec;
 } __attribute__ ((packed));
 
+/* Parameters for declaring a flow flushed. */
+struct ggu_flushed {
+	/* The prefix length of the destination to be flushed. */
+	uint8_t prefix_len;
+} __attribute__ ((packed));
+
 struct ggu_policy {
 	uint8_t state;
+
+	/*
+	 * In case of flushing policy decisions,
+	 * only the destination will be used.
+	 */
 	struct ip_flow flow;
 
 	/*
@@ -179,6 +194,8 @@ struct ggu_policy {
 		struct ggu_granted granted;
 		/* Decision is to decline the flow. */
 		struct ggu_declined declined;
+		/* Decision is to flush the flow. */
+		struct ggu_flushed flushed;
 	} params;
 };
 

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -36,10 +36,12 @@ extern int gk_logtype;
 	rte_log(RTE_LOG_ ## level, gk_logtype, "GATEKEEPER GK: " __VA_ARGS__)
 
 /*
- * A flow entry can be in one of three states:
- * request, granted, or declined.
+ * A flow entry can be in one of four states:
+ * request, granted, declined, or flush.
+ * Note, the flush state is a special state that
+ * used for flushing policy decisions.
  */
-enum gk_flow_state { GK_REQUEST, GK_GRANTED, GK_DECLINED };
+enum gk_flow_state { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_FLUSHED };
 
 /* Structures for each GK instance. */
 struct gk_instance {
@@ -154,6 +156,7 @@ struct gk_config {
 /* Define the possible command operations for GK block. */
 enum gk_cmd_op {
 	GGU_POLICY_ADD,
+	GGU_POLICY_FLUSH,
 	GK_SYNCH_WITH_LPM,
 };
 

--- a/lls/arp.c
+++ b/lls/arp.c
@@ -37,8 +37,8 @@ iface_arp_enabled(struct net_config *net, struct gatekeeper_if *iface)
 int
 ipv4_in_subnet(struct gatekeeper_if *iface, const struct ipaddr *addr)
 {
-	return !((iface->ip4_addr.s_addr ^ addr->ip.v4.s_addr) &
-		iface->ip4_mask.s_addr);
+	return ip4_same_subnet(iface->ip4_addr.s_addr,
+		addr->ip.v4.s_addr, iface->ip4_mask.s_addr);
 }
 
 void

--- a/lls/nd.c
+++ b/lls/nd.c
@@ -101,23 +101,11 @@ int
 ipv6_in_subnet(struct gatekeeper_if *iface, const struct ipaddr *addr)
 {
 	/* Check for both link-local and global subnets. */
-	const uint64_t *paddr_global =
-		(const uint64_t *)&iface->ip6_addr.s6_addr;
-	const uint64_t *pmask_global =
-		(const uint64_t *)&iface->ip6_mask.s6_addr;
-
-	const uint64_t *paddr_local =
-		(const uint64_t *)&iface->ll_ip6_addr.s6_addr;
-	const uint64_t *pmask_local =
-		(const uint64_t *)&iface->ll_ip6_mask.s6_addr;
-
-	const uint64_t *paddr_rcvd = (const uint64_t *)addr->ip.v6.s6_addr;
-
-	return (!((paddr_local[0] ^ paddr_rcvd[0]) & pmask_local[0]) &&
-		!((paddr_local[1] ^ paddr_rcvd[1]) & pmask_local[1]))
+	return (ip6_same_subnet(iface->ll_ip6_addr.s6_addr, addr->ip.v6.s6_addr,
+		iface->ll_ip6_mask.s6_addr)
 		||
-		(!((paddr_global[0] ^ paddr_rcvd[0]) & pmask_global[0]) &&
-		!((paddr_global[1] ^ paddr_rcvd[1]) & pmask_global[1]));
+		ip6_same_subnet(iface->ip6_addr.s6_addr, addr->ip.v6.s6_addr,
+		iface->ip6_mask.s6_addr));
 }
 
 /*

--- a/lua/policy.lua
+++ b/lua/policy.lua
@@ -97,7 +97,7 @@ function lookup_policy(pkt_info, policy)
 	if pl.state == policylib.c.GK_DECLINED then
 		pl.params.declined.expire_sec =
 			group["params"]["expire_sec"]
-	else
+	else if pl.state == policylib.c.GK_GRANTED then
 		pl.params.granted.tx_rate_kb_sec =
 			group["params"]["tx_rate_kb_sec"]
 		pl.params.granted.cap_expire_sec =
@@ -106,6 +106,9 @@ function lookup_policy(pkt_info, policy)
 			group["params"]["next_renewal_ms"]
 		pl.params.granted.renewal_step_ms =
 			group["params"]["renewal_step_ms"]
+	else
+		pl.params.flushed.prefix_len =
+			group["params"]["prefix_len"]
 	end
 end
 

--- a/lua/policylib.lua
+++ b/lua/policylib.lua
@@ -12,7 +12,8 @@ ffi.cdef[[
 enum gk_flow_state {
 	GK_REQUEST,
 	GK_GRANTED,
-	GK_DECLINED
+	GK_DECLINED,
+	GK_FLUSHED
 };
 
 enum protocols {
@@ -102,12 +103,17 @@ struct ggu_declined {
 	uint32_t expire_sec;
 } __attribute__ ((packed));
 
+struct ggu_flushed {
+	uint8_t prefix_len;
+} __attribute__ ((packed));
+
 struct ggu_policy {
 	uint8_t state;
 	struct ip_flow flow;
 	union {
 		struct ggu_granted granted;
 		struct ggu_declined declined;
+		struct ggu_flushed flushed;
 	} params;
 };
 


### PR DESCRIPTION
This patch extends the protocol of the GK-GT unit to support flush policy decisions. This is necessary since when a network administrator changes a policy in response to an attack, she may need to flush all policy decisions cached at the Gatekeeper servers associated to a given destination in order to quickly re-establish the network.