### PR TITLE
Gatekeeper logging changes

### DIFF
--- a/cps/main.c
+++ b/cps/main.c
@@ -897,11 +897,8 @@ match_bgp4(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 	if (unlikely(eth_hdr->ether_type != BE_ETHER_TYPE_IPv4))
 		return -ENOENT;
 
-	if (pkt->data_len < minimum_size) {
-		RTE_LOG(NOTICE, GATEKEEPER, "cps: IPv4 BGP packet received is %"PRIx16" bytes but should be at least %hu bytes\n",
-			pkt->data_len, minimum_size);
+	if (pkt->data_len < minimum_size)
 		return -ENOENT;
-	}
 
 	ip4hdr = (struct ipv4_hdr *)&eth_hdr[1];
 	if (ip4hdr->dst_addr != rte_cpu_to_be_32(iface->ip4_addr.s_addr))
@@ -911,11 +908,8 @@ match_bgp4(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 
 	minimum_size = sizeof(*eth_hdr) + ipv4_hdr_len(ip4hdr) +
 		sizeof(*tcp_hdr);
-	if (pkt->data_len < minimum_size) {
-		RTE_LOG(NOTICE, GATEKEEPER, "cps: IPv4 BGP packet received is %"PRIx16" bytes but should be at least %hu bytes\n",
-			pkt->data_len, minimum_size);
+	if (pkt->data_len < minimum_size)
 		return -ENOENT;
-	}
 
 	tcp_hdr = (struct tcp_hdr *)ipv4_skip_exthdr(ip4hdr);
 	if (tcp_hdr->src_port != cps_bgp_port &&
@@ -954,11 +948,8 @@ match_bgp6(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 	if (unlikely(ether_type_be != BE_ETHER_TYPE_IPv6))
 		return -ENOENT;
 
-	if (pkt->data_len < minimum_size) {
-		RTE_LOG(NOTICE, GATEKEEPER, "cps: IPv6 BGP packet received is %"PRIx16" bytes but should be at least %hu bytes\n",
-			pkt->data_len, minimum_size);
+	if (pkt->data_len < minimum_size)
 		return -ENOENT;
-	}
 
 	if ((memcmp(ip6hdr->dst_addr, &iface->ip6_addr,
 			sizeof(iface->ip6_addr)) != 0))
@@ -969,11 +960,8 @@ match_bgp6(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 		return -ENOENT;
 
 	minimum_size += tcp_offset - sizeof(*ip6hdr);
-	if (pkt->data_len < minimum_size) {
-		RTE_LOG(NOTICE, GATEKEEPER, "cps: IPv6 BGP packet received is %"PRIx16" bytes but should be at least %hu bytes\n",
-			pkt->data_len, minimum_size);
+	if (pkt->data_len < minimum_size)
 		return -ENOENT;
-	}
 
 	tcp_hdr = (struct tcp_hdr *)((uint8_t *)ip6hdr + tcp_offset);
 	if (tcp_hdr->src_port != cps_bgp_port &&

--- a/cps/main.c
+++ b/cps/main.c
@@ -890,23 +890,25 @@ match_bgp4(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 		rte_pktmbuf_mtod(pkt, struct ether_hdr *);
 	struct ipv4_hdr *ip4hdr;
 	struct tcp_hdr *tcp_hdr;
-	uint16_t minimum_size = sizeof(*eth_hdr) +
+	uint16_t ether_type_be = pkt_in_skip_l2(pkt, eth_hdr, (void **)&ip4hdr);
+	size_t l2_len = pkt_in_l2_hdr_len(pkt);
+	uint16_t minimum_size = l2_len +
 		sizeof(struct ipv4_hdr) + sizeof(struct tcp_hdr);
 	uint16_t cps_bgp_port = rte_cpu_to_be_16(get_cps_conf()->tcp_port_bgp);
 
-	if (unlikely(eth_hdr->ether_type != BE_ETHER_TYPE_IPv4))
+	if (unlikely(ether_type_be != BE_ETHER_TYPE_IPv4))
 		return -ENOENT;
 
 	if (pkt->data_len < minimum_size)
 		return -ENOENT;
 
-	ip4hdr = (struct ipv4_hdr *)&eth_hdr[1];
-	if (ip4hdr->dst_addr != rte_cpu_to_be_32(iface->ip4_addr.s_addr))
+	if (ip4hdr->dst_addr != iface->ip4_addr.s_addr)
 		return -ENOENT;
+
 	if (ip4hdr->next_proto_id != IPPROTO_TCP)
 		return -ENOENT;
 
-	minimum_size = sizeof(*eth_hdr) + ipv4_hdr_len(ip4hdr) +
+	minimum_size = l2_len + ipv4_hdr_len(ip4hdr) +
 		sizeof(*tcp_hdr);
 	if (pkt->data_len < minimum_size)
 		return -ENOENT;

--- a/gk/main.c
+++ b/gk/main.c
@@ -246,9 +246,7 @@ extract_packet_info(struct rte_mbuf *pkt, struct ipacket *packet)
 
 	default:
 		packet->flow.proto = 0;
-		RTE_LOG(NOTICE, GATEKEEPER,
-			"gk: unknown network layer protocol %" PRIu16 "!\n",
-			ether_type);
+		log_unknown_l2("gk", ether_type);
 		ret = -1;
 		break;
 	}

--- a/gt/main.c
+++ b/gt/main.c
@@ -1212,9 +1212,7 @@ gt_process_unparsed_incoming_pkt(struct acl_search *acl4,
 		return;
 	}
 
-	RTE_LOG(ALERT, GATEKEEPER,
-		"gt: parsing an invalid packet with outer Ethernet type %hu!\n",
-		outer_ethertype);
+	log_unknown_l2("gt", outer_ethertype);
 	rte_pktmbuf_free(pkt);
 }
 

--- a/include/gatekeeper_l2.h
+++ b/include/gatekeeper_l2.h
@@ -23,7 +23,33 @@
 #include <rte_mbuf.h>
 #include <rte_mbuf_ptype.h>
 
+#include "gatekeeper_main.h"
 #include "gatekeeper_net.h"
+
+#define ETHERNET_II_ETHERTYPES (0x0600)
+
+static inline void
+log_unknown_l2(const char *name, uint16_t ether_type)
+{
+	/*
+	 * If this field is >= 0x0600, it is an EtherType
+	 * field from the Ethernet II standard.
+	 *
+	 * If this field is <= 0x05DC, it is a length
+	 * field from the 802.3 standard. Any other
+	 * value is invalid. We only log this when in
+	 * debug mode.
+	 */
+	if (ether_type < ETHERNET_II_ETHERTYPES) {
+		RTE_LOG(DEBUG, GATEKEEPER,
+			"%s: invalid Ethernet field or frame not Ethernet II:%" PRIu16 "!\n",
+			name, ether_type);
+	} else {
+		RTE_LOG(NOTICE, GATEKEEPER,
+			"%s: unknown EtherType %" PRIu16 "!\n",
+			name, ether_type);
+	}
+}
 
 /*
  * Return the L2 header length of a received packet.

--- a/lls/main.c
+++ b/lls/main.c
@@ -254,11 +254,8 @@ match_nd(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 	if (unlikely(ether_type_be != BE_ETHER_TYPE_IPv6))
 		return -ENOENT;
 
-	if (pkt->data_len < ND_NEIGH_PKT_MIN_LEN(l2_len)) {
-		RTE_LOG(NOTICE, GATEKEEPER, "lls: ND packet received is %"PRIx16" bytes but should be at least %lu bytes in %s\n",
-			pkt->data_len, ND_NEIGH_PKT_MIN_LEN(l2_len), __func__);
+	if (pkt->data_len < ND_NEIGH_PKT_MIN_LEN(l2_len))
 		return -ENOENT;
-	}
 
 	if ((memcmp(ip6hdr->dst_addr, &iface->ip6_addr,
 			sizeof(iface->ip6_addr)) != 0) &&
@@ -277,12 +274,8 @@ match_nd(struct rte_mbuf *pkt, struct gatekeeper_if *iface)
 		return -ENOENT;
 
 	if (pkt->data_len < (ND_NEIGH_PKT_MIN_LEN(l2_len) +
-			nd_offset - sizeof(*ip6hdr))) {
-		RTE_LOG(NOTICE, GATEKEEPER, "lls: ND packet received is %"PRIx16" bytes but should be at least %lu bytes in %s\n",
-			pkt->data_len, ND_NEIGH_PKT_MIN_LEN(l2_len) +
-			nd_offset - sizeof(*ip6hdr), __func__);
+			nd_offset - sizeof(*ip6hdr)))
 		return -ENOENT;
-	}
 
 	nd_hdr = (struct icmpv6_hdr *)((uint8_t *)ip6hdr + nd_offset);
 	if (nd_hdr->type != ND_NEIGHBOR_SOLICITATION &&


### PR DESCRIPTION
These are logging changes I found are needed when testing Gatekeeper in other environments.

Packets that had no ACL matches were being logged as BGP and IPv6 ND packets that had errors, which was incorrect.

Packets from other Ethernet standards were being received and interpreted as Ethernet II packets, so error messages were being displayed.