### PR TITLE
gt: add an option to disable packet reassembling at Grantor servers

### DIFF
--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -44,13 +44,15 @@ struct gt_packet_headers {
 	void     *inner_l3_hdr;
 	void     *l4_hdr;
 
+	/* Field indicating whether the associated packet is fragmented. */
+	bool     frag;
+
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */
 
 	/* Fields for parsing fragmented packets. */
-	bool     frag;
 	uint32_t l2_outer_l3_len;
 	uint32_t inner_l3_len;
 	struct ipv6_extension_fragment *frag_hdr;
@@ -164,6 +166,12 @@ struct gt_config {
 	uint32_t           log_ratelimit_interval_ms;
 	/* Log ratelimit burst size for GT block. */
 	uint32_t           log_ratelimit_burst;
+
+	/*
+	 * An option to disable packet reassembling
+	 * at Grantor servers.
+	 */
+	bool               reassembling_enabled;
 
 	/*
 	 * The fields below are for internal use.

--- a/lua/examples/policy.lua
+++ b/lua/examples/policy.lua
@@ -44,6 +44,10 @@ local simple_policy = {
 -- Function that looks up the simple policy for the packet.
 local function lookup_simple_policy(pkt_info)
 
+	if pkt_info.frag then
+		return dcs_malformed
+	end
+
 	if pkt_info.inner_ip_ver == policylib.c.IPV4 and
 			pkt_info.l4_proto == policylib.c.ICMP then
 		if pkt_info.upper_len < ffi.sizeof("struct rte_icmp_hdr") then

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -103,6 +103,7 @@ struct gt_packet_headers {
 	void *outer_l3_hdr;
 	void *inner_l3_hdr;
 	void *l4_hdr;
+	bool frag;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -268,6 +268,7 @@ struct gt_config {
 	int          log_type;
 	uint32_t     log_ratelimit_interval_ms;
 	uint32_t     log_ratelimit_burst;
+	bool         reassembling_enabled;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/gt.lua
+++ b/lua/gt.lua
@@ -29,6 +29,8 @@ return function (net_conf, lls_conf, numa_table)
 	local batch_interval = 2
 	local max_ggu_notify_pkts = 8
 
+	local reassembling_enabled = false
+
 	-- These variables are unlikely to need to be changed.
 	local ggu_src_port = 0xA0A0
 	local ggu_dst_port = 0xB0B0
@@ -49,6 +51,8 @@ return function (net_conf, lls_conf, numa_table)
 	gt_conf.mailbox_burst_size = mailbox_burst_size
 	gt_conf.log_ratelimit_interval_ms = log_ratelimit_interval_ms
 	gt_conf.log_ratelimit_burst = log_ratelimit_burst
+
+	gt_conf.reassembling_enabled = reassembling_enabled
 
 	gt_conf.max_num_ipv6_neighbors = max_num_ipv6_neighbors
 


### PR DESCRIPTION
This patch closes #305