### PR TITLE
bpf: add features needed to write production BPF programs

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@ CFLAGS += -O2 -target bpf -I../include \
 	  -I$(RTE_SDK)/$(RTE_TARGET)/include \
 	  -Wno-int-to-void-pointer-cast
 
-TARGETS = granted.bpf declined.bpf grantedv2.bpf
+TARGETS = granted.bpf declined.bpf grantedv2.bpf web.bpf
 
 DESTDIR ?= "../lua/bpf"
 INSTALL = install

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@ CFLAGS += -O2 -target bpf -I../include \
 	  -I$(RTE_SDK)/$(RTE_TARGET)/include \
 	  -Wno-int-to-void-pointer-cast
 
-TARGETS = granted.bpf declined.bpf
+TARGETS = granted.bpf declined.bpf grantedv2.bpf
 
 DESTDIR ?= "../lua/bpf"
 INSTALL = install

--- a/bpf/granted.c
+++ b/bpf/granted.c
@@ -44,7 +44,7 @@ struct granted_params {
 	 * request.
 	 */
 	uint32_t renewal_step_ms;
-};
+} __attribute__ ((packed));
 
 struct granted_state {
 	/* When @budget_byte is reset. */

--- a/bpf/granted.c
+++ b/bpf/granted.c
@@ -112,7 +112,7 @@ granted_pkt(struct gk_bpf_pkt_ctx *ctx)
 		priority = PRIORITY_RENEW_CAP;
 	}
 
-	if (gk_bpf_encapsulate(ctx, priority, false) < 0)
+	if (gk_bpf_prep_for_tx(ctx, priority, false) < 0)
 		return GK_BPF_PKT_RET_ERROR;
 
 	return GK_BPF_PKT_RET_FORWARD;

--- a/bpf/grantedv2.c
+++ b/bpf/grantedv2.c
@@ -1,0 +1,57 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This BPF program limits traffic with two rate limits:
+ * primary and secondary limits or channels.
+ * All traffic is subject to the primary limit.
+ * Traffic that fits the primary limit, but is not desirable
+ * (e.g. fragmented packets) is subject to the second limit.
+ */
+
+#include <arpa/inet.h>
+
+#include "grantedv2.h"
+
+SEC("init") uint64_t
+grantedv2_init(struct gk_bpf_init_ctx *ctx)
+{
+	return grantedv2_init_inline(ctx);
+}
+
+SEC("pkt") uint64_t
+grantedv2_pkt(struct gk_bpf_pkt_ctx *ctx)
+{
+	struct grantedv2_state *state =
+		(struct grantedv2_state *)pkt_ctx_to_cookie(ctx);
+	uint32_t pkt_len = pkt_ctx_to_pkt(ctx)->pkt_len;
+	uint64_t ret = grantedv2_pkt_begin(ctx, state, pkt_len);
+
+	if (ret != GK_BPF_PKT_RET_FORWARD)
+		return ret;
+
+	if (ctx->fragmented || (ctx->l4_proto != IPPROTO_UDP &&
+			ctx->l4_proto != IPPROTO_TCP)) {
+		/* Secondary budget. */
+		ret = grantedv2_pkt_test_2nd_limit(state, pkt_len);
+		if (ret != GK_BPF_PKT_RET_FORWARD)
+			return ret;
+	}
+
+	return grantedv2_pkt_end(ctx, state);
+}

--- a/bpf/grantedv2.h
+++ b/bpf/grantedv2.h
@@ -1,0 +1,172 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <rte_common.h>
+
+#include "gatekeeper_flow_bpf.h"
+#include "bpf_mbuf.h"
+
+struct grantedv2_params {
+	/*
+	 * Primary rate limit: kibibyte/second.
+	 * This limit can never be exceeded.
+	 */
+	uint32_t tx1_rate_kib_sec;
+	/*
+	 * Secondary rate limit: kibibyte/second.
+	 * This limit only applies to some part of the traffic.
+	 *
+	 * The traffic subject to the secondary rate limit is traffic that
+	 * is allowed, but at a lower limit.
+	 *
+	 * When tx2_rate_kib_sec >= tx1_rate_kib_sec, it has no effect.
+	 */
+	uint32_t tx2_rate_kib_sec;
+	/*
+	 * The first value of send_next_renewal_at at
+	 * flow entry comes from next_renewal_ms.
+	 */
+	uint32_t next_renewal_ms;
+	/*
+	 * How many milliseconds (unit) GK must wait
+	 * before sending the next capability renewal
+	 * request.
+	 */
+	uint32_t renewal_step_ms;
+	/*
+	 * If true, do not encapsulate granted packets and send them directly
+	 * to their destinations whenever it is possible.
+	 * When a capability is expiring, its granted packets must go
+	 * through Grantor servers.
+	 */
+	bool direct_if_possible;
+} __attribute__ ((packed));
+
+struct grantedv2_state {
+	/* When @budget_byte is reset. */
+	uint64_t budget_renew_at;
+	/*
+	 * When @budget1_byte is reset,
+	 * add @tx1_rate_kib_cycle * 1024 bytes to it.
+	 */
+	uint32_t tx1_rate_kib_cycle;
+	/*
+	 * When @budget2_byte is reset,
+	 * reset it to @tx2_rate_kib_cycle * 1024 bytes.
+	 */
+	uint32_t tx2_rate_kib_cycle;
+	/* How many bytes @src can still send in current cycle. */
+	int64_t budget1_byte;
+	/*
+	 * How many bytes @src can still send in current cycle in
+	 * the secondary channel.
+	 */
+	int64_t budget2_byte;
+	/*
+	 * When GK should send the next renewal to
+	 * the corresponding grantor.
+	 */
+	uint64_t send_next_renewal_at;
+	/*
+	 * How many cycles (unit) GK must wait before
+	 * sending the next capability renewal request.
+	 */
+	uint64_t renewal_step_cycle;
+	/*
+	 * If true, do not encapsulate granted packets and send them directly
+	 * to their destinations whenever it is possible.
+	 */
+	bool direct_if_possible;
+};
+
+static inline uint64_t
+grantedv2_init_inline(struct gk_bpf_init_ctx *ctx)
+{
+	struct gk_bpf_cookie *cookie = init_ctx_to_cookie(ctx);
+	struct grantedv2_params params = *(struct grantedv2_params *)cookie;
+	struct grantedv2_state *state = (struct grantedv2_state *)cookie;
+
+	RTE_BUILD_BUG_ON(sizeof(params) > sizeof(*cookie));
+	RTE_BUILD_BUG_ON(sizeof(*state) > sizeof(*cookie));
+
+	state->budget_renew_at = ctx->now + cycles_per_sec;
+	state->tx1_rate_kib_cycle = params.tx1_rate_kib_sec;
+	state->tx2_rate_kib_cycle = params.tx2_rate_kib_sec;
+	state->budget1_byte = (int64_t)params.tx1_rate_kib_sec * 1024;
+	state->budget2_byte = (int64_t)params.tx2_rate_kib_sec * 1024;
+	state->send_next_renewal_at = ctx->now +
+		params.next_renewal_ms * cycles_per_ms;
+	state->renewal_step_cycle = params.renewal_step_ms * cycles_per_ms;
+	state->direct_if_possible = params.direct_if_possible;
+
+	return GK_BPF_INIT_RET_OK;
+}
+
+static inline uint64_t
+grantedv2_pkt_begin(const struct gk_bpf_pkt_ctx *ctx,
+	struct grantedv2_state *state, uint32_t pkt_len)
+{
+	if (ctx->now >= state->budget_renew_at) {
+		int64_t max_budget1 = (int64_t)state->tx1_rate_kib_cycle * 1024;
+		int64_t cycles = ctx->now - state->budget_renew_at;
+		int64_t epochs = cycles / cycles_per_sec;
+
+		state->budget_renew_at = ctx->now + cycles_per_sec -
+		       (cycles % cycles_per_sec);
+		state->budget1_byte += max_budget1 * (epochs + 1);
+		if (state->budget1_byte > max_budget1)
+			state->budget1_byte = max_budget1;
+		state->budget2_byte = (int64_t)state->tx2_rate_kib_cycle * 1024;
+	}
+
+	/* Primary budget. */
+	state->budget1_byte -= pkt_len;
+	if (state->budget1_byte < 0)
+		return GK_BPF_PKT_RET_DECLINE;
+
+	return GK_BPF_PKT_RET_FORWARD;
+}
+
+static inline uint64_t
+grantedv2_pkt_test_2nd_limit(struct grantedv2_state *state, uint32_t pkt_len)
+{
+	state->budget2_byte -= pkt_len;
+	if (state->budget2_byte < 0)
+		return GK_BPF_PKT_RET_DECLINE;
+	return GK_BPF_PKT_RET_FORWARD;
+}
+
+static inline uint64_t
+grantedv2_pkt_end(struct gk_bpf_pkt_ctx *ctx, struct grantedv2_state *state)
+{
+	uint8_t priority = PRIORITY_GRANTED;
+
+	if (ctx->now >= state->send_next_renewal_at) {
+		state->send_next_renewal_at = ctx->now +
+			state->renewal_step_cycle;
+		priority = PRIORITY_RENEW_CAP;
+	}
+
+	if (gk_bpf_prep_for_tx(ctx, priority, state->direct_if_possible) < 0)
+		return GK_BPF_PKT_RET_ERROR;
+
+	return GK_BPF_PKT_RET_FORWARD;
+}

--- a/bpf/web.c
+++ b/bpf/web.c
@@ -1,0 +1,202 @@
+/*
+ * Gatekeeper - DoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This BPF program is intended as an example for a simple web server
+ * that runs the services HTTP, HTTPS, SSH, and FTP.
+ *
+ * This BPF program builds upon the BPF program grantedv2, so
+ * there are primary and secondary limits. The secondary limit is only used
+ * for fragmented packets.
+ */
+
+#include <net/ethernet.h>
+#include <netinet/ip_icmp.h>
+#include <netinet/icmp6.h>
+#include <netinet/tcp.h>
+
+#include "grantedv2.h"
+
+#ifdef ntohs
+#undef ntohs
+#endif
+#define ntohs(x) __builtin_bswap16(x)
+
+SEC("init") uint64_t
+web_init(struct gk_bpf_init_ctx *ctx)
+{
+	return grantedv2_init_inline(ctx);
+}
+
+SEC("pkt") uint64_t
+web_pkt(struct gk_bpf_pkt_ctx *ctx)
+{
+	struct grantedv2_state *state =
+		(struct grantedv2_state *)pkt_ctx_to_cookie(ctx);
+	struct rte_mbuf *pkt = pkt_ctx_to_pkt(ctx);
+	uint32_t pkt_len = pkt->pkt_len;
+	struct tcphdr *tcp_hdr;
+	uint64_t ret = grantedv2_pkt_begin(ctx, state, pkt_len);
+
+	if (ret != GK_BPF_PKT_RET_FORWARD) {
+		/* Primary budget exceeded. */
+		return ret;
+	}
+
+	/* Allowed L4 protocols. */
+	switch (ctx->l4_proto) {
+	case IPPROTO_ICMP: {
+		struct icmphdr *icmp_hdr;
+
+		if (ctx->l3_proto != ETHERTYPE_IP) {
+			/* ICMP must be on top of IPv4. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		if (ctx->fragmented)
+			return GK_BPF_PKT_RET_DECLINE;
+		if (pkt->l4_len < sizeof(*icmp_hdr)) {
+			/* Malformed ICMP header. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		icmp_hdr = rte_pktmbuf_mtod_offset(pkt,
+			struct icmphdr *, pkt->l2_len + pkt->l3_len);
+		switch (icmp_hdr->type) {
+		case ICMP_ECHOREPLY:
+		case ICMP_DEST_UNREACH:
+		case ICMP_SOURCE_QUENCH:
+		case ICMP_ECHO:
+		case ICMP_TIME_EXCEEDED:
+			break;
+		default:
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		goto secondary_budget;
+	}
+	case IPPROTO_ICMPV6: {
+		struct icmp6_hdr *icmp6_hdr;
+
+		if (ctx->l3_proto != ETHERTYPE_IPV6) {
+			/* ICMPv6 must be on top of IPv6. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		if (ctx->fragmented)
+			return GK_BPF_PKT_RET_DECLINE;
+		if (pkt->l4_len < sizeof(*icmp6_hdr)) {
+			/* Malformed ICMPv6 header. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		icmp6_hdr = rte_pktmbuf_mtod_offset(pkt,
+			struct icmp6_hdr *, pkt->l2_len + pkt->l3_len);
+		switch (icmp6_hdr->icmp6_type) {
+		case ICMP6_DST_UNREACH:
+		case ICMP6_PACKET_TOO_BIG:
+		case ICMP6_TIME_EXCEEDED:
+		case ICMP6_PARAM_PROB:
+		case ICMP6_ECHO_REQUEST:
+		case ICMP6_ECHO_REPLY:
+			break;
+		default:
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		goto secondary_budget;
+	}
+	case IPPROTO_TCP:
+		break;
+	default:
+		return GK_BPF_PKT_RET_DECLINE;
+	}
+
+	/*
+	 * Only TCP packets from here on.
+	 */
+
+	if (ctx->fragmented)
+		goto secondary_budget;
+	if (pkt->l4_len < sizeof(*tcp_hdr)) {
+		/* Malformed TCP header. */
+		return GK_BPF_PKT_RET_DECLINE;
+	}
+	tcp_hdr = rte_pktmbuf_mtod_offset(pkt, struct tcphdr *,
+	       pkt->l2_len + pkt->l3_len);
+
+	/*
+	 * For information on active and passive modes of FTP,
+	 * refer to the following page:
+	 * http://slacksite.com/other/ftp.html
+	 */
+
+	/* Listening sockets. */
+	switch (ntohs(tcp_hdr->th_dport)) {
+
+	/*
+	 * ATTENTION
+	 *    These ports must match the one configured in the FTP
+	 *    daemon. See the following page for an example:
+	 *    http://slacksite.com/other/ftp-appendix1.html
+	 */
+	case 51000 ... 51999:	/* FTP data (passive mode) */
+
+	case 21:	/* FTP command */
+	case 80:	/* HTTP */
+	case 443:	/* HTTPS */
+	case 22:	/* SSH */
+		if (tcp_hdr->syn && tcp_hdr->ack) {
+			/* Amplification attack. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		break;
+
+	case 20:	/* FTP data (active mode) */
+		/*
+		 * Accept connections of the active mode of FTP originated
+		 * from our web server.
+		 */
+		if (tcp_hdr->syn && !tcp_hdr->ack) {
+			/* All listening ports were already tested. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		break;
+
+	default:
+		/* Accept connections originated from our web server. */
+
+		if (tcp_hdr->syn && !tcp_hdr->ack) {
+			/* All listening ports were already tested. */
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+
+		/* Authorized external services. */
+		switch (ntohs(tcp_hdr->th_sport)) {
+		case 80:	/* HTTP  */
+		case 443:	/* HTTPS */
+			break;
+		default:
+			return GK_BPF_PKT_RET_DECLINE;
+		}
+		break;
+	}
+
+	goto forward;
+
+secondary_budget:
+	ret = grantedv2_pkt_test_2nd_limit(state, pkt_len);
+	if (ret != GK_BPF_PKT_RET_FORWARD)
+		return ret;
+forward:
+	return grantedv2_pkt_end(ctx, state);
+}

--- a/gk/bpf.c
+++ b/gk/bpf.c
@@ -194,7 +194,7 @@ update_pkt_priority(struct ipacket *packet, int priority,
 }
 
 static int
-gk_bpf_encapsulate(struct gk_bpf_pkt_ctx *ctx, int priority,
+gk_bpf_prep_for_tx(struct gk_bpf_pkt_ctx *ctx, int priority,
 	int direct_if_possible)
 {
 	struct gk_bpf_pkt_frame *frame = pkt_ctx_to_frame(ctx);
@@ -275,10 +275,10 @@ static const struct rte_bpf_xsym flow_handler_pkt_xsym[] = {
 		},
 	},
 	{
-		.name = "gk_bpf_encapsulate",
+		.name = "gk_bpf_prep_for_tx",
 		.type = RTE_BPF_XTYPE_FUNC,
 		.func = {
-			.val = (void *)gk_bpf_encapsulate,
+			.val = (void *)gk_bpf_prep_for_tx,
 			.nb_args = 3,
 			.args = {
 				[0] = {

--- a/gk/bpf.c
+++ b/gk/bpf.c
@@ -425,15 +425,18 @@ gk_init_bpf_cookie(const struct gk_config *gk_conf, uint8_t program_index,
 
 int
 gk_bpf_decide_pkt(struct gk_config *gk_conf, uint8_t program_index,
-	struct flow_entry *fe, struct ipacket *packet,
-	struct gk_bpf_pkt_ctx *pctx, uint64_t *p_bpf_ret)
+	struct flow_entry *fe, struct ipacket *packet, uint64_t now,
+	uint64_t *p_bpf_ret)
 {
 	struct gk_bpf_pkt_frame frame = {
 		.password = pkt_password,
 		.fe = fe,
 		.packet = packet,
 		.gk_conf = gk_conf,
-		.ctx = *pctx,
+		.ctx = {
+			.now = now,
+			.expire_at = fe->u.bpf.expire_at,
+		},
 	};
 	const struct gk_bpf_flow_handler *handler =
 		&gk_conf->flow_handlers[program_index];

--- a/gk/bpf.h
+++ b/gk/bpf.h
@@ -31,7 +31,7 @@ int gk_load_bpf_flow_handler(struct gk_config *gk_conf, unsigned int index,
 	const char *filename, int jit);
 
 int gk_bpf_decide_pkt(struct gk_config *gk_conf, uint8_t program_index,
-	struct flow_entry *fe, struct ipacket *packet,
-	struct gk_bpf_pkt_ctx *pctx, uint64_t *p_bpf_ret);
+	struct flow_entry *fe, struct ipacket *packet, uint64_t now,
+	uint64_t *p_bpf_ret);
 
 #endif /* _GATEKEEPER_GK_BPF_H_ */

--- a/include/gatekeeper_flow_bpf.h
+++ b/include/gatekeeper_flow_bpf.h
@@ -117,7 +117,7 @@ GK_BPF_INTERNAL struct gk_bpf_cookie *init_ctx_to_cookie(
 GK_BPF_INTERNAL struct gk_bpf_cookie *pkt_ctx_to_cookie(
 	struct gk_bpf_pkt_ctx *ctx);
 GK_BPF_INTERNAL struct rte_mbuf *pkt_ctx_to_pkt(struct gk_bpf_pkt_ctx *ctx);
-GK_BPF_INTERNAL int gk_bpf_encapsulate(struct gk_bpf_pkt_ctx *ctx,
+GK_BPF_INTERNAL int gk_bpf_prep_for_tx(struct gk_bpf_pkt_ctx *ctx,
 	int priority, int direct_if_possible);
 
 #endif /* _GATEKEEPER_FLOW_BPF_H_ */

--- a/include/gatekeeper_flow_bpf.h
+++ b/include/gatekeeper_flow_bpf.h
@@ -25,6 +25,7 @@
 #define _GATEKEEPER_FLOW_BPF_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * Helper macro to place BPF programs, maps, and licenses in
@@ -91,6 +92,9 @@ enum gk_bpf_pkt_return {
 struct gk_bpf_pkt_ctx {
 	uint64_t now;
 	uint64_t expire_at;
+	uint16_t l3_proto;
+	uint8_t  l4_proto;
+	bool     fragmented;
 };
 
 /*

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -160,7 +160,7 @@ struct granted_params {
 	uint32_t tx_rate_kib_sec;
 	uint32_t next_renewal_ms;
 	uint32_t renewal_step_ms;
-};
+} __attribute__ ((packed));
 
 struct in_addr {
 	uint32_t s_addr;

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -198,6 +198,7 @@ c = ffi.C
 BPF_INDEX_GRANTED = 0
 BPF_INDEX_DECLINED = 1
 BPF_INDEX_GRANTEDV2 = 2
+BPF_INDEX_WEB = 3
 
 function decision_granted_nobpf(policy, tx_rate_kib_sec, cap_expire_sec,
 	next_renewal_ms, renewal_step_ms)
@@ -267,6 +268,16 @@ end
 function decision_grantedv2(policy, tx_rate_kib_sec, cap_expire_sec,
 	next_renewal_ms, renewal_step_ms)
 	return decision_grantedv2_will_full_params(BPF_INDEX_GRANTEDV2,
+		policy, tx_rate_kib_sec, tx_rate_kib_sec * 0.05, -- 5%
+		cap_expire_sec, next_renewal_ms, renewal_step_ms, false)
+end
+
+-- The prototype of this function is compatible with decision_granted() to
+-- help testing it. Policies may prefer to call
+-- decision_grantedv2_will_full_params() instead.
+function decision_web(policy, tx_rate_kib_sec, cap_expire_sec,
+	next_renewal_ms, renewal_step_ms)
+	return decision_grantedv2_will_full_params(BPF_INDEX_WEB,
 		policy, tx_rate_kib_sec, tx_rate_kib_sec * 0.05, -- 5%
 		cap_expire_sec, next_renewal_ms, renewal_step_ms, false)
 end

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -10,6 +10,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 	local bpf_programs = {
 		[0] = "granted.bpf",
 		[1] = "declined.bpf",
+		[2] = "grantedv2.bpf",
 	}
 
 	-- XXX #155 These parameters should only be changed for performance reasons.

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -11,6 +11,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 		[0] = "granted.bpf",
 		[1] = "declined.bpf",
 		[2] = "grantedv2.bpf",
+		[3] = "web.bpf",
 	}
 
 	-- XXX #155 These parameters should only be changed for performance reasons.


### PR DESCRIPTION
In production, BPF programs must inspect packet headers and have a more sophisticated bandwidth accounting than the one found in the BPF program `granted.bpf`. This pull request adds all features that have been identified as needed to write production BPF programs and a rich example, namely the BPF program `web.bpf`, to showcase them.