### PR TITLE
Update DPDK library in Gatekeeper

### DIFF
--- a/cps/kni.c
+++ b/cps/kni.c
@@ -48,7 +48,7 @@ extern long init_module(void *, unsigned long, const char *);
 extern long delete_module(const char *, unsigned int);
 
 int
-kni_change_if(uint8_t port_id, uint8_t if_up)
+kni_change_if(uint16_t port_id, uint8_t if_up)
 {
 	return (if_up)
 		? rte_eth_dev_set_link_up(port_id)
@@ -56,7 +56,7 @@ kni_change_if(uint8_t port_id, uint8_t if_up)
 }
 
 int
-kni_change_mtu(uint8_t port_id, unsigned new_mtu)
+kni_change_mtu(uint16_t port_id, unsigned int new_mtu)
 {
 	if (unlikely((new_mtu < ETHER_MIN_MTU) ||
 			(new_mtu > ETHER_MAX_JUMBO_FRAME_LEN -

--- a/cps/kni.h
+++ b/cps/kni.h
@@ -35,8 +35,8 @@ struct nd_request {
 	int              stale;
 };
 
-int kni_change_mtu(uint8_t port_id, unsigned new_mtu);
-int kni_change_if(uint8_t port_id, uint8_t if_up);
+int kni_change_mtu(uint16_t port_id, unsigned int new_mtu);
+int kni_change_if(uint16_t port_id, uint8_t if_up);
 int kni_config(struct rte_kni *kni, struct gatekeeper_if *iface);
 int route_event_sock_open(struct cps_config *cps_conf);
 void route_event_sock_close(struct cps_config *cps_conf);

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -379,7 +379,7 @@ ggu_proc(void *arg)
 {
 	uint32_t lcore = rte_lcore_id();
 	struct ggu_config *ggu_conf = (struct ggu_config *)arg;
-	uint8_t port_in = ggu_conf->net->back.id;
+	uint16_t port_in = ggu_conf->net->back.id;
 	uint16_t rx_queue = ggu_conf->rx_queue_back;
 	unsigned int i;
 

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -824,7 +824,7 @@ remove_prefix_from_lpm_locked(
 
 		ip_prefix_fib = &ltbl->fib_tbl[fib_id];
 	} else if (likely(ip_prefix->addr.proto == ETHER_TYPE_IPv6)) {
-		uint8_t fib_id;
+		uint32_t fib_id;
 
 		ip_prefix_present = rte_lpm6_is_rule_present(
 			ltbl->lpm6, ip_prefix->addr.ip.v6.s6_addr,
@@ -1468,7 +1468,7 @@ check_prefix_locked(struct ip_prefix *prefix,
 		}
 	} else if (likely(prefix->addr.proto == ETHER_TYPE_IPv6)) {
 		for (i = 0; i < prefix->len; i++) {
-			uint8_t fib_id;
+			uint32_t fib_id;
 			ip_prefix_present = rte_lpm6_is_rule_present(
 				ltbl->lpm6, prefix->addr.ip.v6.s6_addr,
 				i, &fib_id);

--- a/gk/main.c
+++ b/gk/main.c
@@ -895,9 +895,9 @@ static int
 gk_setup_rss(struct gk_config *gk_conf)
 {
 	int i, ret = 0;
-	uint8_t port_front = gk_conf->net->front.id;
+	uint16_t port_front = gk_conf->net->front.id;
 	uint16_t gk_queues_front[gk_conf->num_lcores];
-	uint8_t port_back = gk_conf->net->back.id;
+	uint16_t port_back = gk_conf->net->back.id;
 	uint16_t gk_queues_back[gk_conf->num_lcores];
 
 	for (i = 0; i < gk_conf->num_lcores; i++) {
@@ -933,7 +933,7 @@ out:
 
 /* Process the packets on the front interface. */
 static void
-process_pkts_front(uint8_t port_front, uint8_t port_back,
+process_pkts_front(uint16_t port_front, uint16_t port_back,
 	uint16_t rx_queue_front, uint16_t tx_queue_back,
 	unsigned int lcore, struct gk_instance *instance,
 	struct gk_config *gk_conf)
@@ -1182,7 +1182,7 @@ process_pkts_front(uint8_t port_front, uint8_t port_back,
 
 /* Process the packets on the back interface. */
 static void
-process_pkts_back(uint8_t port_back, uint8_t port_front,
+process_pkts_back(uint16_t port_back, uint16_t port_front,
 	uint16_t rx_queue_back, uint16_t tx_queue_front,
 	unsigned int lcore, struct gk_config *gk_conf)
 {
@@ -1354,8 +1354,8 @@ gk_proc(void *arg)
 	unsigned int block_idx = get_block_idx(gk_conf, lcore);
 	struct gk_instance *instance = &gk_conf->instances[block_idx];
 
-	uint8_t port_front = get_net_conf()->front.id;
-	uint8_t port_back = get_net_conf()->back.id;
+	uint16_t port_front = get_net_conf()->front.id;
+	uint16_t port_back = get_net_conf()->back.id;
 	uint16_t rx_queue_front = instance->rx_queue_front;
 	uint16_t tx_queue_front = instance->tx_queue_front;
 	uint16_t rx_queue_back = instance->rx_queue_back;

--- a/gt/main.c
+++ b/gt/main.c
@@ -65,7 +65,7 @@ static int
 gt_setup_rss(struct gt_config *gt_conf)
 {
 	int i;
-	uint8_t port_in = gt_conf->net->front.id;
+	uint16_t port_in = gt_conf->net->front.id;
 	uint16_t gt_queues[gt_conf->num_lcores];
 
 	for (i = 0; i < gt_conf->num_lcores; i++)
@@ -876,7 +876,7 @@ print_unsent_policy(struct ggu_policy *policy)
  * with fragmented packets.
  */
 static void 
-process_death_row(int socket_id, uint8_t port, uint16_t tx_queue,
+process_death_row(int socket_id, uint16_t port, uint16_t tx_queue,
 	int punish, struct rte_ip_frag_death_row *death_row,
 	struct gt_instance *instance, struct gt_config *gt_conf)
 {
@@ -971,7 +971,7 @@ gt_proc(void *arg)
 	struct gt_instance *instance = &gt_conf->instances[block_idx];
 
 	uint64_t last_tsc = rte_rdtsc();
-	uint8_t port = get_net_conf()->front.id;
+	uint16_t port = get_net_conf()->front.id;
 	uint16_t rx_queue = instance->rx_queue;
 	uint16_t tx_queue = instance->tx_queue;
 	uint64_t frag_scan_timeout_cycles = round(

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -70,7 +70,7 @@ struct lls_map {
 	struct ether_addr ha;
 
 	/* Port on which this map exists. */
-	uint8_t           port_id;
+	uint16_t          port_id;
 
 	/* Whether this map has been marked as stale. */
 	int               stale;

--- a/include/gatekeeper_mailbox.h
+++ b/include/gatekeeper_mailbox.h
@@ -47,7 +47,7 @@ void destroy_mailbox(struct mailbox *mb);
 static inline int
 mb_dequeue_burst(struct mailbox *mb, void **obj_table, unsigned n)
 {
-	return rte_ring_sc_dequeue_burst(mb->ring, obj_table, n);
+	return rte_ring_sc_dequeue_burst(mb->ring, obj_table, n, NULL);
 }
 
 static inline void

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -148,7 +148,7 @@ struct gatekeeper_if {
 	struct ether_addr eth_addr;
 
 	/* DPDK port IDs corresponding to each address in @pci_addrs. */
-	uint8_t         *ports;
+	uint16_t        *ports;
 
 	/*
 	 * The DPDK port ID for this interface.
@@ -336,10 +336,10 @@ void lua_free_iface(struct gatekeeper_if *iface);
 
 int get_ip_type(const char *ip_addr);
 int convert_str_to_ip(const char *ip_addr, struct ipaddr *res);
-int ethertype_filter_add(uint8_t port_id, uint16_t ether_type,
+int ethertype_filter_add(uint16_t port_id, uint16_t ether_type,
 	uint16_t queue_id);
 
-int ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
+int ntuple_filter_add(uint16_t port_id, uint32_t dst_ip,
 	uint16_t src_port, uint16_t src_port_mask,
 	uint16_t dst_port, uint16_t dst_port_mask,
 	uint8_t proto, uint16_t queue_id,
@@ -347,8 +347,9 @@ int ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
 struct net_config *get_net_conf(void);
 struct gatekeeper_if *get_if_front(struct net_config *net_conf);
 struct gatekeeper_if *get_if_back(struct net_config *net_conf);
-int gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues);
-int gatekeeper_get_rss_config(uint8_t portid,
+int gatekeeper_setup_rss(uint16_t port_id, uint16_t *queues,
+	uint16_t num_queues);
+int gatekeeper_get_rss_config(uint16_t port_id,
 	struct gatekeeper_rss_config *rss_conf);
 int gatekeeper_init_network(struct net_config *net_conf);
 void gatekeeper_free_network(void);

--- a/include/list.h
+++ b/include/list.h
@@ -19,23 +19,14 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
+#include <rte_common.h>
+
 /*
  * The code of this file is mostly a copy of the Linux kernel.
  */
 
 #undef offsetof
 #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
-
-/**
- * container_of - cast a member of a structure out to the containing structure
- * @ptr:        the pointer to the member.
- * @type:       the type of the container struct this is embedded in.
- * @member:     the name of the member within the struct.
- *
- */
-#define container_of(ptr, type, member) ({                \
-	typeof( ((type *)0)->member ) *__mptr = (ptr);    \
-	(type *)( (char *)__mptr - offsetof(type,member) );})
 
 struct list_head {
 	struct list_head *next, *prev;

--- a/lib/acl.c
+++ b/lib/acl.c
@@ -22,6 +22,9 @@
 /* Maximum number of rules installed per ACL. */
 #define MAX_NUM_ACL_RULES (32)
 
+/* Result returned when the ACL does not find a matching rule. */
+#define ACL_NO_MATCH (0)
+
 /* Callback function for when there's no classification match. */
 static int
 drop_unmatched_pkts(struct rte_mbuf **pkts, unsigned int num_pkts,
@@ -81,10 +84,10 @@ process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
 	memset(num_pkts, 0, sizeof(num_pkts));
 	for (i = 0; i < acl->num; i++) {
 		int type = acl->res[i];
-		if (type == RTE_ACL_INVALID_USERDATA) {
+		if (type == ACL_NO_MATCH) {
 			unsigned int j;
 			/*
-			 * @j starts at 1 to skip RTE_ACL_INVALID_USERDATA,
+			 * @j starts at 1 to skip ACL_NO_MATCH,
 			 * which has no matching function.
 			 */
 			for (j = 1; j < astate->func_count; j++) {
@@ -329,9 +332,9 @@ init_ipv4_acls(struct gatekeeper_if *iface)
 	}
 
 	/* Add drop function for packets that cannot be classified. */
-	RTE_VERIFY(RTE_ACL_INVALID_USERDATA == 0);
-	iface->ipv4_acls.funcs[RTE_ACL_INVALID_USERDATA] = drop_unmatched_pkts;
-	iface->ipv4_acls.ext_funcs[RTE_ACL_INVALID_USERDATA] = NULL;
+	RTE_VERIFY(ACL_NO_MATCH == 0);
+	iface->ipv4_acls.funcs[ACL_NO_MATCH] = drop_unmatched_pkts;
+	iface->ipv4_acls.ext_funcs[ACL_NO_MATCH] = NULL;
 	iface->ipv4_acls.func_count = 1;
 
 	return 0;
@@ -554,9 +557,9 @@ init_ipv6_acls(struct gatekeeper_if *iface)
 	}
 
 	/* Add drop function for packets that cannot be classified. */
-	RTE_VERIFY(RTE_ACL_INVALID_USERDATA == 0);
-	iface->ipv6_acls.funcs[RTE_ACL_INVALID_USERDATA] = drop_unmatched_pkts;
-	iface->ipv6_acls.ext_funcs[RTE_ACL_INVALID_USERDATA] = NULL;
+	RTE_VERIFY(ACL_NO_MATCH == 0);
+	iface->ipv6_acls.funcs[ACL_NO_MATCH] = drop_unmatched_pkts;
+	iface->ipv6_acls.ext_funcs[ACL_NO_MATCH] = NULL;
 	iface->ipv6_acls.func_count = 1;
 
 	return 0;

--- a/lib/lpm.c
+++ b/lib/lpm.c
@@ -101,7 +101,7 @@ int
 lpm_lookup_ipv6(struct rte_lpm6 *lpm, uint8_t *ip)
 {
 	int ret;
-	uint8_t next_hop;
+	uint32_t next_hop;
 
 	ret = rte_lpm6_lookup(lpm, ip, &next_hop);
 	if (ret == -EINVAL) {

--- a/lib/net.c
+++ b/lib/net.c
@@ -119,7 +119,7 @@ static struct rte_eth_conf gatekeeper_port_conf = {
  *	ask help from the DPDK mailinglist, but didn't get reply.
  */
 int
-ethertype_filter_add(uint8_t port_id, uint16_t ether_type, uint16_t queue_id)
+ethertype_filter_add(uint16_t port_id, uint16_t ether_type, uint16_t queue_id)
 {
 	struct rte_eth_ethertype_filter filter = {
 		.ether_type = rte_cpu_to_le_16(ether_type),
@@ -169,7 +169,7 @@ out:
  * it can filter both IPv4 and IPv6 addresses.
  */
 int
-ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
+ntuple_filter_add(uint16_t port_id, uint32_t dst_ip,
 	uint16_t src_port, uint16_t src_port_mask,
 	uint16_t dst_port, uint16_t dst_port_mask,
 	uint8_t proto, uint16_t queue_id,
@@ -210,32 +210,32 @@ ntuple_filter_add(uint8_t portid, uint32_t dst_ip,
 		.queue = queue_id,
 	};
 
-	RTE_VERIFY(rte_eth_dev_filter_supported(portid,
+	RTE_VERIFY(rte_eth_dev_filter_supported(port_id,
 		RTE_ETH_FILTER_NTUPLE) == 0);
 
 	if (!ipv4_configured)
 		goto ipv6;
 
-	ret = rte_eth_dev_filter_ctrl(portid,
+	ret = rte_eth_dev_filter_ctrl(port_id,
 		RTE_ETH_FILTER_NTUPLE,
 		RTE_ETH_FILTER_ADD,
 		&filter_v4);
 	if (ret == -ENOTSUP) {
 		RTE_LOG(ERR, PORT,
 			"Hardware doesn't support adding an IPv4 ntuple filter on port %hhu!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -ENODEV) {
 		RTE_LOG(ERR, PORT,
 			"Port %hhu is invalid for adding an IPv4 ntuple filter!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret != 0) {
 		RTE_LOG(ERR, PORT,
 			"Other errors that depend on the specific operations implementation on port %hhu for adding an IPv4 ntuple filter!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	}
@@ -243,26 +243,26 @@ ipv6:
 	if (!ipv6_configured)
 		goto out;
 
-	ret = rte_eth_dev_filter_ctrl(portid,
+	ret = rte_eth_dev_filter_ctrl(port_id,
 		RTE_ETH_FILTER_NTUPLE,
 		RTE_ETH_FILTER_ADD,
 		&filter_v6);
 	if (ret == -ENOTSUP) {
 		RTE_LOG(ERR, PORT,
 			"Hardware doesn't support adding an IPv6 ntuple filter on port %hhu!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -ENODEV) {
 		RTE_LOG(ERR, PORT,
 			"Port %hhu is invalid for adding an IPv6 ntuple filter!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret != 0) {
 		RTE_LOG(ERR, PORT,
 			"Other errors that depend on the specific operations implementation on port %hhu for adding an IPv6 ntuple filter!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	}
@@ -287,7 +287,7 @@ find_num_numa_nodes(void)
 }
 
 static int
-configure_queue(uint8_t port_id, uint16_t queue_id, enum queue_type ty,
+configure_queue(uint16_t port_id, uint16_t queue_id, enum queue_type ty,
 	unsigned int numa_node, struct rte_mempool *mp)
 {
 	int ret;
@@ -331,7 +331,7 @@ get_queue_id(struct gatekeeper_if *iface, enum queue_type ty,
 {
 	int16_t *queues;
 	int ret;
-	uint8_t port;
+	uint16_t port;
 	unsigned int numa_node;
 	struct rte_mempool *mp;
 	int16_t new_queue_id;
@@ -697,7 +697,7 @@ get_if_back(struct net_config *net_conf)
 }
 
 int
-gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues)
+gatekeeper_setup_rss(uint16_t port_id, uint16_t *queues, uint16_t num_queues)
 {
 	int ret = 0;
 	uint32_t i;
@@ -706,11 +706,11 @@ gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues)
 
 	/* Get RSS redirection table (RETA) information. */
 	memset(&dev_info, 0, sizeof(dev_info));
-	rte_eth_dev_info_get(portid, &dev_info);
+	rte_eth_dev_info_get(port_id, &dev_info);
 	if (dev_info.reta_size == 0) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu (invalid RETA size = 0)!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	}
@@ -718,7 +718,7 @@ gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues)
 	if (dev_info.reta_size > ETH_RSS_RETA_SIZE_512) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu (invalid RETA size = %u)!\n",
-			portid, dev_info.reta_size);
+			port_id, dev_info.reta_size);
 		ret = -1;
 		goto out;
 	}
@@ -737,33 +737,34 @@ gatekeeper_setup_rss(uint8_t portid, uint16_t *queues, uint16_t num_queues)
 	}
 
 	/* RETA update. */
-	ret = rte_eth_dev_rss_reta_update(portid, reta_conf,
+	ret = rte_eth_dev_rss_reta_update(port_id, reta_conf,
 		dev_info.reta_size);
 	if (ret == -ENOTSUP) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu hardware doesn't support.",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -EINVAL) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu (RETA update with bad redirection table parameter)!\n",
-			portid);
+			port_id);
 		ret = -1;
 		goto out;
 	}
 
 	/* RETA query. */
-	ret = rte_eth_dev_rss_reta_query(portid, reta_conf, dev_info.reta_size);
+	ret = rte_eth_dev_rss_reta_query(port_id, reta_conf,
+		dev_info.reta_size);
 	if (ret == -ENOTSUP) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu hardware doesn't support.",
-			portid);
+			port_id);
 		ret = -1;
 	} else if (ret == -EINVAL) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu (RETA query with bad redirection table parameter)!\n",
-			portid);
+			port_id);
 		ret = -1;
 	}
 
@@ -772,7 +773,7 @@ out:
 }
 
 int
-gatekeeper_get_rss_config(uint8_t portid,
+gatekeeper_get_rss_config(uint16_t port_id,
 	struct gatekeeper_rss_config *rss_conf)
 {
 	int ret = 0;
@@ -781,13 +782,13 @@ gatekeeper_get_rss_config(uint8_t portid,
 
 	/* Get RSS redirection table (RETA) information. */
 	memset(&dev_info, 0, sizeof(dev_info));
-	rte_eth_dev_info_get(portid, &dev_info);
+	rte_eth_dev_info_get(port_id, &dev_info);
 	rss_conf->reta_size = dev_info.reta_size;
 	if (rss_conf->reta_size == 0 ||
 			rss_conf->reta_size > ETH_RSS_RETA_SIZE_512) {
 		RTE_LOG(ERR, PORT,
 			"Failed to setup RSS at port %hhu (invalid RETA size = %hu)!\n",
-			portid, rss_conf->reta_size);
+			port_id, rss_conf->reta_size);
 		ret = -1;
 		goto out;
 	}
@@ -799,17 +800,17 @@ gatekeeper_get_rss_config(uint8_t portid,
 	}
 
 	/* RETA query. */
-	ret = rte_eth_dev_rss_reta_query(portid,
+	ret = rte_eth_dev_rss_reta_query(port_id,
 		rss_conf->reta_conf, rss_conf->reta_size);
 	if (ret == -ENOTSUP) {
 		RTE_LOG(ERR, PORT,
 			"Failed to query RSS configuration at port %hhu hardware doesn't support!\n",
-			portid);
+			port_id);
 		ret = -1;
 	} else if (ret == -EINVAL) {
 		RTE_LOG(ERR, PORT,
 			"Failed to query RSS configuration at port %hhu (RETA query with bad redirection table parameter)!\n",
-			portid);
+			port_id);
 		ret = -1;
 	}
 
@@ -818,7 +819,7 @@ out:
 }
 
 static int
-init_port(struct gatekeeper_if *iface, uint8_t port_id,
+init_port(struct gatekeeper_if *iface, uint16_t port_id,
 	uint8_t *pnum_succ_ports)
 {
 	int ret = rte_eth_dev_configure(port_id, iface->num_rx_queues,
@@ -929,7 +930,7 @@ close_partial:
 }
 
 static int
-start_port(uint8_t port_id, uint8_t *pnum_succ_ports, int wait_for_link)
+start_port(uint16_t port_id, uint8_t *pnum_succ_ports, int wait_for_link)
 {
 	struct rte_eth_link link;
 	uint8_t attempts = 0;

--- a/lib/net.c
+++ b/lib/net.c
@@ -870,27 +870,16 @@ init_iface(struct gatekeeper_if *iface)
 
 	/* Initialize all ports on this interface. */
 	for (i = 0; i < iface->num_ports; i++) {
-		struct rte_pci_addr pci_addr;
-		uint8_t port_id;
-
-		ret = eal_parse_pci_DomBDF(iface->pci_addrs[i], &pci_addr);
-		if (ret < 0) {
-			RTE_LOG(ERR, PORT,
-				"Failed to parse PCI %s (err=%d)!\n",
-				iface->pci_addrs[i], ret);
-			goto close_partial;
-		}
-
-		ret = rte_eth_dev_get_port_by_addr(&pci_addr, &port_id);
+		ret = rte_eth_dev_get_port_by_name(iface->pci_addrs[i],
+			&iface->ports[i]);
 		if (ret < 0) {
 			RTE_LOG(ERR, PORT,
 				"Failed to map PCI %s to a port (err=%d)!\n",
 				iface->pci_addrs[i], ret);
 			goto close_partial;
 		}
-		iface->ports[i] = port_id;
 
-		ret = init_port(iface, port_id, &num_succ_ports);
+		ret = init_port(iface, iface->ports[i], &num_succ_ports);
 		if (ret < 0)
 			goto close_partial;
 	}

--- a/lib/net.c
+++ b/lib/net.c
@@ -1262,9 +1262,9 @@ gatekeeper_init_network(struct net_config *net_conf)
 	/* Check port limits. */
 	num_ports = net_conf->front.num_ports +
 		(net_conf->back_iface_enabled ? net_conf->back.num_ports : 0);
-	if (num_ports > rte_eth_dev_count()) {
+	if (num_ports > rte_eth_dev_count_avail()) {
 		RTE_LOG(ERR, GATEKEEPER, "There are only %i network ports available to DPDK/Gatekeeper, but configuration is using %i ports\n",
-			rte_eth_dev_count(), num_ports);
+			rte_eth_dev_count_avail(), num_ports);
 		ret = -1;
 		goto numa;
 	}

--- a/lib/net.c
+++ b/lib/net.c
@@ -889,7 +889,11 @@ init_iface(struct gatekeeper_if *iface)
 	if (iface->num_ports <= 1 && iface->bonding_mode != BONDING_MODE_8023AD)
 		iface->id = iface->ports[0];
 	else {
-		ret = rte_eth_bond_create(iface->name, iface->bonding_mode, 0);
+		char dev_name[64];
+		ret = snprintf(dev_name, sizeof(dev_name), "net_bonding%s",
+			iface->name);
+		RTE_VERIFY(ret > 0 && ret < (int)sizeof(dev_name));
+		ret = rte_eth_bond_create(dev_name, iface->bonding_mode, 0);
 		if (ret < 0) {
 			RTE_LOG(ERR, PORT,
 				"Failed to create bonded port (err=%d)!\n",

--- a/lls/cache.h
+++ b/lls/cache.h
@@ -90,7 +90,7 @@ struct lls_mod_req {
 	 * Port of modification, possibly not
 	 * different from existing port ID in record.
 	 */
-	uint8_t           port_id;
+	uint16_t          port_id;
 
 	/* Timestamp of this modification. */
 	time_t            ts;

--- a/main/main.c
+++ b/main/main.c
@@ -136,7 +136,7 @@ main(int argc, char **argv)
 		rte_exit(EXIT_FAILURE, "Error with EAL initialization!\n");
 
 	/* XXX Set the global log level. Change it as needed. */
-	rte_set_log_level(RTE_LOG_DEBUG);
+	rte_log_set_global_level(RTE_LOG_DEBUG);
 
 	/* Used by the LLS block. */
 	rte_timer_subsystem_init();

--- a/setup.sh
+++ b/setup.sh
@@ -56,7 +56,7 @@ ln -s ${RTE_SDK}/build ${RTE_SDK}/${RTE_TARGET}
 cd ../luajit-2.0
 
 # Build and install.
-make
+make CFLAGS=-fPIC
 sudo make install
 
 cd ../../


### PR DESCRIPTION
The DPDK library in Gatekeeper had not been updated in about 1.5 years. These patches update DPDK and make Gatekeeper adhere to the DPDK changes.
