### PR TITLE
cps: make all compile-time parameters runtime parameters

### DIFF
--- a/cps/kni.c
+++ b/cps/kni.c
@@ -34,9 +34,6 @@
 #include "gatekeeper_main.h"
 #include "kni.h"
 
-/* Number of times to attempt bring a KNI interface up or down. */
-#define NUM_ATTEMPTS_KNI_LINK_SET (5)
-
 /* Maximum number of updates for LPM table to serve at once. */
 #define MAX_CPS_ROUTE_UPDATES (8)
 
@@ -247,7 +244,7 @@ modify_link(struct mnl_socket *nl, struct rte_kni *kni,
 next:
 			attempts++;
 			sleep(1);
-		} while (attempts < NUM_ATTEMPTS_KNI_LINK_SET);
+		} while (attempts < get_cps_conf()->num_attempts_kni_link_set);
 	}
 kill:
 	/* Failed to wait for child or waited for too many attempts. */

--- a/cps/kni.c
+++ b/cps/kni.c
@@ -34,9 +34,6 @@
 #include "gatekeeper_main.h"
 #include "kni.h"
 
-/* Maximum number of updates for LPM table to serve at once. */
-#define MAX_CPS_ROUTE_UPDATES (8)
-
 /*
  * According to init_module(2) and delete_module(2), there
  * are no declarations for these functions in header files.
@@ -821,7 +818,8 @@ del_route(struct route_update *update, struct gk_config *gk_conf)
 void
 kni_cps_route_event(struct cps_config *cps_conf)
 {
-	struct route_update updates[MAX_CPS_ROUTE_UPDATES];
+	uint16_t max_cps_route_updates = cps_conf->max_cps_route_updates;
+	struct route_update updates[max_cps_route_updates];
 	unsigned int i;
 	unsigned int num_updates = 0;
 	char buf[MNL_SOCKET_BUFFER_SIZE];
@@ -844,7 +842,7 @@ kni_cps_route_event(struct cps_config *cps_conf)
 
 		if (updates[num_updates].valid)
 			num_updates++;
-	} while (num_updates < MAX_CPS_ROUTE_UPDATES);
+	} while (num_updates < max_cps_route_updates);
 
 	if (cps_conf->gk == NULL) {
 		RTE_LOG(WARNING, GATEKEEPER,

--- a/cps/main.c
+++ b/cps/main.c
@@ -36,9 +36,6 @@
 /* XXX Sample parameters, need to be tested for better performance. */
 #define CPS_REQ_BURST_SIZE (32)
 
-/* Period between scans of the outstanding resolution requests from KNIs. */
-#define CPS_SCAN_INTERVAL_SEC (5)
-
 static struct cps_config cps_conf;
 
 struct cps_config *
@@ -1125,8 +1122,8 @@ run_cps(struct net_config *net_conf, struct gk_config *gk_conf,
 
 	rte_timer_init(&cps_conf->scan_timer);
 	ret = rte_timer_reset(&cps_conf->scan_timer,
-		CPS_SCAN_INTERVAL_SEC * rte_get_timer_hz(), PERIODICAL,
-		cps_conf->lcore_id, cps_scan, cps_conf);
+		cps_conf->cps_scan_interval_sec * rte_get_timer_hz(),
+		PERIODICAL, cps_conf->lcore_id, cps_scan, cps_conf);
 	if (ret < 0) {
 		RTE_LOG(ERR, TIMER, "Cannot set CPS scan timer\n");
 		goto mailbox;

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -50,6 +50,12 @@ struct cps_config {
 	unsigned int      max_cps_route_updates;
 
 	/*
+	 * Period between scans of the outstanding
+	 * resolution requests from KNIs.
+	 */
+	unsigned int      cps_scan_interval_sec;
+
+	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -46,6 +46,9 @@ struct cps_config {
 	/* Number of times to attempt bring a KNI interface up or down. */
 	unsigned int      num_attempts_kni_link_set;
 
+	/* Maximum number of updates for LPM table to serve at once. */
+	unsigned int      max_cps_route_updates;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -43,6 +43,9 @@ struct cps_config {
 	uint16_t          front_max_pkt_burst;
 	uint16_t          back_max_pkt_burst;
 
+	/* Number of times to attempt bring a KNI interface up or down. */
+	unsigned int      num_attempts_kni_link_set;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -24,6 +24,9 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	-- Number of times to attempt bring a KNI interface up or down.
 	cps_conf.num_attempts_kni_link_set = 5
 
+	-- Maximum number of updates for LPM table to serve at once.
+	cps_conf.max_cps_route_updates = 8
+
 	local ret = gatekeeper.c.run_cps(net_conf, gk_conf, gt_conf,
 		cps_conf, lls_conf, kni_kmod_path)
 	if ret < 0 then

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -27,6 +27,10 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	-- Maximum number of updates for LPM table to serve at once.
 	cps_conf.max_cps_route_updates = 8
 
+	-- Period between scans of the outstanding
+	-- resolution requests from KNIs.
+	cps_conf.cps_scan_interval_sec = 5
+
 	local ret = gatekeeper.c.run_cps(net_conf, gk_conf, gt_conf,
 		cps_conf, lls_conf, kni_kmod_path)
 	if ret < 0 then

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -21,6 +21,9 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	cps_conf.front_max_pkt_burst = 32
 	cps_conf.back_max_pkt_burst = 32
 
+	-- Number of times to attempt bring a KNI interface up or down.
+	cps_conf.num_attempts_kni_link_set = 5
+
 	local ret = gatekeeper.c.run_cps(net_conf, gk_conf, gt_conf,
 		cps_conf, lls_conf, kni_kmod_path)
 	if ret < 0 then

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -187,6 +187,7 @@ struct cps_config {
 	uint16_t     front_max_pkt_burst;
 	uint16_t     back_max_pkt_burst;
 	unsigned int num_attempts_kni_link_set;
+	unsigned int max_cps_route_updates;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -188,6 +188,7 @@ struct cps_config {
 	uint16_t     back_max_pkt_burst;
 	unsigned int num_attempts_kni_link_set;
 	unsigned int max_cps_route_updates;
+	unsigned int cps_scan_interval_sec;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -186,6 +186,7 @@ struct cps_config {
 	int          debug;
 	uint16_t     front_max_pkt_burst;
 	uint16_t     back_max_pkt_burst;
+	unsigned int num_attempts_kni_link_set;
 	/* This struct has hidden fields. */
 };
 


### PR DESCRIPTION
This patch makes all cps compile-time parameters runtime parameters, except for the mailbox related parameters, which are dealt in a special theme for mailbox (i.e., #126 )