### PR TITLE
Bug fixes concerned with IP address assignment

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -1863,18 +1863,26 @@ cleanup_gk(struct gk_config *gk_conf)
 		destroy_mailbox(&gk_conf->instances[i].mb);
 	}
 
-	for (ui = 0; ui < gk_conf->gk_max_num_ipv4_fib_entries; ui++) {
-		struct gk_fib *fib = &gk_conf->lpm_tbl.fib_tbl[ui];
-		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
-				fib->action == GK_FWD_NEIGHBOR_BACK_NET)
-			destroy_neigh_hash_table(&fib->u.neigh);
+	if (gk_conf->lpm_tbl.fib_tbl != NULL) {
+		for (ui = 0; ui < gk_conf->gk_max_num_ipv4_fib_entries; ui++) {
+			struct gk_fib *fib = &gk_conf->lpm_tbl.fib_tbl[ui];
+			if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
+					fib->action ==
+						GK_FWD_NEIGHBOR_BACK_NET) {
+				destroy_neigh_hash_table(&fib->u.neigh);
+			}
+		}
 	}
 
-	for (ui = 0; ui < gk_conf->gk_max_num_ipv6_fib_entries; ui++) {
-		struct gk_fib *fib = &gk_conf->lpm_tbl.fib_tbl6[ui];
-		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
-				fib->action == GK_FWD_NEIGHBOR_BACK_NET)
-			destroy_neigh_hash_table(&fib->u.neigh6);
+	if (gk_conf->lpm_tbl.fib_tbl6 != NULL) {
+		for (ui = 0; ui < gk_conf->gk_max_num_ipv6_fib_entries; ui++) {
+			struct gk_fib *fib = &gk_conf->lpm_tbl.fib_tbl6[ui];
+			if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
+					fib->action ==
+						GK_FWD_NEIGHBOR_BACK_NET) {
+				destroy_neigh_hash_table(&fib->u.neigh6);
+			}
+		}
 	}
 
 	destroy_gk_lpm(&gk_conf->lpm_tbl);

--- a/lib/net.c
+++ b/lib/net.c
@@ -1597,6 +1597,19 @@ gatekeeper_init_network(struct net_config *net_conf)
 	if (ret < 0)
 		return -1;
 
+	if (net_conf->back_iface_enabled) {
+		if (ipv4_if_configured(&net_conf->front) !=
+				ipv4_if_configured(&net_conf->back)) {
+			G_LOG(ERR, "net: front and back interfaces must either both support IPv4 or neither support IPv4\n");
+			return -1;
+		}
+		if (ipv6_if_configured(&net_conf->front) !=
+				ipv6_if_configured(&net_conf->back)) {
+			G_LOG(ERR, "net: front and back interfaces must either both support IPv6 or neither support IPv6\n");
+			return -1;
+		}
+	}
+
 	net_conf->numa_nodes = find_num_numa_nodes();
 	net_conf->numa_used = rte_calloc("numas", net_conf->numa_nodes,
 		sizeof(*net_conf->numa_used), 0);


### PR DESCRIPTION
When leaving out an IPv6 address on one of the interfaces, the FIB initialization fails and the GK cleanup routine caused a segfault. These patches fixes the cleanup routine and adds a check to make sure the FIB initialization won't fail because of mismatching IP address versions on the interfaces.