### PR TITLE
Drop new flows probabilistically when the flow hash table is full

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -411,7 +411,7 @@ gk_process_declined(struct flow_entry *fe, struct ipacket *packet,
 {
 	uint64_t now = rte_rdtsc();
 
-	if (unlikely(now >= fe->u.declined.expire_at)) {
+	if (false && unlikely(now >= fe->u.declined.expire_at)) {
 		reinitialize_flow_entry(fe, now);
 		return gk_process_request(fe, packet, sol_conf, stats);
 	}
@@ -1558,7 +1558,6 @@ process_pkts_front(uint16_t port_front, uint16_t port_back,
 					 * flow a chance sending a
 					 * request to the grantor
 					 * server.
-					 */
 					struct flow_entry temp_fe;
 					initialize_flow_entry(&temp_fe,
 						&packet.flow, fib);
@@ -1571,6 +1570,9 @@ process_pkts_front(uint16_t port_front, uint16_t port_back,
 					}
 					instance->is_ht_full = true;
 					continue;
+					 */
+					instance->is_ht_full = true;
+					goto declined;
 				} else if (ret < 0) {
 					drop_packet_front(pkt, instance);
 					continue;
@@ -1681,7 +1683,8 @@ process_pkts_front(uint16_t port_front, uint16_t port_back,
 		 */
 		switch (fe->state) {
 		case GK_REQUEST:
-			ret = gk_process_request(fe, &packet,
+declined:
+			ret = gk_process_declined(fe, &packet,
 				gk_conf->sol_conf, stats);
 			break;
 
@@ -1974,6 +1977,40 @@ gk_proc(void *arg)
 
 	srand((long)time(NULL));
 	instance->is_ht_full = false;
+
+#if 0
+	int i = 0;
+	while (i < 256) {
+		struct ipacket packet;
+		packet.flow.proto = RTE_ETHER_TYPE_IPV4;
+		packet.flow.f.v4.src.s_addr = rte_cpu_to_be_32(0x0a000100 | i);
+		packet.flow.f.v4.dst.s_addr = rte_cpu_to_be_32(0x0a000322);
+		uint32_t rss_hash_val;
+		uint32_t idx;
+		uint32_t shift;
+		uint16_t queue_id;
+		int block_idx;
+		rss_hash_val = rss_ip_flow_hf(&packet.flow, 0, 0) %
+			gk_conf->rss_conf_front.reta_size;
+
+		/*
+		 * Identify which GK block is responsible for the
+		 * pair <Src, Dst> in the decision.
+		 */
+		idx = rss_hash_val / RTE_RETA_GROUP_SIZE;
+		shift = rss_hash_val % RTE_RETA_GROUP_SIZE;
+		queue_id = gk_conf->rss_conf_front.reta_conf[idx].reta[shift];
+		block_idx = gk_conf->queue_id_to_instance[queue_id];
+
+		printf("address: %08x:%08x; software: %u (%u)\n",
+			packet.flow.f.v4.src.s_addr,
+			packet.flow.f.v4.dst.s_addr,
+			rss_ip_flow_hf(&packet.flow, 0, 0),
+			block_idx);
+
+		i++;
+	}
+#endif
 
 	while (likely(!exiting)) {
 		uint64_t now;

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -96,6 +96,7 @@ struct gk_measurement_metrics {
 
 /* Structures for each GK instance. */
 struct gk_instance {
+	bool              is_ht_full;
 	struct rte_hash   *ip_flow_hash_table;
 	struct flow_entry *ip_flow_entry_table;
 	struct acl_search *acl4;

--- a/lua/examples/add.lua
+++ b/lua/examples/add.lua
@@ -1,0 +1,14 @@
+require "gatekeeper/staticlib"
+
+local acc_start = ""
+local reply_msg = ""
+
+local dyc = staticlib.c.get_dy_conf()
+
+local ret = dylib.c.add_fib_entry("10.0.3.0/24", "10.0.3.2",
+	"10.0.2.2", dylib.c.GK_FWD_GRANTOR, dyc.gk)
+if ret < 0 then
+	return "gk: failed to add an FIB entry\n"
+end
+
+return "gk: successfully processed all the FIB entries\n" .. reply_msg

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -34,7 +34,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 	local max_num_ipv4_fib_entries = 256
 	local max_num_ipv6_fib_entries = 65536
 
-	local basic_measurement_logging_ms = 60 * 1000 -- (1 minute)
+	local basic_measurement_logging_ms = 30 * 1000 -- (1 minute)
 
 	local front_icmp_msgs_per_sec = 1000
 	local front_icmp_msgs_burst = 50

--- a/lua/lls.lua
+++ b/lua/lls.lua
@@ -5,7 +5,7 @@ return function (net_conf, numa_table)
 	--
 
 	-- These parameters should likely be initially changed.
-	local log_level = staticlib.c.RTE_LOG_DEBUG
+	local log_level = staticlib.c.RTE_LOG_INFO
 
 	-- XXX #155 These parameters should only be changed for performance reasons.
 	local mailbox_max_entries_exp = 7

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -13,14 +13,14 @@ return function (gatekeeper_server)
 	local front_ips  = {"10.0.1.1/24", "2001:db8:1::1/48"}
 	local front_bonding_mode = staticlib.c.BONDING_MODE_ROUND_ROBIN
 	local front_vlan_tag = 0x123
-	local front_vlan_insert = true
+	local front_vlan_insert = false
 	local front_mtu = 1500
 
 	local back_ports = {"enp133s0f1"}
 	local back_ips  = {"10.0.2.1/24", "2001:db8:2::1/48"}
 	local back_bonding_mode = staticlib.c.BONDING_MODE_ROUND_ROBIN
 	local back_vlan_tag = 0x456
-	local back_vlan_insert = true
+	local back_vlan_insert = false
 	local back_mtu = 2048
 
 	-- XXX #155 These parameters should only be changed for performance reasons.


### PR DESCRIPTION
Note that, **this patch is more to discuss the idea since it's not complete. We will need the code to dynamically adjust the probability threshold.**

After this patch, the evaluation with different hard-coded probability thresholds is shown as following:

1. Dropping ``50%`` new flows when flow hash table is full:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^10  |  5.05  |  2.41  |  6.40  |  3.05  |
|  1  |  2^15  |  4.78  |  2.28  |  5.96  |  2.84  |
|  1  |  2^20  |  0.14  |  0.07  |  6.49  |  3.10  |
|        |            |              |              |                  |                  |
|  2  |  2^10  |  3.74  |  1.79  |  6.35  |  3.03  |
|  2  |  2^15  |  0.52  |  0.25  |  6.13  |  2.92  |
|  2  |  2^20  |  0.32  |  0.15  |  6.49  |  3.10  |
|        |            |              |              |                  |                  |
|  3  |  2^10  |  4.24  |  2.02  |  6.27  |  2.99  |
|  3  |  2^15  |  0.6  |  0.29  |  6.24  |  2.98  |
|  3  |  2^20  |  0.42  |  0.2  |  5.74  |  2.74  |
|        |            |              |              |                  |                  |

2. Dropping ``95%`` new flows when flow hash table is full:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^10  |  5.17  |  2.47  |  5.80  |  2.76  |
|  1  |  2^15  |  5.03  |  2.4  |  6.88  |  3.28  |
|  1  |  2^20  |  1.29  |  0.61  |  6.26  |  2.98  |
|        |            |              |              |                  |                  |
|  2  |  2^10  |  3.06  |  1.46  |  5.85  |  2.79  |
|  2  |  2^15  |  2.24  |  1.07  |  6.38  |  3.04  |
|  2  |  2^20  |  2.35  |  1.12  |  5.84  |  2.78  |
|        |            |              |              |                  |                  |
|  3  |  2^10  |  4.38  |  2.09  |  5.94  |  2.83  |
|  3  |  2^15  |  2.78  |  1.33  |  6.58  |  3.14  |
|  3  |  2^20  |  2.54  |  1.21  |  5.59  |  2.67  |
|        |            |              |              |                  |                  |

3. Dropping ``99%`` new flows when flow hash table is full:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^10  |  5.74  |  2.74  |  5.88  |  2.80  |
|  1  |  2^15  |  4.19  |  2.0  |  5.97  |  2.85  |
|  1  |  2^20  |  3.68  |  1.75  |  6.20  |  2.96  |
|        |            |              |              |                  |                  |
|  2  |  2^10  |  3.61  |  1.72  |  6.00  |  2.86  |
|  2  |  2^15  |  3.93  |  1.87  |  6.38  |  3.04  |
|  2  |  2^20  |  3.04  |  1.45  |  6.13  |  2.92  |
|        |            |              |              |                  |                  |
|  3  |  2^10  |  4.4  |  2.1  |  6.32  |  3.01  |
|  3  |  2^15  |  4.29  |  2.04  |  6.61  |  3.15  |
|  3  |  2^20  |  3.46  |  1.65  |  5.83  |  2.78  |
|        |            |              |              |                  |                  |

For the performance of the master branch, you can find the metrics in https://github.com/AltraMayor/gatekeeper/pull/330
