### PR TITLE
gt: upgrade field upper_len of struct gt_packet_headers to uint16_t

### DIFF
--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -37,7 +37,7 @@ struct gt_packet_headers {
 	uint8_t  priority;
 	uint8_t  outer_ecn;
 	/* Length of packet after IP headers (L4 + L5 + payload). */
-	uint8_t  upper_len;
+	uint16_t upper_len;
 
 	void     *l2_hdr;
 	void     *outer_l3_hdr;

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -97,7 +97,7 @@ struct gt_packet_headers {
 	uint8_t l4_proto;
 	uint8_t priority;
 	uint8_t outer_ecn;
-	uint8_t upper_len;
+	uint16_t upper_len;
 
 	void *l2_hdr;
 	void *outer_l3_hdr;


### PR DESCRIPTION
This patch closes #306