### PR TITLE
Change flow table scanning behavior

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -1950,31 +1950,19 @@ gk_proc(void *arg)
 	struct rte_mbuf *front_icmp_bufs[gk_conf->front_max_pkt_burst];
 	struct rte_mbuf *back_icmp_bufs[gk_conf->back_max_pkt_burst];
 
-	int num_buckets = rte_hash_get_num_buckets(
-		instance->ip_flow_hash_table);
 	uint32_t bucket_idx = 0;
-	uint64_t last_scan_tsc = rte_rdtsc();
-	uint64_t last_measure_tsc = last_scan_tsc;
+	uint64_t last_measure_tsc = rte_rdtsc();
 	uint64_t basic_measurement_logging_cycles =
 		gk_conf->basic_measurement_logging_ms *
 		rte_get_tsc_hz() / 1000;
-	uint64_t bucket_scan_timeout_cycles = round(
-		(double)(gk_conf->flow_table_full_scan_ms *
-		rte_get_tsc_hz()) / (num_buckets * 1000.));
-	if (bucket_scan_timeout_cycles == 0) {
-		GK_LOG(WARNING,
-			"The value of the field flow_table_full_scan_ms in Gatekeeper configuration is too small\n");
-		exiting = true;
-		return -1;
-	}
+	uint32_t scan_iter = gk_conf->flow_table_scan_iter + 1;
+	uint64_t iter_count = 0;
 
 	GK_LOG(NOTICE, "The GK block is running at lcore = %u\n", lcore);
 
 	gk_conf_hold(gk_conf);
 
 	while (likely(!exiting)) {
-		uint64_t now;
-
 		front_num_pkts = 0;
 		back_num_pkts = 0;
 
@@ -1995,15 +1983,12 @@ gk_proc(void *arg)
 
 		process_cmds_from_mailbox(instance, gk_conf);
 
-		now = rte_rdtsc();
-		if (now - last_scan_tsc >= bucket_scan_timeout_cycles) {
+		if (iter_count % scan_iter == 0) {
 			gk_flow_tbl_bucket_scan(&bucket_idx,
 				gk_conf->request_timeout_cycles, instance);
-			last_scan_tsc = rte_rdtsc();
-			now = last_scan_tsc;
 		}
 
-		if (now - last_measure_tsc >=
+		if (rte_rdtsc() - last_measure_tsc >=
 				basic_measurement_logging_cycles) {
 			struct gk_measurement_metrics *stats =
 				&instance->traffic_stats;
@@ -2027,6 +2012,8 @@ gk_proc(void *arg)
 
 			last_measure_tsc = rte_rdtsc();
 		}
+
+		iter_count++;
 	}
 
 	GK_LOG(NOTICE, "The GK block at lcore = %u is exiting\n", lcore);

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -116,8 +116,8 @@ struct gk_instance {
 	struct token_bucket_ratelimit_state back_icmp_rs;
 	/* Whether the aggressive scan mode is enabled. */
 	int               agg_scan;
-	/* Bucket that the aggressive scan starts (and ends) at. */
-	uint32_t          agg_scan_bucket_idx;
+	/* Entry that the aggressive scan starts (and ends) at. */
+	uint32_t          agg_scan_entry_idx;
 } __rte_cache_aligned;
 
 #define GK_MAX_BPF_FLOW_HANDLERS	(UINT8_MAX + 1)
@@ -254,14 +254,17 @@ struct gk_config {
 };
 
 /* A flow entry can be in one of the following states: */
-enum gk_flow_state { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_BPF };
+enum { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_BPF };
 
 struct flow_entry {
 	/* IP flow information. */
 	struct ip_flow flow;
 
 	/* The state of the entry. */
-	enum gk_flow_state state;
+	uint8_t state;
+
+	/* Whether this entry is currently in use in ip_flow_entry_table. */
+	uint8_t in_use;
 
 	/*
 	 * The fib entry that instructs where

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -161,8 +161,12 @@ struct gk_config {
 	unsigned int       max_num_ipv4_fib_entries;
 	unsigned int       max_num_ipv6_fib_entries;
 
-	/* Time for scanning the whole flow table in ms. */
-	unsigned int       flow_table_full_scan_ms;
+	/*
+	 * Number of iterations of the GK block's main loop
+	 * between scanning entries of the flow table. Set to
+	 * 0 to scan an entry every iteration of the loop.
+	 */
+	unsigned int       flow_table_scan_iter;
 
 	/* The maximum number of packets to retrieve/transmit. */
 	uint16_t           front_max_pkt_burst;

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -114,6 +114,10 @@ struct gk_instance {
 	/* Data structures used to limit the rate of icmp messages. */
 	struct token_bucket_ratelimit_state front_icmp_rs;
 	struct token_bucket_ratelimit_state back_icmp_rs;
+	/* Whether the aggressive scan mode is enabled. */
+	int               agg_scan;
+	/* Bucket that the aggressive scan starts (and ends) at. */
+	uint32_t          agg_scan_bucket_idx;
 } __rte_cache_aligned;
 
 #define GK_MAX_BPF_FLOW_HANDLERS	(UINT8_MAX + 1)
@@ -167,6 +171,14 @@ struct gk_config {
 	 * 0 to scan an entry every iteration of the loop.
 	 */
 	unsigned int       flow_table_scan_iter;
+
+	/*
+	 * Number of iterations of the GK block's main loop
+	 * between scanning entries of the flow table during
+	 * aggressive scan mode. Aggressive scan mode is activated
+	 * when the flow table becomes full.
+	 */
+	unsigned int       flow_table_agg_scan_iter;
 
 	/* The maximum number of packets to retrieve/transmit. */
 	uint16_t           front_max_pkt_burst;

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -195,7 +195,7 @@ struct gk_config {
 	unsigned int max_num_ipv6_neighbors;
 	unsigned int max_num_ipv4_fib_entries;
 	unsigned int max_num_ipv6_fib_entries;
-	unsigned int flow_table_full_scan_ms;
+	unsigned int flow_table_scan_iter;
 	uint16_t     front_max_pkt_burst;
 	uint16_t     back_max_pkt_burst;
 	uint32_t     front_icmp_msgs_per_sec;

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -196,6 +196,7 @@ struct gk_config {
 	unsigned int max_num_ipv4_fib_entries;
 	unsigned int max_num_ipv6_fib_entries;
 	unsigned int flow_table_scan_iter;
+	unsigned int flow_table_agg_scan_iter;
 	uint16_t     front_max_pkt_burst;
 	uint16_t     back_max_pkt_burst;
 	uint32_t     front_icmp_msgs_per_sec;

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -25,6 +25,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 
 	local flow_ht_size = 1024
 	local flow_table_scan_iter = 1000
+	local flow_table_agg_scan_iter = 10
 
 	local max_num_ipv4_rules = 1024
 	local num_ipv4_tbl8s = 256
@@ -86,6 +87,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 
 	staticlib.c.set_gk_request_timeout(request_timeout_sec, gk_conf)
 	gk_conf.flow_table_scan_iter = flow_table_scan_iter
+	gk_conf.flow_table_agg_scan_iter = flow_table_agg_scan_iter
 	gk_conf.basic_measurement_logging_ms = basic_measurement_logging_ms
 
 	gk_conf.front_icmp_msgs_per_sec = math.floor(front_icmp_msgs_per_sec /

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -24,7 +24,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 	local max_pkt_burst_back = 32
 
 	local flow_ht_size = 1024
-	local flow_table_full_scan_ms = 10 * 60 * 1000 -- (10 minutes)
+	local flow_table_scan_iter = 1000
 
 	local max_num_ipv4_rules = 1024
 	local num_ipv4_tbl8s = 256
@@ -85,7 +85,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 	end
 
 	staticlib.c.set_gk_request_timeout(request_timeout_sec, gk_conf)
-	gk_conf.flow_table_full_scan_ms = flow_table_full_scan_ms
+	gk_conf.flow_table_scan_iter = flow_table_scan_iter
 	gk_conf.basic_measurement_logging_ms = basic_measurement_logging_ms
 
 	gk_conf.front_icmp_msgs_per_sec = math.floor(front_icmp_msgs_per_sec /


### PR DESCRIPTION
Before this patch is added, this is the performance:

| lcores | table size | GK Mpps rcvd | GK Gbps rcvd | Client Mpps sent | Client Gbps sent |
|--------|------------|--------------|--------------|------------------|------------------|
| 1      | 2^10       | 4.88         | 2.33         | 5.77             | 2.75             |
| 1      | 2^15       | 5.84         | 2.78         | 6.24             | 2.98             |
| 1      | 2^20       | 5.53         | 2.63         | 5.70             | 2.72             |
|        |            |              |              |                  |                  |
| 2      | 2^10       | 5.59         | 2.67         | 5.57             | 2.65             |
| 2      | 2^15       | 5.73         | 2.73         | 5.64             | 2.69             |
| 2      | 2^20       | 0.17         | 0.08         | 5.85             | 2.79             |
|        |            |              |              |                  |                  |
| 3      | 2^10       | 5.09         | 2.43         | 5.12             | 2.44             |
| 3      | 2^15       | 5.35         | 2.55         | 5.57             | 2.66             |
| 3      | 2^20       | 5.88         | 2.74         | 5.81             | 2.77             |

After this patch is added, this is the performance:

| lcores | table size | GK Mpps rcvd | GK Gbps rcvd | client Mpps sent | client Gbps sent |
|--------|------------|--------------|--------------|------------------|------------------|
| 1      | 2^10       | 4.17         | 5.53         | 1.99             | 2.64             |
| 1      | 2^15       | 0.75         | 6.14         | 0.36             | 2.93             |
| 1      | 2^20       | 0.07         | 5.56         | 0.03             | 2.65             |
|        |            |              |              |                  |                  |
| 2      | 2^10       | 5.67         | 6.02         | 2.70             | 2.87             |
| 2      | 2^15       | 0.15         | 6.38         | 0.07             | 3.04             |
| 2      | 2^20       | 0.21         | 6.46         | 0.10             | 3.08             |
|        |            |              |              |                  |                  |
| 3      | 2^10       | 5.64         | 6.17         | 2.69             | 2.94             |
| 3      | 2^15       | 0.32         | 6.53         | 0.15             | 3.11             |
| 3      | 2^20       | 0.26         | 6.55         | 0.13             | 3.12             |