### PR TITLE
policy: follow network order on packet headers in policies

### DIFF
--- a/lua/examples/policy.lua
+++ b/lua/examples/policy.lua
@@ -37,7 +37,7 @@ local simple_policy = {
 	[policylib.c.IPV4] = {
 		-- Loosely assume that TCP and UDP ports are equivalents
 		-- to simplify this example.
-		[80] = dcs_friendly,
+		[policylib.c.rte_cpu_to_be_16(80)] = dcs_friendly,
 	},
 }
 

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -177,6 +177,14 @@ struct rte_lpm6 {
 	/* This struct has hidden fields. */
 };
 
+typedef uint16_t rte_be16_t;
+typedef uint32_t rte_be32_t;
+
+rte_be16_t rte_cpu_to_be_16 (uint16_t x);
+rte_be32_t rte_cpu_to_be_32 (uint32_t x);
+uint16_t rte_be_to_cpu_16 (rte_be16_t x);
+uint32_t rte_be_to_cpu_32 (rte_be32_t x);
+
 ]]
 
 c = ffi.C


### PR DESCRIPTION
This patch closes #304