### PR TITLE
lua: clean up Dynamic Config file

### DIFF
--- a/lua/dyn_cfg.lua
+++ b/lua/dyn_cfg.lua
@@ -1,30 +1,45 @@
 return function (gk_conf, gt_conf, numa_table)
 
-	-- Init the dynamic configuration structure.
+	--
+	-- Configure the variables below for the Dynamic Config block.
+	--
+
+	-- These parameters should likely be initially changed.
+	local log_level = gatekeeper.c.RTE_LOG_DEBUG
+
+	-- XXX #155 These parameters should only be changed for performance reasons.
+	local log_ratelimit_interval_ms = 5000
+	local log_ratelimit_burst = 10
+
+	-- These variables are unlikely to need to be changed.
+	local server_path = "/tmp/dyn_cfg.socket"
+	local lua_dy_base_dir = "./lua/gatekeeper"
+	local lua_dy_lib = "dylib.lua"
+	local rcv_timeout_sec = 30
+	local rcv_timeout_usec = 0
+
+	--
+	-- End configuration of Dynamic Config block.
+	--
+
 	local dy_conf = gatekeeper.c.get_dy_conf()
 	if dy_conf == nil then
 		error("Failed to allocate dy_conf")
 	end
 
-	local server_path = "/tmp/dyn_cfg.socket"
-	local lua_dy_base_dir = "./lua"
-	local dynamic_config_file = "gatekeeper/dylib.lua"
-
 	dy_conf.lcore_id = gatekeeper.alloc_an_lcore(numa_table)
 
-	-- Log level for Dynamic Configuration.
-	dy_conf.log_level = gatekeeper.c.RTE_LOG_DEBUG
+	dy_conf.log_level = log_level
 
-	-- Log ratelimit interval and burst size.
-	dy_conf.log_ratelimit_interval_ms = 5000
-	dy_conf.log_ratelimit_burst = 10
+	dy_conf.log_ratelimit_interval_ms = log_ratelimit_interval_ms
+	dy_conf.log_ratelimit_burst = log_ratelimit_burst
 
-	gatekeeper.c.set_dyc_timeout(30, 0, dy_conf)
+	gatekeeper.c.set_dyc_timeout(rcv_timeout_sec,
+		rcv_timeout_usec, dy_conf)
 
-	-- Setup the dynamic config functional block.
 	local ret = gatekeeper.c.run_dynamic_config(
 		gk_conf, gt_conf, server_path,
-		lua_dy_base_dir, dynamic_config_file, dy_conf)
+		lua_dy_base_dir, lua_dy_lib, dy_conf)
 	if ret < 0 then
 		error("Failed to run dynamic config block")
 	end


### PR DESCRIPTION
Restructure the Lua configuration file for the Dynamic Config block. Rename variables and descriptions to match this wiki page:

https://github.com/AltraMayor/gatekeeper/wiki/Functional-Block:-Dynamic-Config