### PR TITLE
policy: make byteorder conversion functions avaiable to Lua

### DIFF
--- a/gt/main.c
+++ b/gt/main.c
@@ -30,6 +30,7 @@
 #include <rte_random.h>
 #include <rte_cycles.h>
 #include <rte_common.h>
+#include <rte_byteorder.h>
 
 #include "gatekeeper_fib.h"
 #include "gatekeeper_lls.h"
@@ -2210,4 +2211,53 @@ l_update_gt_lua_states_incrementally(lua_State *l)
 	}
 
 	return 0;
+}
+
+/*
+ * The prototype is needed, otherwise there will be a compilation error:
+ * no previous prototype for 'gt_cpu_to_be_16' [-Werror=missing-prototypes]
+ */
+uint16_t gt_cpu_to_be_16(uint16_t x);
+uint32_t gt_cpu_to_be_32(uint32_t x);
+uint16_t gt_be_to_cpu_16(uint16_t x);
+uint32_t gt_be_to_cpu_32(uint32_t x);
+
+/*
+ * This function is only meant to be used in Lua policies.
+ * If you need it in Gatekeeper's C code, use rte_cpu_to_be_16()
+ */
+uint16_t
+gt_cpu_to_be_16(uint16_t x)
+{
+	return rte_cpu_to_be_16(x);
+}
+
+/*
+ * This function is only meant to be used in Lua policies.
+ * If you need it in Gatekeeper's C code, use rte_cpu_to_be_32()
+ */
+uint32_t
+gt_cpu_to_be_32(uint32_t x)
+{
+	return rte_cpu_to_be_32(x);
+}
+
+/*
+ * This function is only meant to be used in Lua policies.
+ * If you need it in Gatekeeper's C code, use rte_be_to_cpu_16()
+ */
+uint16_t
+gt_be_to_cpu_16(uint16_t x)
+{
+	return rte_be_to_cpu_16(x);
+}
+
+/*
+ * This function is only meant to be used in Lua policies.
+ * If you need it in Gatekeeper's C code, use rte_be_to_cpu_32()
+ */
+uint32_t
+gt_be_to_cpu_32(uint32_t x)
+{
+	return rte_be_to_cpu_32(x);
 }

--- a/lua/examples/policy.lua
+++ b/lua/examples/policy.lua
@@ -37,7 +37,7 @@ local simple_policy = {
 	[policylib.c.IPV4] = {
 		-- Loosely assume that TCP and UDP ports are equivalents
 		-- to simplify this example.
-		[policylib.c.rte_cpu_to_be_16(80)] = dcs_friendly,
+		[policylib.c.gt_cpu_to_be_16(80)] = dcs_friendly,
 	},
 }
 

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -178,13 +178,10 @@ struct rte_lpm6 {
 	/* This struct has hidden fields. */
 };
 
-typedef uint16_t rte_be16_t;
-typedef uint32_t rte_be32_t;
-
-rte_be16_t rte_cpu_to_be_16 (uint16_t x);
-rte_be32_t rte_cpu_to_be_32 (uint32_t x);
-uint16_t rte_be_to_cpu_16 (rte_be16_t x);
-uint32_t rte_be_to_cpu_32 (rte_be32_t x);
+uint16_t gt_cpu_to_be_16(uint16_t x);
+uint32_t gt_cpu_to_be_32(uint32_t x);
+uint16_t gt_be_to_cpu_16(uint16_t x);
+uint32_t gt_be_to_cpu_32(uint32_t x);
 
 ]]
 


### PR DESCRIPTION
The issue at #321 was caused by the fact that the byteorder conversion
functions int DPDK (e.g., rte_cpu_to_be_16()) are declared as
'static' functions, so they are not exposed to Lua. This patch
makes these functions available to Lua.

This patch closes #321