### PR TITLE
sol: add option to define request channel bw

### DIFF
--- a/include/gatekeeper_sol.h
+++ b/include/gatekeeper_sol.h
@@ -113,6 +113,19 @@ struct sol_config {
 	double             tb_rate_approx_err;
 
 	/*
+	 * Bandwidth of request channel in Mbps.
+	 *
+	 * Used only in the case when the Solicitor
+	 * block cannot read the back interface's
+	 * available bandwidth, such as is the case
+	 * with the Amazon ENA. Should be calculated
+	 * by the operator.
+	 *
+	 * Should be set to 0 if not needed.
+	 */
+	double             req_channel_bw_mbps;
+
+	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -200,6 +200,7 @@ struct sol_config {
 	unsigned int enq_burst_size;
 	unsigned int deq_burst_size;
 	double       tb_rate_approx_err;
+	double       req_channel_bw_mbps;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/sol.lua
+++ b/lua/sol.lua
@@ -16,6 +16,11 @@ return function (net_conf, lcore)
 	-- Token bucket rate approximation error.
 	sol_conf.tb_rate_approx_err = 1e-7
 
+	-- Only used when the NIC does not provide a
+	-- guaranteed bandwidth, such as Amazon ENA.
+	-- Otherwise, should be kept as 0.
+	sol_conf.req_channel_bw = 0.0
+
 	-- Setup the sol functional block.
 	local ret = gatekeeper.c.run_sol(net_conf, sol_conf)
 	if ret < 0 then


### PR DESCRIPTION
When the NIC does not support a guaranteed bandwidth
(such as the Amazon ENA), the operator must calculate
and define the desired bandwidth of the request channel.