### PR TITLE
gk: replace request flow expiration test

### DIFF
--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -196,9 +196,6 @@ struct gk_config {
 	 * Configuration files should not refer to them.
 	 */
 
-	/* Timeout in cycles used to prune the expired request flow entries. */
-	uint64_t           request_timeout_cycles;
-
 	rte_atomic32_t     ref_cnt;
 
 	/* The lcore ids at which each instance runs. */
@@ -354,8 +351,6 @@ struct gk_cmd_entry {
 };
 
 struct gk_config *alloc_gk_conf(void);
-void set_gk_request_timeout(unsigned int request_timeout_sec,
-	struct gk_config *gk_conf);
 int gk_conf_put(struct gk_config *gk_conf);
 int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,
 	struct sol_config *sol_conf);

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -343,8 +343,6 @@ int gatekeeper_setup_user(struct net_config *net_conf,
 int gatekeeper_init_network(struct net_config *net_conf);
 
 struct gk_config *alloc_gk_conf(void);
-void set_gk_request_timeout(unsigned int request_timeout_sec,
-	struct gk_config *gk_conf);
 int gk_load_bpf_flow_handler(struct gk_config *gk_conf, unsigned int index,
 	const char *filename, int jit);
 int run_gk(struct net_config *net_conf, struct gk_config *gk_conf,

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -34,7 +34,6 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 	local max_num_ipv4_fib_entries = 256
 	local max_num_ipv6_fib_entries = 65536
 
-	local request_timeout_sec = 48 * 60 * 60       -- (48 hours)
 	local basic_measurement_logging_ms = 60 * 1000 -- (1 minute)
 
 	local front_icmp_msgs_per_sec = 1000
@@ -84,7 +83,6 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 		gk_conf.max_num_ipv6_fib_entries = 0
 	end
 
-	staticlib.c.set_gk_request_timeout(request_timeout_sec, gk_conf)
 	gk_conf.flow_table_full_scan_ms = flow_table_full_scan_ms
 	gk_conf.basic_measurement_logging_ms = basic_measurement_logging_ms
 


### PR DESCRIPTION
Changing the timeout test for request flows to check
whether the priority is changing enables the GK block to
better prune its flow tables during floods. It also
eliminates the configuration parameter request_timeout_cycles.

Before this patch, this is the performance:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
1 | 2^10 | 5.66 | 2.7 | 6.28 | 3.00 |
1 | 2^15 | 5.13 | 2.45 | 5.14 | 2.45 |
1 | 2^20 | 5.29 | 2.52 | 5.93 | 2.83 |
|        |            |              |              |                  |                  |
2 | 2^10 | 5.73 | 2.73 | 5.75 | 2.74 |
2 | 2^15 | 5.84 | 2.78 | 5.89 | 2.81 |
2 | 2^20 | 0.19 | 0.09 | 5.90 | 2.81 |
|        |            |              |              |                  |                  |
3 | 2^10 | 5.76 | 2.75 | 5.79 | 2.76 |
3 | 2^15 | 5.48 | 2.61 | 5.80 | 2.76 |
3 | 2^20 | 5.17 | 2.46 | 6.06 | 2.89 |
|        |            |              |              |                  |                  |

After this patch, this is the performance:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^10  |  5.9  |  2.81  |  6.12  |  2.92  |
|  1  |  2^15  |  5.21  |  2.48  |  6.42  |  3.06  |
|  1  |  2^20  |  0.11  |  0.05  |  6.02  |  2.87  |
|        |            |              |              |                  |                  |
|  2  |  2^10  |  6.31  |  3.01  |  6.26  |  2.98  |
|  2  |  2^15  |  0.32  |  0.15  |  5.73  |  2.73  |
|  2  |  2^20  |  0.18  |  0.09  |  6.28  |  3.00  |
|        |            |              |              |                  |                  |
|  3  |  2^10  |  6.31  |  3.01  |  6.35  |  3.03  |
|  3  |  2^15  |  0.23  |  0.11  |  6.43  |  3.07  |
|  3  |  2^20  |  0.19  |  0.09  |  6.10  |  2.91  |
|        |            |              |              |                  |                  |