### PR TITLE
KNI changes

### DIFF
--- a/cps/kni.c
+++ b/cps/kni.c
@@ -82,6 +82,23 @@ kni_change_mtu(uint16_t port_id, unsigned int new_mtu)
 	return rte_eth_dev_set_mtu(port_id, new_mtu);
 }
 
+int
+kni_disable_change_mac_address(__attribute__((unused)) uint16_t port_id,
+	__attribute__((unused)) uint8_t *mac_addr)
+{
+	/*
+	 * Gatekeeper does not support changing the MAC addresses
+	 * of its NICs. For example, some blocks cache Ethernet
+	 * headers and are not prepared to change the source MAC
+	 * address in those cached headers.
+	 *
+	 * Therefore, we need to prevent any changes to the KNI's
+	 * MAC address because it must always match the MAC address
+	 * of its corresponding Gatekeeper interface.
+	 */
+	return -ENOTSUP;
+}
+
 static int
 modify_ipaddr(struct mnl_socket *nl, unsigned int cmd, int flags,
 	int family, void *ipaddr, uint8_t prefixlen, const char *kni_name)

--- a/cps/kni.h
+++ b/cps/kni.h
@@ -37,6 +37,7 @@ struct nd_request {
 
 int kni_change_mtu(uint16_t port_id, unsigned int new_mtu);
 int kni_change_if(uint16_t port_id, uint8_t if_up);
+int kni_disable_change_mac_address(uint16_t port_id, uint8_t *mac_addr);
 int kni_config_ip_addrs(struct rte_kni *kni, struct gatekeeper_if *iface);
 int kni_config_link(struct rte_kni *kni);
 int route_event_sock_open(struct cps_config *cps_conf);

--- a/cps/kni.h
+++ b/cps/kni.h
@@ -37,7 +37,8 @@ struct nd_request {
 
 int kni_change_mtu(uint16_t port_id, unsigned int new_mtu);
 int kni_change_if(uint16_t port_id, uint8_t if_up);
-int kni_config(struct rte_kni *kni, struct gatekeeper_if *iface);
+int kni_config_ip_addrs(struct rte_kni *kni, struct gatekeeper_if *iface);
+int kni_config_link(struct rte_kni *kni);
 int route_event_sock_open(struct cps_config *cps_conf);
 void route_event_sock_close(struct cps_config *cps_conf);
 void kni_cps_route_event(struct cps_config *cps_conf);

--- a/cps/main.c
+++ b/cps/main.c
@@ -695,10 +695,7 @@ nodev:
 	ops.port_id = conf.group_id;
 	ops.change_mtu = kni_change_mtu;
 	ops.config_network_if = kni_change_if;
-	/*
-	 * XXX This must be implemented to change KNI MAC address.
-	 * ops.config_mac_address = kni_config_mac_address;
-	 */
+	ops.config_mac_address = kni_disable_change_mac_address;
 
 	*kni = rte_kni_alloc(mp, &conf, &ops);
 	if (*kni == NULL) {


### PR DESCRIPTION
This patch enables Gatekeeper to be able to set KNI links up without using the link up/down API, and instead restarting the device as shown by the KNI sample application.

This means we don't need to have patches in DPDK adding the link up/down API to the ENA and virtio drivers.

It also removes an `XXX` that turned out to be unneeded.