### PR TITLE
net: apply filters to individual ports

### DIFF
--- a/cps/main.c
+++ b/cps/main.c
@@ -971,7 +971,7 @@ add_bgp_filters(struct gatekeeper_if *iface, uint16_t tcp_port_bgp,
 			 * Capture pkts for connections
 			 * started by our BGP speaker.
 			 */
-			int ret = ntuple_filter_add(iface->id,
+			int ret = ntuple_filter_add(iface,
 				iface->ip4_addr.s_addr,
 				rte_cpu_to_be_16(tcp_port_bgp), UINT16_MAX,
 				0, 0, IPPROTO_TCP, rx_queue, true, false);
@@ -983,7 +983,7 @@ add_bgp_filters(struct gatekeeper_if *iface, uint16_t tcp_port_bgp,
 			}
 
 			/* Capture connections remote speakers started. */
-			ret = ntuple_filter_add(iface->id,
+			ret = ntuple_filter_add(iface,
 				iface->ip4_addr.s_addr, 0, 0,
 				rte_cpu_to_be_16(tcp_port_bgp), UINT16_MAX,
 				IPPROTO_TCP, rx_queue, true, false);

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -628,7 +628,7 @@ ggu_stage2(void *arg)
 	 * to its queue for both IPv4 and IPv6 addresses.
 	 */
 	if (hw_filter_ntuple_available(&ggu_conf->net->back)) {
-		return ntuple_filter_add(ggu_conf->net->back.id,
+		return ntuple_filter_add(&ggu_conf->net->back,
 			ggu_conf->net->back.ip4_addr.s_addr,
 			ggu_conf->ggu_src_port, UINT16_MAX,
 			ggu_conf->ggu_dst_port, UINT16_MAX,

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -426,10 +426,10 @@ int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 int get_ip_type(const char *ip_addr);
 int convert_str_to_ip(const char *ip_addr, struct ipaddr *res);
 int convert_ip_to_str(const struct ipaddr *ip_addr, char *res, int n);
-int ethertype_filter_add(uint16_t port_id, uint16_t ether_type,
+int ethertype_filter_add(struct gatekeeper_if *iface, uint16_t ether_type,
 	uint16_t queue_id);
 
-int ntuple_filter_add(uint16_t port_id, uint32_t dst_ip,
+int ntuple_filter_add(struct gatekeeper_if *iface, uint32_t dst_ip,
 	uint16_t src_port, uint16_t src_port_mask,
 	uint16_t dst_port, uint16_t dst_port_mask,
 	uint8_t proto, uint16_t queue_id,

--- a/lls/main.c
+++ b/lls/main.c
@@ -748,7 +748,7 @@ lls_stage2(void *arg)
 
 	if (lls_conf->arp_cache.iface_enabled(net_conf, &net_conf->front)) {
 		if (hw_filter_eth_available(&net_conf->front)) {
-			ret = ethertype_filter_add(net_conf->front.id,
+			ret = ethertype_filter_add(&net_conf->front,
 				ETHER_TYPE_ARP, lls_conf->rx_queue_front);
 			if (ret < 0)
 				return ret;
@@ -772,7 +772,7 @@ lls_stage2(void *arg)
 
 	if (lls_conf->arp_cache.iface_enabled(net_conf, &net_conf->back)) {
 		if (hw_filter_eth_available(&net_conf->back)) {
-			ret = ethertype_filter_add(net_conf->back.id,
+			ret = ethertype_filter_add(&net_conf->back,
 				ETHER_TYPE_ARP, lls_conf->rx_queue_back);
 			if (ret < 0)
 				return ret;


### PR DESCRIPTION
EtherType and ntuple filters were being applied to the interface
ID instead of individual ports.

This worked for Gatekeeper interfaces with only a single port,
since the interface ID will match the port ID in that case. But
when there are multiple ports, the interface ID identifies the
bonded port, which does not support these filters.

To use these filters when multiple ports are configured, this
patch applies the filters to the ports directly instead of the
Gatekeeper interface IDs.

A filter is only considered supported by a Gatekeeper interface
if all component ports in the interface support it.