### PR TITLE
gk: drop compile-time parameter GK_MAX_NUM_FIB_ENTRIES

### DIFF
--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -30,12 +30,6 @@
 #include "gatekeeper_sol.h"
 
 /*
- * The LPM reserves 24-bit for the next-hop field.
- * TODO Drop the constant below and make it dynamic.
- */
-#define GK_MAX_NUM_FIB_ENTRIES (256)
-
-/*
  * A flow entry can be in one of three states:
  * request, granted, or declined.
  */


### PR DESCRIPTION
This patch drops an unused compile-time parameter.