### PR TITLE
acl: check whether IPv4 ACL is configured

### DIFF
--- a/lib/acl.c
+++ b/lib/acl.c
@@ -58,7 +58,7 @@ drop_unmatched_pkts(struct rte_mbuf **pkts, unsigned int num_pkts,
 int
 process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
 	struct acl_search *acl, struct acl_state *astate,
-	bool proto_if_configured, const char *proto_name)
+	int acl_enabled, const char *proto_name)
 {
 	struct rte_mbuf *pkts[astate->func_count][GATEKEEPER_MAX_PKT_BURST];
 	int num_pkts[astate->func_count];
@@ -66,7 +66,7 @@ process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
 	unsigned int i;
 	int ret;
 
-	if (unlikely(!proto_if_configured)) {
+	if (!acl_enabled) {
 		ret = 0;
 		goto drop_acl_pkts;
 	}

--- a/lib/net.c
+++ b/lib/net.c
@@ -1124,14 +1124,14 @@ out:
 		"net: ntuple filters %s supported on the %s iface\n",
 		iface->hw_filter_ntuple ? "are" : "are NOT", iface->name);
 
-	if (!iface->hw_filter_ntuple && ipv4_if_configured(iface)) {
+	if (ipv4_acl_enabled(iface)) {
 		ret = init_ipv4_acls(iface);
 		if (ret < 0)
 			goto stop_partial;
 	}
 
 	rte_eth_macaddr_get(iface->id, &iface->eth_addr);
-	if (ipv6_if_configured(iface)) {
+	if (ipv6_acl_enabled(iface)) {
 		ret = init_ipv6_acls(iface);
 		if (ret < 0)
 			goto ipv4_acls;


### PR DESCRIPTION
The IPv4 ACL is only used when the ntuple filter is not
available, so before processing IPv4 packets through
the ACL we need to check whether it is configured.