### PR TITLE
cps: add fixes to CPS block

### DIFF
--- a/cps/main.c
+++ b/cps/main.c
@@ -676,6 +676,7 @@ kni_create(struct rte_kni **kni, const char *kni_name, struct rte_mempool *mp,
 	strcpy(conf.name, kni_name);
 	conf.mbuf_size = rte_pktmbuf_data_room_size(mp);
 	conf.mtu = iface->mtu;
+	rte_eth_macaddr_get(iface->id, (struct rte_ether_addr *)conf.mac_addr);
 
 	/* If the interface is bonded, take PCI info from the primary slave. */
 	if (iface->num_ports > 1 || iface->bonding_mode == BONDING_MODE_8023AD)
@@ -788,6 +789,12 @@ cps_stage1(void *arg)
 			"Failed to configure KNI link on the front iface\n");
 		goto error;
 	}
+	ret = rte_kni_update_link(cps_conf->front_kni, true);
+	if (ret < 0) {
+		CPS_LOG(ERR,
+			"Failed to set KNI link up on the front iface\n");
+		goto error;
+	}
 
 	cps_conf->front_kni_index = if_nametoindex(name);
 	if (cps_conf->front_kni_index == 0) {
@@ -814,6 +821,12 @@ cps_stage1(void *arg)
 		if (ret < 0) {
 			CPS_LOG(ERR,
 				"Failed to configure KNI link on the back iface\n");
+			goto error;
+		}
+		ret = rte_kni_update_link(cps_conf->back_kni, true);
+		if (ret < 0) {
+			CPS_LOG(ERR,
+				"Failed to set KNI link up on the back iface\n");
 			goto error;
 		}
 


### PR DESCRIPTION
There have been small changes to the KNI configuration over time in DPDK, and this patch brings Gatekeeper up to speed with these changes and enables the BIRD program to successfully run.

Without the carrier state (`IFF_LOWER_UP` as opposed to only `IFF_UP`) being set, BIRD does not recognize the interface as up and will not initialize a BGP session. This is now enabled via a module parameter:

https://doc.dpdk.org/guides/prog_guide/kernel_nic_interface.html#kni-default-carrier-state

If the KNI does not have the same MAC address as the Gatekeeper interface, ARP replies to the KNI will not work since the KNI makes the ARP request with a different address than the one in the response (because we relay the ARP response that was originally sent to the Gatekeeper interface). Somewhere along the line the KNI was configured to not inherit the MAC address of the backing interface by default, so we need to set it explicitly.