### PR TITLE
lua: fix configuration bugs

### DIFF
--- a/lua/dyn_cfg.lua
+++ b/lua/dyn_cfg.lua
@@ -13,8 +13,8 @@ return function (gk_conf, gt_conf, numa_table)
 
 	-- These variables are unlikely to need to be changed.
 	local server_path = "/tmp/dyn_cfg.socket"
-	local lua_dy_base_dir = "./lua/gatekeeper"
-	local lua_dy_lib = "dylib.lua"
+	local lua_dy_base_dir = "./lua"
+	local lua_dy_lib = "gatekeeper/dylib.lua"
 	local rcv_timeout_sec = 30
 	local rcv_timeout_usec = 0
 

--- a/lua/examples/example_of_dynamic_config_request.lua
+++ b/lua/examples/example_of_dynamic_config_request.lua
@@ -1,4 +1,4 @@
-require "gatekeeper/dylib"
+require "gatekeeper/staticlib"
 
 local acc_start = ""
 local reply_msg = ""
@@ -6,7 +6,7 @@ local reply_msg = ""
 local dyc = staticlib.c.get_dy_conf()
 
 if dyc.gt ~= nil then
-	dylib.update_lua_states(dyc.gt)
+	dylib.update_gt_lua_states(dyc.gt)
 	return "gt: successfully updated the lua states\n"
 end
 

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -1,7 +1,5 @@
 module("dylib", package.seeall)
 
-require "gatekeeper/staticlib"
-
 --
 -- C functions exported through FFI
 --


### PR DESCRIPTION
The error message when configuring Grantor via dynamic configuration is:
GATEKEEPER DYN CFG: ./lua/gatekeeper/dylib.lua:3: module 'gatekeeper/staticlib' not found