### PR TITLE
Improve Netlink interactions and support RTM_GETROUTE

### DIFF
--- a/cps/kni.c
+++ b/cps/kni.c
@@ -580,6 +580,7 @@ attr_get(struct route_update *update, int family, struct nlattr *tb[])
 {
 	bool dst_present = false;
 	bool gw_present = false;
+	bool oif_present = false;
 
 	if (tb[RTA_MULTIPATH]) {
 		/*
@@ -656,6 +657,7 @@ attr_get(struct route_update *update, int family, struct nlattr *tb[])
 	if (tb[RTA_OIF]) {
 		update->oif_index = mnl_attr_get_u32(tb[RTA_OIF]);
 		CPS_LOG(DEBUG, "cps update: oif=%u\n", update->oif_index);
+		oif_present = true;
 	}
 	if (tb[RTA_FLOW]) {
 		CPS_LOG(WARNING,
@@ -728,7 +730,7 @@ attr_get(struct route_update *update, int family, struct nlattr *tb[])
 
 	update->valid = dst_present &&
 		(update->type == RTM_DELROUTE ||
-		(update->type == RTM_NEWROUTE && gw_present));
+		(update->type == RTM_NEWROUTE && gw_present && oif_present));
 	return 0;
 }
 

--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -56,8 +56,8 @@ struct cps_config {
 	/* Number of times to attempt bring a KNI interface up or down. */
 	unsigned int      num_attempts_kni_link_set;
 
-	/* Maximum number of updates for LPM table to serve at once. */
-	unsigned int      max_route_updates;
+	/* Maximum number of route update packets to serve at once. */
+	unsigned int      max_rt_update_pkts;
 
 	/*
 	 * Period between scans of the outstanding
@@ -175,37 +175,6 @@ struct cps_request {
 		/* If @ty is CPS_REQ_ND, use @nd. */
 		struct cps_nd_req nd;
 	} u;
-};
-
-struct route_update {
-	/* Type of update: RTM_NEWROUTE or RTM_DELROUTE. */
-	int      type;
-
-	/* Address family of update: AF_INET or AF_INET6. */
-	int      family;
-
-	/*
-	 * Whether this update has all the fields and attributes
-	 * necessary to update the LPM table.
-	 */
-	int      valid;
-
-	uint8_t  prefix_len;
-
-	uint32_t oif_index;
-
-	/* Route origin. See field rtm_protocol of struct rtmsg. */
-	uint8_t  rt_proto;
-
-	union {
-		struct in_addr  v4;
-		struct in6_addr v6;
-	} ip;
-
-	union {
-		struct in_addr  v4;
-		struct in6_addr v6;
-	} gw;
 };
 
 struct cps_config *get_cps_conf(void);

--- a/lib/lpm.c
+++ b/lib/lpm.c
@@ -58,11 +58,9 @@ lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip)
 	ret = rte_lpm_lookup(lpm, ntohl(ip), &next_hop);
 	if (ret == -EINVAL) {
 		G_LOG(ERR, "lpm: incorrect arguments for IPv4 lookup\n");
-		ret = -1;
 		goto out;
 	} else if (ret == -ENOENT) {
 		G_LOG(WARNING, "lpm: IPv4 lookup miss\n");
-		ret = -1;
 		goto out;
 	}
 
@@ -105,11 +103,9 @@ lpm_lookup_ipv6(struct rte_lpm6 *lpm, uint8_t *ip)
 	ret = rte_lpm6_lookup(lpm, ip, &next_hop);
 	if (ret == -EINVAL) {
 		G_LOG(ERR, "lpm: incorrect arguments for IPv6 lookup\n");
-		ret = -1;
 		goto out;
 	} else if (ret == -ENOENT) {
 		G_LOG(WARNING, "lpm: IPv6 lookup miss\n");
-		ret = -1;
 		goto out;
 	}
 

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -20,7 +20,7 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	-- These variables are unlikely to need to be changed.
 	local tcp_port_bgp = 179
 	local num_attempts_kni_link_set = 5
-	local max_route_updates = 8
+	local max_rt_update_pkts = 8
 	local scan_interval_sec = 5
 
 	--
@@ -46,7 +46,7 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 
 	cps_conf.tcp_port_bgp = tcp_port_bgp
 	cps_conf.num_attempts_kni_link_set = num_attempts_kni_link_set
-	cps_conf.max_route_updates = max_route_updates
+	cps_conf.max_rt_update_pkts = max_rt_update_pkts
 	cps_conf.scan_interval_sec = scan_interval_sec
 
 	-- Netlink port ID to receive updates and scans from routing daemon.

--- a/lua/gatekeeper.lua
+++ b/lua/gatekeeper.lua
@@ -244,7 +244,7 @@ struct cps_config {
 	uint16_t     front_max_pkt_burst;
 	uint16_t     back_max_pkt_burst;
 	unsigned int num_attempts_kni_link_set;
-	unsigned int max_route_updates;
+	unsigned int max_rt_update_pkts;
 	unsigned int scan_interval_sec;
 	unsigned int mailbox_max_entries_exp;
 	unsigned int mailbox_mem_cache_size;


### PR DESCRIPTION
The first two patches improve interactions with the routing daemon via Netlink by supporting multiple messages per packet and sending acknowledgements and errors when necessary.

The last patch adds support to receive `RTM_GETROUTE` requests from the routing daemon and respond.