### PR TITLE
Building Bird requires libreadline-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Install the following software dependencies:
 
     $ sudo apt-get update
-    $ sudo apt-get -y -q install git clang doxygen hugepages build-essential linux-headers-`uname -r` libmnl0 libmnl-dev libnuma-dev autoconf flex bison libncurses5-dev
+    $ sudo apt-get -y -q install git clang doxygen hugepages build-essential linux-headers-`uname -r` libmnl0 libmnl-dev libnuma-dev autoconf flex bison libncurses5-dev libreadline-dev
 
 Note: Both `libmnl0` and `libmnl-dev` are needed to compile and run `gatekeeper`, but only `libmnl0` is needed for simply running `gatekeeper`.
-`libnuma-dev` is needed to compile the latest DPDK and/or support NUMA system. The `autoconf`, `flex`, `bison`, and `libncurses5-dev` packages are for BIRD.
+`libnuma-dev` is needed to compile the latest DPDK and/or support NUMA system. The `autoconf`, `flex`, `bison`, `libncurses5-dev` and `libreadline-dev` packages are for BIRD.
 
 To use DPDK, make sure you have all of the environmental requirements: <http://dpdk.org/doc/guides/linux_gsg/sys_reqs.html#running-dpdk-applications>.
 


### PR DESCRIPTION
Without this package, the `. setup.sh` step reports the error below.

```
configure: error: The client requires GNU Readline library. Either install the library or use --disable-client to compile without the client.
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target 'install'.  Stop.
```