### PR TITLE
gk: fix bugs and style issues

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -1370,7 +1370,7 @@ gk_proc(void *arg)
 		rte_get_tsc_hz()) / (num_buckets * 1000.));
 	if (bucket_scan_timeout_cycles == 0) {
 		RTE_LOG(WARNING, GATEKEEPER,
-			"gk: the value of the field flow_table_full_scan_ms in Gatekeeper configuration is too small!");
+			"gk: the value of the field flow_table_full_scan_ms in Gatekeeper configuration is too small!\n");
 		exiting = true;
 		return -1;
 	}


### PR DESCRIPTION
This patch fix the issues related to the function calls:
rte_lpm_is_rule_present() and rte_lpm6_is_rule_present().

The above two functions will return 1 if the rule exists,
0 if it does not, a negative value on failure.

Also, this patch add a newline for all the log messages.
Otherwise, the log message is hard to parse.