### PR TITLE
cps: make KNI MTU match physical MTU

### DIFF
--- a/cps/kni.c
+++ b/cps/kni.c
@@ -1216,7 +1216,7 @@ rd_getlink(const struct nlmsghdr *req, const struct cps_config *cps_conf,
 
 	rd_fill_getlink_reply(cps_conf, batch,
 		rte_kni_get_name(cps_conf->front_kni),
-		cps_conf->front_kni_index, kni_mtu(&cps_conf->net->front),
+		cps_conf->front_kni_index, cps_conf->net->front.mtu,
 		req->nlmsg_seq);
 	if (!mnl_nlmsg_batch_next(batch)) {
 		/* Send whatever was in the batch, if anything. */
@@ -1230,7 +1230,7 @@ rd_getlink(const struct nlmsghdr *req, const struct cps_config *cps_conf,
 		rd_fill_getlink_reply(cps_conf, batch,
 			rte_kni_get_name(cps_conf->back_kni),
 			cps_conf->back_kni_index,
-			kni_mtu(&cps_conf->net->back), req->nlmsg_seq);
+			cps_conf->net->back.mtu, req->nlmsg_seq);
 		if (!mnl_nlmsg_batch_next(batch)) {
 			*err = rd_send_batch(cps_conf, batch, "LINK",
 				req->nlmsg_seq, req->nlmsg_pid, false);

--- a/cps/kni.h
+++ b/cps/kni.h
@@ -35,18 +35,6 @@ struct nd_request {
 	int              stale;
 };
 
-static inline uint16_t
-kni_mtu(struct gatekeeper_if *iface)
-{
-	/*
-	 * If the physical interface has a VLAN ID, we need
-	 * to account for that in the MTU of the KNI.
-	 */
-	return iface->vlan_insert
-		? iface->mtu - sizeof(struct vlan_hdr)
-		: iface->mtu;
-}
-
 int kni_disable_change_mtu(uint16_t port_id, unsigned int new_mtu);
 int kni_change_if(uint16_t port_id, uint8_t if_up);
 int kni_disable_change_mac_address(uint16_t port_id, uint8_t *mac_addr);

--- a/cps/main.c
+++ b/cps/main.c
@@ -675,7 +675,7 @@ kni_create(struct rte_kni **kni, const char *kni_name, struct rte_mempool *mp,
 	RTE_VERIFY(strlen(kni_name) < sizeof(conf.name));
 	strcpy(conf.name, kni_name);
 	conf.mbuf_size = rte_pktmbuf_data_room_size(mp);
-	conf.mtu = kni_mtu(iface);
+	conf.mtu = iface->mtu;
 
 	/* If the interface is bonded, take PCI info from the primary slave. */
 	if (iface->num_ports > 1 || iface->bonding_mode == BONDING_MODE_8023AD)


### PR DESCRIPTION
Since the link layer header length is not counted toward the MTU,
we don't need to account for any difference between the expected
link layer header lengths between the KNI and the physical interface.

This patch closes #234.