### PR TITLE
Add routing daemon interaction and route information

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "dependencies/luajit-2.0"]
 	path = dependencies/luajit-2.0
 	url = http://luajit.org/git/luajit-2.0.git
+[submodule "dependencies/bird"]
+	path = dependencies/bird
+	url = http://github.com/cjdoucette/bird.git
+	branch = gatekeeper

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Install the following software dependencies:
 
     $ sudo apt-get update
-    $ sudo apt-get -y -q install git clang doxygen hugepages build-essential linux-headers-`uname -r` libmnl0 libmnl-dev libnuma-dev
+    $ sudo apt-get -y -q install git clang doxygen hugepages build-essential linux-headers-`uname -r` libmnl0 libmnl-dev libnuma-dev autoconf flex bison libncurses5-dev
 
 Note: Both `libmnl0` and `libmnl-dev` are needed to compile and run `gatekeeper`, but only `libmnl0` is needed for simply running `gatekeeper`.
-`libnuma-dev` is needed to compile the latest DPDK and/or support NUMA system.
+`libnuma-dev` is needed to compile the latest DPDK and/or support NUMA system. The `autoconf`, `flex`, `bison`, and `libncurses5-dev` packages are for BIRD.
 
 To use DPDK, make sure you have all of the environmental requirements: <http://dpdk.org/doc/guides/linux_gsg/sys_reqs.html#running-dpdk-applications>.
 

--- a/cps/kni.c
+++ b/cps/kni.c
@@ -653,6 +653,9 @@ rd_modroute(const struct nlmsghdr *req, void *arg)
 	/* Default to an invalid index number. */
 	update->oif_index = 0;
 
+	/* Route origin (routing daemon). */
+	update->rt_proto = rm->rtm_protocol;
+
 	switch(rm->rtm_family) {
 	case AF_INET:
 		mnl_attr_parse(req, sizeof(*rm), data_ipv4_attr_cb, tb);
@@ -798,7 +801,8 @@ new_route(struct route_update *update, struct cps_config *cps_conf)
 		}
 
 		return add_fib_entry_numerical(&prefix_info, NULL, &gw_addr,
-			GK_FWD_GATEWAY_FRONT_NET, cps_conf->gk);
+			GK_FWD_GATEWAY_FRONT_NET, update->rt_proto,
+			cps_conf->gk);
 	}
 
 	if (gw_fib->action == GK_FWD_NEIGHBOR_BACK_NET) {
@@ -814,7 +818,8 @@ new_route(struct route_update *update, struct cps_config *cps_conf)
 		}
 
 		return add_fib_entry_numerical(&prefix_info, NULL, &gw_addr,
-			GK_FWD_GATEWAY_BACK_NET, cps_conf->gk);
+			GK_FWD_GATEWAY_BACK_NET, update->rt_proto,
+			cps_conf->gk);
 	}
 
 	return -1;

--- a/cps/kni.h
+++ b/cps/kni.h
@@ -38,7 +38,8 @@ struct nd_request {
 int kni_change_mtu(uint16_t port_id, unsigned int new_mtu);
 int kni_change_if(uint16_t port_id, uint8_t if_up);
 int kni_disable_change_mac_address(uint16_t port_id, uint8_t *mac_addr);
-int kni_config_ip_addrs(struct rte_kni *kni, struct gatekeeper_if *iface);
+int kni_config_ip_addrs(struct rte_kni *kni, unsigned int kni_index,
+	struct gatekeeper_if *iface);
 int kni_config_link(struct rte_kni *kni);
 int rd_event_sock_open(struct cps_config *cps_conf);
 void rd_event_sock_close(struct cps_config *cps_conf);

--- a/cps/kni.h
+++ b/cps/kni.h
@@ -40,9 +40,9 @@ int kni_change_if(uint16_t port_id, uint8_t if_up);
 int kni_disable_change_mac_address(uint16_t port_id, uint8_t *mac_addr);
 int kni_config_ip_addrs(struct rte_kni *kni, struct gatekeeper_if *iface);
 int kni_config_link(struct rte_kni *kni);
-int route_event_sock_open(struct cps_config *cps_conf);
-void route_event_sock_close(struct cps_config *cps_conf);
-void kni_cps_route_event(struct cps_config *cps_conf);
+int rd_event_sock_open(struct cps_config *cps_conf);
+void rd_event_sock_close(struct cps_config *cps_conf);
+void kni_cps_rd_event(struct cps_config *cps_conf);
 int init_kni(const char *kni_kmod_path, unsigned int num_kni);
 void rm_kni(void);
 

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -88,6 +88,10 @@ struct cps_config {
 	struct rte_kni    *front_kni;
 	struct rte_kni    *back_kni;
 
+	/* Output interface IDs for the KNIs; used with routing daemons. */
+	unsigned int      front_kni_index;
+	unsigned int      back_kni_index;
+
 	/* Mailbox to hold requests from other blocks. */
 	struct mailbox    mailbox;
 

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -190,6 +190,9 @@ struct route_update {
 
 	uint32_t oif_index;
 
+	/* Route origin. See field rtm_protocol of struct rtmsg. */
+	uint8_t  rt_proto;
+
 	union {
 		struct in_addr  v4;
 		struct in6_addr v6;

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -70,6 +70,9 @@ struct cps_config {
 	unsigned int      mailbox_mem_cache_size;
 	unsigned int      mailbox_burst_size;
 
+	/* Netlink port ID for communicating with routing daemon. */
+	uint32_t          nl_pid;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
@@ -101,8 +104,12 @@ struct cps_config {
 	/* Timer to scan over outstanding resolution requests. */
 	struct rte_timer  scan_timer;
 
-	/* Socket for receiving routing table updates. */
-	struct mnl_socket *nl;
+	/*
+	 * Netlink socket for receiving from the routing daemon.
+	 * Bound to @nl_pid so that userspace routing daemons
+	 * can be configured to update Gatekeeper.
+	 */
+	struct mnl_socket *rd_nl;
 
 	struct gk_config  *gk;
 	struct gt_config  *gt;

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -143,6 +143,13 @@ struct gk_fib {
 		struct {
 			/* The cached Ethernet header. */
 			struct ether_cache *eth_cache;
+
+			/*
+			 * Routing table protocol - origin of the root.
+			 * RTPROT_STATIC for routes added by user.
+			 * RTPROT_BIRD for routes added by BIRD daemon, etc.
+			 */
+			uint8_t rt_proto;
 		} gateway;
 
 		struct {
@@ -248,7 +255,8 @@ int parse_ip_prefix(const char *ip_prefix, struct ipaddr *res);
 
 int add_fib_entry_numerical(struct ip_prefix *prefix_info,
 	struct ipaddr *gt_addr, struct ipaddr *gw_addr,
-	enum gk_fib_action action, struct gk_config *gk_conf);
+	enum gk_fib_action action, uint8_t protocol,
+	struct gk_config *gk_conf);
 int add_fib_entry(const char *prefix, const char *gt_ip, const char *gw_ip,
 	enum gk_fib_action action, struct gk_config *gk_conf);
 int del_fib_entry_numerical(

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -46,6 +46,9 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	-- resolution requests from KNIs.
 	cps_conf.cps_scan_interval_sec = 5
 
+	-- Netlink port ID to receive updates and scans from routing daemon.
+	cps_conf.nl_pid = 0x6A7E
+
 	local ret = gatekeeper.c.run_cps(net_conf, gk_conf, gt_conf,
 		cps_conf, lls_conf, kni_kmod_path)
 	if ret < 0 then

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -248,6 +248,7 @@ struct cps_config {
 	unsigned int mailbox_max_entries_exp;
 	unsigned int mailbox_mem_cache_size;
 	unsigned int mailbox_burst_size;
+	uint32_t     nl_pid;
 	/* This struct has hidden fields. */
 };
 

--- a/setup.sh
+++ b/setup.sh
@@ -59,6 +59,15 @@ cd ../luajit-2.0
 make CFLAGS=-fPIC
 sudo make install
 
+# Setup BIRD.
+cd ../bird
+
+# Build and install.
+autoreconf
+./configure
+make
+sudo make install
+
 cd ../../
 
 # Build interface name -> PCI address map.


### PR DESCRIPTION
These patches add the first part of the functionality that allows Gatekeeper to interact directly with a userspace routing daemon. The first step is to bind Gatekeeper's Netlink socket to a port ID that the routing daemon can be configured to send to. This allows the Netlink messages to not be interpreted by the kernel.

The next step is to support the functionality required by userspace routing daemons. The one we're targeting, BIRD, performs `RTM_GETROUTE` scans of the routing table to find any manually-added routes or to pick up any other changes that it should be aware of. Therefore, the rest of the patches deal with setting up Gatekeeper to be able to accept a table scan and respond.

While reviewing it might be useful to see the Netlink code in BIRD to see what it is expecting:

https://github.com/cjdoucette/bird/blob/gatekeeper/sysdep/linux/netlink.c

Seeing the patches that I added to BIRD may also be useful:

https://github.com/cjdoucette/bird/commits/gatekeeper

Finally, it might be useful to see the libmnl batching documentation, used for sending multiple Netlink messages in one byte stream (such as many routes at once):

https://www.netfilter.org/projects/libmnl/doxygen/html/group__batch.html
https://github.com/threatstack/libmnl/blob/master/src/nlmsg.c#L388



