### PR TITLE
gatekeeper: add dynamic log type for gatekeeper

### DIFF
--- a/config/static.c
+++ b/config/static.c
@@ -253,8 +253,7 @@ config_gatekeeper(const char *lua_base_dir, const char *gatekeeper_config_file)
 
 	lua_state = luaL_newstate();
 	if (!lua_state) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"config: failed to create new Lua state\n");
+		G_LOG(ERR, "config: failed to create new Lua state\n");
 		return -1;
 	}
 
@@ -263,8 +262,7 @@ config_gatekeeper(const char *lua_base_dir, const char *gatekeeper_config_file)
 	set_lua_path(lua_state, lua_base_dir);
 	ret = luaL_loadfile(lua_state, lua_entry_path);
 	if (ret != 0) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"config: %s\n", lua_tostring(lua_state, -1));
+		G_LOG(ERR, "config: %s\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
 	}
@@ -281,8 +279,7 @@ config_gatekeeper(const char *lua_base_dir, const char *gatekeeper_config_file)
 	 */
 	ret = lua_pcall(lua_state, 0, 0, 0);
 	if (ret != 0) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"config: %s\n", lua_tostring(lua_state, -1));
+		G_LOG(ERR, "config: %s\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
 	}
@@ -291,16 +288,14 @@ config_gatekeeper(const char *lua_base_dir, const char *gatekeeper_config_file)
 	lua_getglobal(lua_state, "gatekeeper_init");
 	ret = lua_pcall(lua_state, 0, 1, 0);
 	if (ret != 0) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"config: %s\n", lua_tostring(lua_state, -1));
+		G_LOG(ERR, "config: %s\n", lua_tostring(lua_state, -1));
 		ret = -1;
 		goto out;
 	}
 
 	ret = luaL_checkinteger(lua_state, -1);
 	if (ret < 0)
-		RTE_LOG(ERR, GATEKEEPER,
-			"config: gatekeeper_init() return value is %d\n",
+		G_LOG(ERR, "config: gatekeeper_init() return value is %d\n",
 			ret);
 
 out:

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -407,9 +407,7 @@ setup_neighbor_tbl(unsigned int socket_id, int identifier,
 	neigh_hash_params.socket_id = socket_id;
 	neigh->hash_table = rte_hash_create(&neigh_hash_params);
 	if (neigh->hash_table == NULL) {
-		RTE_LOG(ERR, HASH,
-			"The GK block cannot create hash table for neighbor FIB\n");
-
+		GK_LOG(ERR, "Cannot create hash table for neighbor FIB\n");
 		ret = -1;
 		goto out;
 	}
@@ -418,9 +416,7 @@ setup_neighbor_tbl(unsigned int socket_id, int identifier,
 	neigh->cache_tbl = rte_calloc(NULL,
 		ht_size, sizeof(struct ether_cache), 0);
 	if (neigh->cache_tbl == NULL) {
-		RTE_LOG(ERR, MALLOC,
-			"The GK block cannot create Ethernet header cache table\n");
-
+		GK_LOG(ERR, "Cannot create Ethernet header cache table\n");
 		ret = -1;
 		goto neigh_hash;
 	}

--- a/include/gatekeeper_l2.h
+++ b/include/gatekeeper_l2.h
@@ -41,12 +41,12 @@ log_unknown_l2(const char *name, uint16_t ether_type)
 	 * debug mode.
 	 */
 	if (ether_type < ETHERNET_II_ETHERTYPES) {
-		RTE_LOG(DEBUG, GATEKEEPER,
-			"%s: invalid Ethernet field or frame not Ethernet II:%" PRIu16 "\n",
+		G_LOG(DEBUG,
+			"l2: %s: invalid Ethernet field or frame not Ethernet II:%" PRIu16 "\n",
 			name, ether_type);
 	} else {
-		RTE_LOG(NOTICE, GATEKEEPER,
-			"%s: unknown EtherType %" PRIu16 "\n",
+		G_LOG(NOTICE,
+			"l2: %s: unknown EtherType %" PRIu16 "\n",
 			name, ether_type);
 	}
 }

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -33,8 +33,6 @@
  * Custom log type for Gatekeeper-related log entries
  * that are not relevant to a specific block.
  */
-#define RTE_LOGTYPE_GATEKEEPER RTE_LOGTYPE_USER1
-
 extern int gatekeeper_logtype;
 
 #define G_LOG(level, ...)		\

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -35,6 +35,12 @@
  */
 #define RTE_LOGTYPE_GATEKEEPER RTE_LOGTYPE_USER1
 
+extern int gatekeeper_logtype;
+
+#define G_LOG(level, ...)		\
+	rte_log(RTE_LOG_ ## level,	\
+	gatekeeper_logtype, "GATEKEEPER: " __VA_ARGS__)
+
 extern volatile int exiting;
 
 extern uint64_t cycles_per_sec;

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -333,6 +333,12 @@ struct net_config {
 	 */
 	bool                 *numa_used;
 
+	/* Log level for all non-block related activity. */
+	uint32_t             log_level;
+
+	/* Dynamic logging type, assigned at runtime. */
+	int                  log_type;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.

--- a/include/seqlock.h
+++ b/include/seqlock.h
@@ -70,8 +70,8 @@ __read_once_size(const volatile void *p, void *res, int size)
 		break;
 
  	default:
-		RTE_LOG(WARNING, GATEKEEPER,
-			"seqlock: Data access exceeds word size and won't be atomic\n");
+		G_LOG(WARNING,
+			"seqlock: data access exceeds word size and won't be atomic\n");
 		break;
 	}
 }

--- a/lib/acl.c
+++ b/lib/acl.c
@@ -62,7 +62,7 @@ drop_unmatched_pkts(struct rte_mbuf **pkts, unsigned int num_pkts,
 		 *   Gatekeeper down since Gatekeeper does a lot of
 		 *   processing to eventually discard these packets.
 		 */
-		RTE_LOG(WARNING, GATEKEEPER,
+		G_LOG(WARNING,
 			"acl: a packet failed to match any ACL rules, the whole packet is dumped below:\n");
 		/*
 		 * XXX #76 The default output used DPDK logging system
@@ -97,8 +97,8 @@ process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
 	ret = rte_acl_classify(astate->acls[socket_id],
 		acl->data, res, acl->num, 1);
 	if (unlikely(ret < 0)) {
-		RTE_LOG(ERR, ACL,
-			"invalid arguments given to %s rte_acl_classify()\n",
+		G_LOG(ERR,
+			"acl: invalid arguments given to %s rte_acl_classify()\n",
 			proto_name);
 		goto drop_acl_pkts;
 	}
@@ -140,7 +140,7 @@ process_acl(struct gatekeeper_if *iface, unsigned int lcore_id,
 			 * Each ACL function is responsible for
 			 * freeing packets not already handled.
 			 */
-			RTE_LOG(WARNING, GATEKEEPER,
+			G_LOG(WARNING,
 				"acl: %s ACL function %d failed on %s iface\n",
 				proto_name, i, iface->name);
 		}
@@ -255,7 +255,7 @@ register_ipv4_acl(struct ipv4_acl_rule *ipv4_rules, unsigned int num_rules,
 	unsigned int i;
 
 	if (iface->ipv4_acls.func_count == GATEKEEPER_ACL_MAX) {
-		RTE_LOG(ERR, GATEKEEPER, "acl: cannot install more IPv4 ACL types on the %s iface\n",
+		G_LOG(ERR, "acl: cannot install more IPv4 ACL types on the %s iface\n",
 			iface->name);
 		return -1;
 	}
@@ -273,7 +273,7 @@ register_ipv4_acl(struct ipv4_acl_rule *ipv4_rules, unsigned int num_rules,
 		ret = rte_acl_add_rules(iface->ipv4_acls.acls[i],
 			(struct rte_acl_rule *)ipv4_rules, num_rules);
 		if (ret < 0) {
-			RTE_LOG(ERR, ACL, "Failed to add IPv4 ACL rules on the %s interface on socket %d\n",
+			G_LOG(ERR, "acl: failed to add IPv4 ACL rules on the %s interface on socket %d\n",
 				iface->name, i);
 			return ret;
 		}
@@ -307,8 +307,8 @@ build_ipv4_acls(struct gatekeeper_if *iface)
 		ret = rte_acl_build(iface->ipv4_acls.acls[i],
 			&acl_build_params);
 		if (ret < 0) {
-			RTE_LOG(ERR, ACL,
-				"Failed to build IPv4 ACL for the %s iface\n",
+			G_LOG(ERR,
+				"acl: failed to build IPv4 ACL for the %s iface\n",
 				iface->name);
 			return ret;
 		}
@@ -344,7 +344,7 @@ init_ipv4_acls(struct gatekeeper_if *iface)
 		if (iface->ipv4_acls.acls[i] == NULL) {
 			unsigned int j;
 
-			RTE_LOG(ERR, ACL, "Failed to create IPv4 ACL for the %s iface on socket %d\n",
+			G_LOG(ERR, "acl: failed to create IPv4 ACL for the %s iface on socket %d\n",
 				iface->name, i);
 			for (j = 0; j < i; j++) {
 				rte_acl_free(iface->ipv4_acls.acls[i]);
@@ -480,7 +480,7 @@ register_ipv6_acl(struct ipv6_acl_rule *ipv6_rules, unsigned int num_rules,
 	unsigned int i;
 
 	if (iface->ipv6_acls.func_count == GATEKEEPER_ACL_MAX) {
-		RTE_LOG(ERR, GATEKEEPER, "acl: cannot install more IPv6 ACL types on the %s iface\n",
+		G_LOG(ERR, "acl: cannot install more IPv6 ACL types on the %s iface\n",
 			iface->name);
 		return -1;
 	}
@@ -498,7 +498,7 @@ register_ipv6_acl(struct ipv6_acl_rule *ipv6_rules, unsigned int num_rules,
 		ret = rte_acl_add_rules(iface->ipv6_acls.acls[i],
 			(struct rte_acl_rule *)ipv6_rules, num_rules);
 		if (ret < 0) {
-			RTE_LOG(ERR, ACL, "Failed to add IPv6 ACL rules on the %s interface on socket %d\n",
+			G_LOG(ERR, "acl: failed to add IPv6 ACL rules on the %s interface on socket %d\n",
 				iface->name, i);
 			return ret;
 		}
@@ -532,8 +532,8 @@ build_ipv6_acls(struct gatekeeper_if *iface)
 		ret = rte_acl_build(iface->ipv6_acls.acls[i],
 			&acl_build_params);
 		if (ret < 0) {
-			RTE_LOG(ERR, ACL,
-				"Failed to build IPv6 ACL for the %s iface\n",
+			G_LOG(ERR,
+				"acl: failed to build IPv6 ACL for the %s iface\n",
 				iface->name);
 			return ret;
 		}
@@ -569,7 +569,7 @@ init_ipv6_acls(struct gatekeeper_if *iface)
 		if (iface->ipv6_acls.acls[i] == NULL) {
 			unsigned int j;
 
-			RTE_LOG(ERR, ACL, "Failed to create IPv6 ACL for the %s iface on socket %d\n",
+			G_LOG(ERR, "acl: failed to create IPv6 ACL for the %s iface on socket %d\n",
 				iface->name, i);
 			for (j = 0; j < i; j++) {
 				rte_acl_free(iface->ipv6_acls.acls[i]);

--- a/lib/flow.c
+++ b/lib/flow.c
@@ -122,28 +122,28 @@ print_flow_err_msg(struct ip_flow *flow, const char *err_msg)
 	if (flow->proto == ETHER_TYPE_IPv4) {
 		if (inet_ntop(AF_INET, &flow->f.v4.src,
 				src, sizeof(src)) == NULL) {
-			RTE_LOG(ERR, GATEKEEPER, "%s: failed to convert a number to an IPv4 address (%s)\n",
+			G_LOG(ERR, "flow: %s: failed to convert a number to an IPv4 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
 
 		if (inet_ntop(AF_INET, &flow->f.v4.dst,
 				dst, sizeof(dst)) == NULL) {
-			RTE_LOG(ERR, GATEKEEPER, "%s: failed to convert a number to an IPv4 address (%s)\n",
+			G_LOG(ERR, "flow: %s: failed to convert a number to an IPv4 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
 	} else if (likely(flow->proto == ETHER_TYPE_IPv6)) {
 		if (inet_ntop(AF_INET6, flow->f.v6.src,
 				src, sizeof(src)) == NULL) {
-			RTE_LOG(ERR, GATEKEEPER, "%s: failed to convert a number to an IPv6 address (%s)\n",
+			G_LOG(ERR, "flow: %s: failed to convert a number to an IPv6 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
 
 		if (inet_ntop(AF_INET6, flow->f.v6.dst,
 				dst, sizeof(dst)) == NULL) {
-			RTE_LOG(ERR, GATEKEEPER, "%s: failed to convert a number to an IPv6 address (%s)\n",
+			G_LOG(ERR, "flow: %s: failed to convert a number to an IPv6 address (%s)\n",
 				__func__, strerror(errno));
 			return;
 		}
@@ -151,7 +151,7 @@ print_flow_err_msg(struct ip_flow *flow, const char *err_msg)
 		rte_panic("Unexpected condition at %s: unknown flow type %hu\n",
 			__func__, flow->proto);
 
-	RTE_LOG(ERR, GATEKEEPER,
-		"%s for the flow with IP source address %s, and destination address %s\n",
+	G_LOG(ERR,
+		"flow: %s for the flow with IP source address %s, and destination address %s\n",
 		err_msg, src, dst);
 }

--- a/lib/ipip.c
+++ b/lib/ipip.c
@@ -55,8 +55,7 @@ encapsulate(struct rte_mbuf *pkt, uint8_t priority,
 		/* Allocate space for outer IPv4 header and L2 header. */
 		eth_hdr = adjust_pkt_len(pkt, iface, sizeof(struct ipv4_hdr));
 		if (eth_hdr == NULL) {
-			RTE_LOG(ERR, GATEKEEPER,
-				"ipip: could not adjust IPv4 packet length\n");
+			G_LOG(ERR, "ipip: could not adjust IPv4 packet length\n");
 			return -1;
 		}
 
@@ -94,8 +93,7 @@ encapsulate(struct rte_mbuf *pkt, uint8_t priority,
 		/* Allocate space for new IPv6 header and L2 header. */
 		eth_hdr = adjust_pkt_len(pkt, iface, sizeof(struct ipv6_hdr));
 		if (eth_hdr == NULL) {
-			RTE_LOG(ERR, GATEKEEPER,
-				"ipip: could not adjust IPv6 packet length\n");
+			G_LOG(ERR, "ipip: could not adjust IPv6 packet length\n");
 			return -1;
 		}
 

--- a/lib/l2.c
+++ b/lib/l2.c
@@ -58,8 +58,8 @@ adjust_pkt_len(struct rte_mbuf *pkt, struct gatekeeper_if *iface,
 		eth_hdr = (struct ether_hdr *)rte_pktmbuf_prepend(pkt,
 			bytes_to_add);
 		if (eth_hdr == NULL) {
-			RTE_LOG(ERR, MBUF,
-				"Not enough headroom space in the first segment\n");
+			G_LOG(ERR,
+				"l2: not enough headroom space in the first segment\n");
 			return NULL;
 		}
 	} else if (bytes_to_add < 0) {
@@ -70,8 +70,7 @@ adjust_pkt_len(struct rte_mbuf *pkt, struct gatekeeper_if *iface,
 		eth_hdr = (struct ether_hdr *)rte_pktmbuf_adj(pkt,
 			-bytes_to_add);
 		if (eth_hdr == NULL) {
-			RTE_LOG(ERR, MBUF,
-				"Could not remove headroom space\n");
+			G_LOG(ERR, "l2: could not remove headroom space\n");
 			return NULL;
 		}
 	} else
@@ -96,8 +95,8 @@ verify_l2_hdr(struct gatekeeper_if *iface, struct ether_hdr *eth_hdr,
 		 * we would have to make space for a new header.
 		 */
 		if (unlikely(l2_type != RTE_PTYPE_L2_ETHER_VLAN)) {
-			RTE_LOG(WARNING, GATEKEEPER,
-				"lls: %s interface incorrectly received an %s packet without a VLAN header\n",
+			G_LOG(WARNING,
+				"l2: %s interface incorrectly received an %s packet without a VLAN header\n",
 				iface->name, proto_name);
 			return -1;
 		}
@@ -108,8 +107,8 @@ verify_l2_hdr(struct gatekeeper_if *iface, struct ether_hdr *eth_hdr,
 		 */
 		vlan_hdr = (struct vlan_hdr *)&eth_hdr[1];
 		if (unlikely(vlan_hdr->vlan_tci != iface->vlan_tag_be)) {
-			RTE_LOG(WARNING, GATEKEEPER,
-				"lls: %s interface received an %s packet with an incorrect VLAN tag (0x%02x but should be 0x%02x)\n",
+			G_LOG(WARNING,
+				"l2: %s interface received an %s packet with an incorrect VLAN tag (0x%02x but should be 0x%02x)\n",
 				iface->name, proto_name,
 				rte_be_to_cpu_16(vlan_hdr->vlan_tci),
 				rte_be_to_cpu_16(iface->vlan_tag_be));
@@ -120,8 +119,8 @@ verify_l2_hdr(struct gatekeeper_if *iface, struct ether_hdr *eth_hdr,
 		 * Drop packets that have a VLAN header when we're not expecting
 		 * one, since we would have to remove space in the header.
 		 */
-		RTE_LOG(WARNING, GATEKEEPER,
-			"lls: %s interface incorrectly received an %s packet with a VLAN header\n",
+		G_LOG(WARNING,
+			"l2: %s interface incorrectly received an %s packet with a VLAN header\n",
 			iface->name, proto_name);
 		return -1;
 	}

--- a/lib/launch.c
+++ b/lib/launch.c
@@ -51,7 +51,7 @@ launch_at_stage1(lcore_function_t *f, void *arg)
 
 	entry = rte_malloc(__func__, sizeof(*entry), 0);
 	if (entry == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: DPDK ran out of memory", __func__);
+		G_LOG(ERR, "launch: %s: DPDK ran out of memory", __func__);
 		return -1;
 	}
 
@@ -103,7 +103,7 @@ launch_at_stage2(lcore_function_t *f, void *arg)
 
 	entry = rte_malloc(__func__, sizeof(*entry), 0);
 	if (entry == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: DPDK ran out of memory", __func__);
+		G_LOG(ERR, "launch: %s: DPDK ran out of memory", __func__);
 		return -1;
 	}
 
@@ -163,7 +163,7 @@ launch_at_stage3(const char *name, lcore_function_t *f, void *arg,
 
 	entry = rte_malloc(__func__, sizeof(*entry), 0);
 	if (entry == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: DPDK ran out of memory", __func__);
+		G_LOG(ERR, "launch: %s: DPDK ran out of memory", __func__);
 		goto name_cpy;
 	}
 
@@ -214,7 +214,7 @@ launch_stage3(void)
 		ret = rte_eal_remote_launch(entry->f, entry->arg,
 			entry->lcore_id);
 		if (ret != 0) {
-			RTE_LOG(ERR, EAL, "lcore %u failed to launch %s\n",
+			G_LOG(ERR, "launch: lcore %u failed to launch %s\n",
 				entry->lcore_id, entry->name);
 			return ret;
 		}

--- a/lib/lpm.c
+++ b/lib/lpm.c
@@ -39,8 +39,8 @@ init_ipv4_lpm(const char *tag,
 
 	lpm = rte_lpm_create(lpm_name, socket_id, lpm_conf);
 	if (lpm == NULL) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"Unable to create the IPv4 LPM table %s on socket %u\n",
+		G_LOG(ERR,
+			"lpm: unable to create the IPv4 LPM table %s on socket %u\n",
 			lpm_name, socket_id);
 		return NULL;
 	}
@@ -57,12 +57,11 @@ lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip)
 
 	ret = rte_lpm_lookup(lpm, ntohl(ip), &next_hop);
 	if (ret == -EINVAL) {
-		RTE_LOG(ERR, LPM,
-			"lpm: incorrect arguments for IPv4 lookup\n");
+		G_LOG(ERR, "lpm: incorrect arguments for IPv4 lookup\n");
 		ret = -1;
 		goto out;
 	} else if (ret == -ENOENT) {
-		RTE_LOG(WARNING, LPM, "lpm: IPv4 lookup miss\n");
+		G_LOG(WARNING, "lpm: IPv4 lookup miss\n");
 		ret = -1;
 		goto out;
 	}
@@ -88,8 +87,8 @@ init_ipv6_lpm(const char *tag,
 
 	lpm = rte_lpm6_create(lpm_name, socket_id, lpm6_conf);
 	if (lpm == NULL) {
-		RTE_LOG(ERR, GATEKEEPER,
-			"Unable to create the IPv6 LPM table %s on socket %u\n",
+		G_LOG(ERR,
+			"lpm: unable to create the IPv6 LPM table %s on socket %u\n",
 			lpm_name, socket_id);
 		return NULL;
 	}
@@ -105,12 +104,11 @@ lpm_lookup_ipv6(struct rte_lpm6 *lpm, uint8_t *ip)
 
 	ret = rte_lpm6_lookup(lpm, ip, &next_hop);
 	if (ret == -EINVAL) {
-		RTE_LOG(ERR, LPM,
-			"lpm: incorrect arguments for IPv6 lookup\n");
+		G_LOG(ERR, "lpm: incorrect arguments for IPv6 lookup\n");
 		ret = -1;
 		goto out;
 	} else if (ret == -ENOENT) {
-		RTE_LOG(WARNING, LPM, "lpm: IPv6 lookup miss\n");
+		G_LOG(WARNING, "lpm: IPv6 lookup miss\n");
 		ret = -1;
 		goto out;
 	}

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -42,7 +42,7 @@ init_mailbox(const char *tag, int mailbox_max_entries_exp,
 		ring_name, 1 << mailbox_max_entries_exp,
 		socket_id, RING_F_SC_DEQ);
     	if (mb->ring == NULL) {
-		RTE_LOG(ERR, RING,
+		G_LOG(ERR,
 			"mailbox: can't create ring %s (len = %d) at lcore %u\n",
 			ring_name, ret, lcore_id);
 		ret = -1;
@@ -57,7 +57,7 @@ init_mailbox(const char *tag, int mailbox_max_entries_exp,
 		pool_name, (1 << mailbox_max_entries_exp) - 1, ele_size,
 		cache_size, 0, NULL, NULL, NULL, NULL, socket_id, 0);
     	if (mb->pool == NULL) {
-		RTE_LOG(ERR, MEMPOOL,
+		G_LOG(ERR,
 			"mailbox: can't create mempool %s (len = %d) at lcore %u\n",
 			pool_name, ret, lcore_id);
 		ret = -1;
@@ -79,8 +79,7 @@ mb_alloc_entry(struct mailbox *mb)
 	void *obj = NULL;
 	int ret = rte_mempool_get(mb->pool, &obj);
 	if (ret == -ENOENT) {
-		RTE_LOG(ERR, MEMPOOL,
-			"mailbox: not enough entries in the mempool.\n");
+		G_LOG(ERR, "mailbox: not enough entries in the mempool\n");
 		return NULL;
 	}
 
@@ -94,12 +93,12 @@ mb_send_entry(struct mailbox *mb, void *obj)
 {
 	int ret = rte_ring_mp_enqueue(mb->ring, obj);
 	if (ret == -EDQUOT) {
-		RTE_LOG(WARNING, RING,
-			"mailbox: high water mark exceeded. The object has been enqueued.\n");
+		G_LOG(WARNING,
+			"mailbox: high water mark exceeded; the object has been enqueued\n");
 		ret = 0;
 	} else if (ret == -ENOBUFS) {
-		RTE_LOG(ERR, RING,
-			"mailbox: quota exceeded. Not enough room in the ring to enqueue.\n");
+		G_LOG(ERR,
+			"mailbox: quota exceeded; not enough room in the ring to enqueue\n");
 		mb_free_entry(mb, obj);
 	} else
 		RTE_VERIFY(ret == 0);

--- a/lib/net.c
+++ b/lib/net.c
@@ -1330,6 +1330,12 @@ gatekeeper_init_network(struct net_config *net_conf)
 	if (net_conf == NULL)
 		return -1;
 
+	net_conf->log_type = gatekeeper_logtype;
+
+	ret = rte_log_set_level(net_conf->log_type, net_conf->log_level);
+	if (ret < 0)
+		return -1;
+
 	net_conf->numa_nodes = find_num_numa_nodes();
 	net_conf->numa_used = rte_calloc("numas", net_conf->numa_nodes,
 		sizeof(*net_conf->numa_used), 0);

--- a/lib/net.c
+++ b/lib/net.c
@@ -135,20 +135,20 @@ ethertype_filter_add(uint16_t port_id, uint16_t ether_type, uint16_t queue_id)
 		RTE_ETH_FILTER_ADD,
 		&filter);
 	if (ret == -ENOTSUP) {
-		RTE_LOG(NOTICE, PORT,
-			"Hardware doesn't support adding an EtherType filter for 0x%02hx on port %hhu\n",
+		G_LOG(NOTICE,
+			"net: hardware doesn't support adding an EtherType filter for 0x%02hx on port %hhu\n",
 			ether_type, port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -ENODEV) {
-		RTE_LOG(NOTICE, PORT,
-			"Port %hhu is invalid for adding an EtherType filter for 0x%02hx\n",
+		G_LOG(NOTICE,
+			"net: port %hhu is invalid for adding an EtherType filter for 0x%02hx\n",
 			port_id, ether_type);
 		ret = -1;
 		goto out;
 	} else if (ret != 0) {
-		RTE_LOG(NOTICE, PORT,
-			"Other errors that depend on the specific operations implementation on port %hhu for adding an EtherType filter for 0x%02hx\n",
+		G_LOG(NOTICE,
+			"net: other errors that depend on the specific operations implementation on port %hhu for adding an EtherType filter for 0x%02hx\n",
 			port_id, ether_type);
 		ret = -1;
 		goto out;
@@ -220,20 +220,20 @@ ntuple_filter_add(uint16_t port_id, uint32_t dst_ip,
 		RTE_ETH_FILTER_ADD,
 		&filter_v4);
 	if (ret == -ENOTSUP) {
-		RTE_LOG(ERR, PORT,
-			"Hardware doesn't support adding an IPv4 ntuple filter on port %hhu\n",
+		G_LOG(ERR,
+			"net: hardware doesn't support adding an IPv4 ntuple filter on port %hhu\n",
 			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -ENODEV) {
-		RTE_LOG(ERR, PORT,
-			"Port %hhu is invalid for adding an IPv4 ntuple filter\n",
+		G_LOG(ERR,
+			"net: port %hhu is invalid for adding an IPv4 ntuple filter\n",
 			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret != 0) {
-		RTE_LOG(ERR, PORT,
-			"Other errors that depend on the specific operations implementation on port %hhu for adding an IPv4 ntuple filter\n",
+		G_LOG(ERR,
+			"net: other errors that depend on the specific operations implementation on port %hhu for adding an IPv4 ntuple filter\n",
 			port_id);
 		ret = -1;
 		goto out;
@@ -247,20 +247,20 @@ ipv6:
 		RTE_ETH_FILTER_ADD,
 		&filter_v6);
 	if (ret == -ENOTSUP) {
-		RTE_LOG(ERR, PORT,
-			"Hardware doesn't support adding an IPv6 ntuple filter on port %hhu\n",
+		G_LOG(ERR,
+			"net: hardware doesn't support adding an IPv6 ntuple filter on port %hhu\n",
 			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -ENODEV) {
-		RTE_LOG(ERR, PORT,
-			"Port %hhu is invalid for adding an IPv6 ntuple filter\n",
+		G_LOG(ERR,
+			"net: port %hhu is invalid for adding an IPv6 ntuple filter\n",
 			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret != 0) {
-		RTE_LOG(ERR, PORT,
-			"Other errors that depend on the specific operations implementation on port %hhu for adding an IPv6 ntuple filter\n",
+		G_LOG(ERR,
+			"net: other errors that depend on the specific operations implementation on port %hhu for adding an IPv6 ntuple filter\n",
 			port_id);
 		ret = -1;
 		goto out;
@@ -296,7 +296,7 @@ configure_queue(uint16_t port_id, uint16_t queue_id, enum queue_type ty,
 		ret = rte_eth_rx_queue_setup(port_id, queue_id,
 			GATEKEEPER_NUM_RX_DESC, numa_node, NULL, mp);
 		if (ret < 0) {
-			RTE_LOG(ERR, PORT, "Failed to configure port %hhu rx_queue %hu (err=%d)\n",
+			G_LOG(ERR, "net: failed to configure port %hhu rx_queue %hu (err=%d)\n",
 				port_id, queue_id, ret);
 			return ret;
 		}
@@ -305,14 +305,13 @@ configure_queue(uint16_t port_id, uint16_t queue_id, enum queue_type ty,
 		ret = rte_eth_tx_queue_setup(port_id, queue_id,
 			GATEKEEPER_NUM_TX_DESC, numa_node, NULL);
 		if (ret < 0) {
-			RTE_LOG(ERR, PORT, "Failed to configure port %hhu tx_queue %hu (err=%d)\n",
+			G_LOG(ERR, "net: failed to configure port %hhu tx_queue %hu (err=%d)\n",
 				port_id, queue_id, ret);
 			return ret;
 		}
 		break;
 	default:
-		RTE_LOG(ERR, GATEKEEPER,
-			"Unsupported queue type (%d) passed to %s\n",
+		G_LOG(ERR, "net: unsupported queue type (%d) passed to %s\n",
 			ty, __func__);
 		return -1;
 	}
@@ -354,7 +353,7 @@ get_queue_id(struct gatekeeper_if *iface, enum queue_type ty,
 	new_queue_id = rte_atomic16_add_return(ty == QUEUE_TYPE_RX ?
 		&iface->rx_queue_id : &iface->tx_queue_id, 1);
 	if (new_queue_id == GATEKEEPER_QUEUE_UNALLOCATED) {
-		RTE_LOG(ERR, GATEKEEPER, "net: exhausted all %s queues for the %s interface; this is likely a bug\n",
+		G_LOG(ERR, "net: exhausted all %s queues for the %s interface; this is likely a bug\n",
 			(ty == QUEUE_TYPE_RX) ? "RX" : "TX", iface->name);
 		return -1;
 	}
@@ -491,15 +490,13 @@ get_ip_type(const char *ip_addr)
 
 	ret = getaddrinfo(ip_addr, NULL, &hint, &res);
     	if (ret) {
-        	RTE_LOG(ERR, GATEKEEPER,
-			"gk: invalid ip address %s; %s\n",
+		G_LOG(ERR, "net: invalid ip address %s; %s\n",
 			ip_addr, gai_strerror(ret));
 		return AF_UNSPEC;
     	}
 
     	if (res->ai_family != AF_INET && res->ai_family != AF_INET6)
-		RTE_LOG(ERR, GATEKEEPER,
-			"gk: %s is an is unknown address format %d\n",
+		G_LOG(ERR, "net: %s is an is unknown address format %d\n",
 			ip_addr, res->ai_family);
 
 	ret = res->ai_family;
@@ -533,18 +530,18 @@ convert_ip_to_str(struct ipaddr *ip_addr, char *res, int n)
 {
 	if (ip_addr->proto == ETHER_TYPE_IPv4) {
 		if (inet_ntop(AF_INET, &ip_addr->ip.v4, res, n) == NULL) {
-			RTE_LOG(ERR, GATEKEEPER, "%s: failed to convert a number to an IPv4 address (%s)\n",
+			G_LOG(ERR, "net: %s: failed to convert a number to an IPv4 address (%s)\n",
 				__func__, strerror(errno));
 			return -1;
 		}
 	} else if (likely(ip_addr->proto == ETHER_TYPE_IPv6)) {
 		if (inet_ntop(AF_INET6, &ip_addr->ip.v6, res, n) == NULL) {
-			RTE_LOG(ERR, GATEKEEPER, "%s: failed to convert a number to an IPv6 address (%s)\n",
+			G_LOG(ERR, "net: %s: failed to convert a number to an IPv6 address (%s)\n",
 				__func__, strerror(errno));
 			return -1;
 		}
 	} else {
-		RTE_LOG(ERR, GATEKEEPER, "Unexpected condition at %s: unknown IP type %hu\n",
+		G_LOG(ERR, "net: unexpected condition at %s: unknown IP type %hu\n",
 			__func__, ip_addr->proto);
 		return -1;
 	}
@@ -560,7 +557,7 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	uint8_t i, j;
 
 	if (num_ip_cidrs < 1 || num_ip_cidrs > 2) {
-		RTE_LOG(ERR, GATEKEEPER,
+		G_LOG(ERR,
 			"net: an interface has at least 1 IP address, also at most 1 IPv4 and 1 IPv6 address.\n");
 		return -1;
 	}
@@ -569,7 +566,7 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 
 	iface->name = rte_malloc("iface_name", strlen(iface_name) + 1, 0);
 	if (iface->name == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: Out of memory for iface name\n",
+		G_LOG(ERR, "net: %s: Out of memory for iface name\n",
 			__func__);
 		return -1;
 	}
@@ -578,7 +575,7 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 	iface->pci_addrs = rte_calloc("pci_addrs", num_pci_addrs,
 		sizeof(*pci_addrs), 0);
 	if (iface->pci_addrs == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: Out of memory for PCI array\n",
+		G_LOG(ERR, "net: %s: Out of memory for PCI array\n",
 			__func__);
 		goto name;
 	}
@@ -587,8 +584,8 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 		iface->pci_addrs[i] = rte_malloc(NULL,
 			strlen(pci_addrs[i]) + 1, 0);
 		if (iface->pci_addrs[i] == NULL) {
-			RTE_LOG(ERR, MALLOC,
-				"%s: Out of memory for PCI address %s\n",
+			G_LOG(ERR,
+				"net: %s: Out of memory for PCI address %s\n",
 				__func__, pci_addrs[i]);
 			for (j = 0; j < i; j++)
 				rte_free(iface->pci_addrs[j]);
@@ -637,20 +634,20 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 
 		prefix_len = strtol(prefix_len_str, &end, 10);
 		if (prefix_len_str == end || !*prefix_len_str || *end) {
-			RTE_LOG(ERR, GATEKEEPER,
+			G_LOG(ERR,
 				"net: prefix length \"%s\" is not a number\n",
 				prefix_len_str);
 			goto name;
 		}
 		if ((prefix_len == LONG_MAX || prefix_len == LONG_MIN) &&
 				errno == ERANGE) {
-			RTE_LOG(ERR, GATEKEEPER,
+			G_LOG(ERR,
 				"net: prefix length \"%s\" caused underflow or overflow\n",
 				prefix_len_str);
 			goto name;
 		}
 		if (prefix_len < 0 || prefix_len > max_prefix_len(gk_type)) {
-			RTE_LOG(ERR, GATEKEEPER,
+			G_LOG(ERR,
 				"net: prefix length \"%s\" is out of range\n",
 				prefix_len_str);
 			goto name;
@@ -735,16 +732,16 @@ gatekeeper_setup_rss(uint16_t port_id, uint16_t *queues, uint16_t num_queues)
 	memset(&dev_info, 0, sizeof(dev_info));
 	rte_eth_dev_info_get(port_id, &dev_info);
 	if (dev_info.reta_size == 0) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu (invalid RETA size = 0)\n",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu (invalid RETA size = 0)\n",
 			port_id);
 		ret = -1;
 		goto out;
 	}
 
 	if (dev_info.reta_size > ETH_RSS_RETA_SIZE_512) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu (invalid RETA size = %u)\n",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu (invalid RETA size = %u)\n",
 			port_id, dev_info.reta_size);
 		ret = -1;
 		goto out;
@@ -767,14 +764,14 @@ gatekeeper_setup_rss(uint16_t port_id, uint16_t *queues, uint16_t num_queues)
 	ret = rte_eth_dev_rss_reta_update(port_id, reta_conf,
 		dev_info.reta_size);
 	if (ret == -ENOTSUP) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu hardware doesn't support.",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu hardware doesn't support\n",
 			port_id);
 		ret = -1;
 		goto out;
 	} else if (ret == -EINVAL) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu (RETA update with bad redirection table parameter)\n",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu (RETA update with bad redirection table parameter)\n",
 			port_id);
 		ret = -1;
 		goto out;
@@ -784,13 +781,13 @@ gatekeeper_setup_rss(uint16_t port_id, uint16_t *queues, uint16_t num_queues)
 	ret = rte_eth_dev_rss_reta_query(port_id, reta_conf,
 		dev_info.reta_size);
 	if (ret == -ENOTSUP) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu hardware doesn't support.",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu hardware doesn't support\n",
 			port_id);
 		ret = -1;
 	} else if (ret == -EINVAL) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu (RETA query with bad redirection table parameter)\n",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu (RETA query with bad redirection table parameter)\n",
 			port_id);
 		ret = -1;
 	}
@@ -813,8 +810,8 @@ gatekeeper_get_rss_config(uint16_t port_id,
 	rss_conf->reta_size = dev_info.reta_size;
 	if (rss_conf->reta_size == 0 ||
 			rss_conf->reta_size > ETH_RSS_RETA_SIZE_512) {
-		RTE_LOG(ERR, PORT,
-			"Failed to setup RSS at port %hhu (invalid RETA size = %hu)\n",
+		G_LOG(ERR,
+			"net: failed to setup RSS at port %hhu (invalid RETA size = %hu)\n",
 			port_id, rss_conf->reta_size);
 		ret = -1;
 		goto out;
@@ -830,13 +827,13 @@ gatekeeper_get_rss_config(uint16_t port_id,
 	ret = rte_eth_dev_rss_reta_query(port_id,
 		rss_conf->reta_conf, rss_conf->reta_size);
 	if (ret == -ENOTSUP) {
-		RTE_LOG(ERR, PORT,
-			"Failed to query RSS configuration at port %hhu hardware doesn't support\n",
+		G_LOG(ERR,
+			"net: ailed to query RSS configuration at port %hhu hardware doesn't support\n",
 			port_id);
 		ret = -1;
 	} else if (ret == -EINVAL) {
-		RTE_LOG(ERR, PORT,
-			"Failed to query RSS configuration at port %hhu (RETA query with bad redirection table parameter)\n",
+		G_LOG(ERR,
+			"net: failed to query RSS configuration at port %hhu (RETA query with bad redirection table parameter)\n",
 			port_id);
 		ret = -1;
 	}
@@ -887,13 +884,13 @@ init_port(struct gatekeeper_if *iface, uint16_t port_id,
 		 */
 		if (configured_rss_hf !=
 				port_conf.rx_adv_conf.rss_conf.rss_hf) {
-			RTE_LOG(WARNING, PORT,
-				"Port %hu invalid configured rss_hf: 0x%"PRIx64", valid value: 0x%"PRIx64"\n",
+			G_LOG(WARNING,
+				"net: port %hu invalid configured rss_hf: 0x%"PRIx64", valid value: 0x%"PRIx64"\n",
 				port_id, configured_rss_hf,
 				port_conf.rx_adv_conf.rss_conf.rss_hf);
 		}
 	} else {
-		RTE_LOG(WARNING, GATEKEEPER, "net: the %s interface does not have RSS capabilities; the GK or GT block will receive all packets and send them to the other blocks as needed. Gatekeeper or Grantor should only be run with one lcore dedicated to GK or GT in this mode; restart with only one GK or GT lcore if necessary.\n",
+		G_LOG(WARNING, "net: the %s interface does not have RSS capabilities; the GK or GT block will receive all packets and send them to the other blocks as needed. Gatekeeper or Grantor should only be run with one lcore dedicated to GK or GT in this mode; restart with only one GK or GT lcore if necessary\n",
 			iface->name);
 		iface->num_rx_queues = 1;
 	}
@@ -910,8 +907,7 @@ init_port(struct gatekeeper_if *iface, uint16_t port_id,
 	ret = rte_eth_dev_configure(port_id, iface->num_rx_queues,
 		iface->num_tx_queues, &port_conf);
 	if (ret < 0) {
-		RTE_LOG(ERR, PORT,
-			"Failed to configure port %hhu (err=%d)\n",
+		G_LOG(ERR, "net: failed to configure port %hhu (err=%d)\n",
 			port_id, ret);
 		return ret;
 	}
@@ -942,7 +938,7 @@ init_iface(struct gatekeeper_if *iface)
 	iface->ports = rte_calloc("ports", iface->num_ports,
 		sizeof(*iface->ports), 0);
 	if (iface->ports == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: Out of memory for %s ports\n",
+		G_LOG(ERR, "net: %s: out of memory for %s ports\n",
 			__func__, iface->name);
 		destroy_iface(iface, IFACE_DESTROY_LUA);
 		return -1;
@@ -953,8 +949,8 @@ init_iface(struct gatekeeper_if *iface)
 		ret = rte_eth_dev_get_port_by_name(iface->pci_addrs[i],
 			&iface->ports[i]);
 		if (ret < 0) {
-			RTE_LOG(ERR, PORT,
-				"Failed to map PCI %s to a port (err=%d)\n",
+			G_LOG(ERR,
+				"net: failed to map PCI %s to a port (err=%d)\n",
 				iface->pci_addrs[i], ret);
 			goto close_partial;
 		}
@@ -974,8 +970,8 @@ init_iface(struct gatekeeper_if *iface)
 		RTE_VERIFY(ret > 0 && ret < (int)sizeof(dev_name));
 		ret = rte_eth_bond_create(dev_name, iface->bonding_mode, 0);
 		if (ret < 0) {
-			RTE_LOG(ERR, PORT,
-				"Failed to create bonded port (err=%d)\n",
+			G_LOG(ERR,
+				"net: failed to create bonded port (err=%d)\n",
 				ret);
 			goto close_partial;
 		}
@@ -986,7 +982,7 @@ init_iface(struct gatekeeper_if *iface)
 			ret = rte_eth_bond_slave_add(iface->id,
 				iface->ports[i]);
 			if (ret < 0) {
-				RTE_LOG(ERR, PORT, "Failed to add slave port %hhu to bonded port %hhu (err=%d)\n",
+				G_LOG(ERR, "net: failed to add slave port %hhu to bonded port %hhu (err=%d)\n",
 					iface->ports[i], iface->id, ret);
 				rm_slave_ports(iface, num_slaves_added);
 				goto close_ports;
@@ -1022,8 +1018,7 @@ start_port(uint8_t port_id, uint8_t *pnum_succ_ports,
 	/* Start device. */
 	int ret = rte_eth_dev_start(port_id);
 	if (ret < 0) {
-		RTE_LOG(ERR, PORT,
-			"Failed to start port %hhu (err=%d)\n",
+		G_LOG(ERR, "net: failed to start port %hhu (err=%d)\n",
 			port_id, ret);
 		return ret;
 	}
@@ -1050,11 +1045,11 @@ start_port(uint8_t port_id, uint8_t *pnum_succ_ports,
 		if (link.link_status)
 			break;
 
-		RTE_LOG(ERR, PORT, "Querying port %hhu, and link is down\n",
+		G_LOG(ERR, "net: querying port %hhu, and link is down\n",
 			port_id);
 
 		if (!wait_for_link || attempts > num_attempts_link_get) {
-			RTE_LOG(ERR, PORT, "Giving up on port %hhu\n", port_id);
+			G_LOG(ERR, "net: giving up on port %hhu\n", port_id);
 			ret = -1;
 			return ret;
 		}
@@ -1157,7 +1152,7 @@ start_iface(struct gatekeeper_if *iface, unsigned int num_attempts_link_get)
 
 	ret = rte_eth_dev_set_mtu(iface->id, iface->mtu);
 	if (ret < 0) {
-		RTE_LOG(ERR, PORT,
+		G_LOG(ERR,
 			"net: cannot set the MTU on the %s iface (error %d)\n",
 			iface->name, -ret);
 		goto stop_partial;
@@ -1165,13 +1160,13 @@ start_iface(struct gatekeeper_if *iface, unsigned int num_attempts_link_get)
 
 	iface->hw_filter_eth = rte_eth_dev_filter_supported(iface->id,
 		RTE_ETH_FILTER_ETHERTYPE) == 0;
-	RTE_LOG(NOTICE, PORT,
+	G_LOG(NOTICE,
 		"net: EtherType filters %s supported on the %s iface\n",
 		iface->hw_filter_eth ? "are" : "are NOT", iface->name);
 
 	iface->hw_filter_ntuple = rte_eth_dev_filter_supported(iface->id,
 		RTE_ETH_FILTER_NTUPLE) == 0;
-	RTE_LOG(NOTICE, PORT,
+	G_LOG(NOTICE,
 		"net: ntuple filters %s supported on the %s iface\n",
 		iface->hw_filter_ntuple ? "are" : "are NOT", iface->name);
 
@@ -1211,7 +1206,7 @@ init_net_stage1(void *arg)
 			rte_calloc("mbuf_pool", net_conf->numa_nodes,
 				sizeof(struct rte_mempool *), 0);
 		if (net_conf->gatekeeper_pktmbuf_pool == NULL) {
-			RTE_LOG(ERR, MALLOC, "%s: Out of memory\n", __func__);
+			G_LOG(ERR, "net: %s: out of memory\n", __func__);
 			return -1;
 		}
 	}
@@ -1238,17 +1233,17 @@ init_net_stage1(void *arg)
 		 * doesn't offer a way to deallocate pools.
 		 */
 		if (net_conf->gatekeeper_pktmbuf_pool[i] == NULL) {
-			RTE_LOG(ERR, MEMPOOL,
-				"Failed to allocate mbuf for numa node %u\n",
+			G_LOG(ERR,
+				"net: failed to allocate mbuf for numa node %u\n",
 				i);
 
-			if (rte_errno == E_RTE_NO_CONFIG) RTE_LOG(ERR, MEMPOOL, "Function could not get pointer to rte_config structure\n");
-			else if (rte_errno == E_RTE_SECONDARY) RTE_LOG(ERR, MEMPOOL, "Function was called from a secondary process instance\n");
-			else if (rte_errno == EINVAL) RTE_LOG(ERR, MEMPOOL, "Cache size provided is too large\n");
-			else if (rte_errno == ENOSPC) RTE_LOG(ERR, MEMPOOL, "The maximum number of memzones has already been allocated\n");
-			else if (rte_errno == EEXIST) RTE_LOG(ERR, MEMPOOL, "A memzone with the same name already exists\n");
-			else if (rte_errno == ENOMEM) RTE_LOG(ERR, MEMPOOL, "No appropriate memory area found in which to create memzone\n");
-			else RTE_LOG(ERR, MEMPOOL, "Unknown error\n");
+			if (rte_errno == E_RTE_NO_CONFIG) G_LOG(ERR, "net: function could not get pointer to rte_config structure\n");
+			else if (rte_errno == E_RTE_SECONDARY) G_LOG(ERR, "net: function was called from a secondary process instance\n");
+			else if (rte_errno == EINVAL) G_LOG(ERR, "net: cache size provided is too large\n");
+			else if (rte_errno == ENOSPC) G_LOG(ERR, "net: the maximum number of memzones has already been allocated\n");
+			else if (rte_errno == EEXIST) G_LOG(ERR, "net: a memzone with the same name already exists\n");
+			else if (rte_errno == ENOMEM) G_LOG(ERR, "net: no appropriate memory area found in which to create memzone\n");
+			else G_LOG(ERR, "net: unknown error creating mbuf pool\n");
 
 			return -1;
 		}
@@ -1290,7 +1285,7 @@ start_network_stage2(void *arg)
 destroy_front:
 	destroy_iface(&net->front, IFACE_DESTROY_ALL);
 fail:
-	RTE_LOG(ERR, GATEKEEPER, "Failed to start Gatekeeper network\n");
+	G_LOG(ERR, "net: failed to start Gatekeeper network\n");
 	return ret;
 }
 
@@ -1340,13 +1335,13 @@ gatekeeper_init_network(struct net_config *net_conf)
 	net_conf->numa_used = rte_calloc("numas", net_conf->numa_nodes,
 		sizeof(*net_conf->numa_used), 0);
 	if (net_conf->numa_used == NULL) {
-		RTE_LOG(ERR, MALLOC, "%s: Out of memory for NUMA used array\n",
+		G_LOG(ERR, "net: %s: out of memory for NUMA used array\n",
 			__func__);
 		return -1;
 	}
 
 	if (randomize_rss_key(net_conf->guarantee_random_entropy) < 0) {
-		RTE_LOG(ERR, GATEKEEPER, "Failed to initialize RSS key.\n");
+		G_LOG(ERR, "net: failed to initialize RSS key.\n");
 		ret = -1;
 		goto numa;
 	}
@@ -1359,13 +1354,13 @@ gatekeeper_init_network(struct net_config *net_conf)
 	num_ports = net_conf->front.num_ports +
 		(net_conf->back_iface_enabled ? net_conf->back.num_ports : 0);
 	if (num_ports > rte_eth_dev_count_avail()) {
-		RTE_LOG(ERR, GATEKEEPER, "There are only %i network ports available to DPDK/Gatekeeper, but configuration is using %i ports\n",
+		G_LOG(ERR, "net: there are only %i network ports available to DPDK/Gatekeeper, but configuration is using %i ports\n",
 			rte_eth_dev_count_avail(), num_ports);
 		ret = -1;
 		goto numa;
 	}
 	if (num_ports > GATEKEEPER_MAX_PORTS) {
-		RTE_LOG(ERR, GATEKEEPER, "Gatekeeper was compiled to support at most %i network ports, but configuration is using %i ports\n",
+		G_LOG(ERR, "net: Gatekeeper was compiled to support at most %i network ports, but configuration is using %i ports\n",
 			GATEKEEPER_MAX_PORTS, num_ports);
 		ret = -1;
 		goto numa;

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -144,6 +144,8 @@ struct net_config {
 	int          guarantee_random_entropy;
 	unsigned int num_attempts_link_get;
 	bool         *numa_used;
+	uint32_t     log_level;
+	int          log_type;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -43,6 +43,12 @@ return function (gatekeeper_server)
 	local front_ipv6_default_hop_limits = 255
 	local back_ipv6_default_hop_limits = 255
 
+	-- Set the log level for all Gatekeeper activity that is
+	-- not associated with a functional block. Only activated
+	-- when network starts; for early log entries, set using
+	-- the --log-level EAL command line option.
+	net_conf.log_level = gatekeeper.c.RTE_LOG_DEBUG
+
 	local front_ports = {"enp133s0f0"}
 	-- Each interface should have at most two ip addresses:
 	-- 1 IPv4, 1 IPv6.


### PR DESCRIPTION
For Gatekeeper activity that is not related to individual blocks
(such as libraries), this patch adds a dynamic logging type and
removes any lingering references in the Gatekeeper code to
built-in static library log types.