### PR TITLE
gk: drop new flows over batches when flow table is full

### DIFF
--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -114,6 +114,7 @@ struct gk_instance {
 	/* Data structures used to limit the rate of icmp messages. */
 	struct token_bucket_ratelimit_state front_icmp_rs;
 	struct token_bucket_ratelimit_state back_icmp_rs;
+	bool has_insertion_failed;
 } __rte_cache_aligned;
 
 #define GK_MAX_BPF_FLOW_HANDLERS	(UINT8_MAX + 1)


### PR DESCRIPTION
This patch solves the performance degradation issue https://github.com/AltraMayor/gatekeeper/pull/330.
The key insight is that having a single failure per batch
may be bearable. Given a batch of received packets,
it tries to add all new flows, but if one addition fails
for the batch of received packets, it doesn't try all
the other flows to be added in that batch.