### PR TITLE
setup: add output file for interface map script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,7 @@ cd ../../
 
 # Build interface name -> PCI address map.
 gcc generate_if_map.c -o generate_if_map -Wall
-./generate_if_map
+./generate_if_map lua/if_map.lua
 
 # Build client.
 cd gkctl


### PR DESCRIPTION
generate_if_map.c now expects an output file, so this patch adds an output file for its use in the Gatekeeper setup script.