### PR TITLE
bpf: allow BPF programs to read cycle measurements

### DIFF
--- a/include/gatekeeper_flow_bpf.h
+++ b/include/gatekeeper_flow_bpf.h
@@ -102,8 +102,8 @@ struct gk_bpf_pkt_ctx {
 #endif
 
 /* Symbols available to the BPF functions init() and pkt(). */
-GK_BPF_INTERNAL uint64_t cycles_per_sec;
-GK_BPF_INTERNAL uint64_t cycles_per_ms;
+extern uint64_t cycles_per_sec;
+extern uint64_t cycles_per_ms;
 
 /* Symbols available to the BPF function init(). */
 GK_BPF_INTERNAL struct gk_bpf_cookie *init_ctx_to_cookie(


### PR DESCRIPTION
The cycles_per_sec and cycles_per_ms variables were not correctly
visible to BPF programs, which introduced bugs into programs that
depended on their values.

This patch closes #325.