### PR TITLE
gk: scan over flow table entries directly

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -193,6 +193,7 @@ initialize_flow_entry(struct flow_entry *fe,
 
 	rte_memcpy(&fe->flow, flow, sizeof(*flow));
 
+	fe->in_use = true;
 	fe->state = GK_REQUEST;
 	fe->u.request.last_packet_seen_at = rte_rdtsc();
 	fe->u.request.last_priority = START_PRIORITY;
@@ -552,32 +553,17 @@ gk_del_flow_entry_from_hash(struct rte_hash *h, struct flow_entry *fe)
 	return ret;
 }
 
-/* Return true when it removes at least one entry, and false otherwise. */
+/* Return true when it removes an entry, and false otherwise. */
 static bool
-gk_flow_tbl_bucket_scan(uint32_t *bidx, struct gk_instance *instance)
+gk_flow_tbl_entry_scan(uint32_t entry_idx, struct gk_instance *instance)
 {
-	int32_t index;
-	const struct ip_flow *key;
-	void *data;
-	uint32_t next = 0;
-	uint64_t now = rte_rdtsc();
-	bool flow_removed = false;
-
-	index = rte_hash_bucket_iterate(instance->ip_flow_hash_table,
-		(void *)&key, &data, bidx, &next);
-	while (index >= 0) {
-		struct flow_entry *fe = &instance->ip_flow_entry_table[index];
-		if (is_flow_expired(fe, now)) {
-			gk_del_flow_entry_from_hash(
-				instance->ip_flow_hash_table, fe);
-			flow_removed = true;
-		}
-
-		index = rte_hash_bucket_iterate(instance->ip_flow_hash_table,
-			(void *)&key, &data, bidx, &next);
+	struct flow_entry *fe = &instance->ip_flow_entry_table[entry_idx];
+	if (fe->in_use && is_flow_expired(fe, rte_rdtsc())) {
+		gk_del_flow_entry_from_hash(
+			instance->ip_flow_hash_table, fe);
+		return true;
 	}
-
-	return flow_removed;
+	return false;
 }
 
 static int
@@ -682,7 +668,7 @@ out:
 
 static struct flow_entry *
 find_flow_entry_candidate(struct gk_instance *instance,
-	uint32_t bidx, enum gk_flow_state state_to_add)
+	uint32_t bidx, uint8_t state_to_add)
 {
 	int32_t index;
 	uint32_t next = 0;
@@ -720,7 +706,7 @@ find_flow_entry_candidate(struct gk_instance *instance,
 
 static int
 drop_flow_entry_heuristically(struct gk_instance *instance,
-	hash_sig_t sig, enum gk_flow_state state_to_add)
+	hash_sig_t sig, uint8_t state_to_add)
 {
 	uint32_t primary_bidx = rte_hash_get_primary_bucket(
 		instance->ip_flow_hash_table, sig);
@@ -738,8 +724,7 @@ drop_flow_entry_heuristically(struct gk_instance *instance,
  */
 static int
 gk_hash_add_flow_entry(struct gk_instance *instance,
-	struct ip_flow *flow, uint32_t rss_hash_val,
-	enum gk_flow_state state_to_add)
+	struct ip_flow *flow, uint32_t rss_hash_val, uint8_t state_to_add)
 {
 	int retried = false;
 	while (true) {
@@ -806,7 +791,7 @@ add_new_flow_from_policy(
 
 	fe = &instance->ip_flow_entry_table[ret];
 	rte_memcpy(&fe->flow, &policy->flow, sizeof(fe->flow));
-
+	fe->in_use = true;
 	fe->grantor_fib = fib;
 
 	return fe;
@@ -2018,7 +2003,7 @@ gk_proc(void *arg)
 	struct rte_mbuf *front_icmp_bufs[gk_conf->front_max_pkt_burst];
 	struct rte_mbuf *back_icmp_bufs[gk_conf->back_max_pkt_burst];
 
-	uint32_t bucket_idx = 0;
+	uint32_t entry_idx = 0;
 	uint64_t last_measure_tsc = rte_rdtsc();
 	uint64_t basic_measurement_logging_cycles =
 		gk_conf->basic_measurement_logging_ms *
@@ -2054,10 +2039,10 @@ gk_proc(void *arg)
 		if (iter_count >= scan_iter) {
 			/*
 			 * Reset the flag @has_insertion_failed when
-			 * one or more entries have been freed from
-			 * the flow table.
+			 * an entry has been freed from the flow table.
 			 */
-			if (gk_flow_tbl_bucket_scan(&bucket_idx, instance))
+			entry_idx = (entry_idx + 1) % gk_conf->flow_ht_size;
+			if (gk_flow_tbl_entry_scan(entry_idx, instance))
 				instance->has_insertion_failed = false;
 
 			iter_count = 0;

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -240,14 +240,17 @@ struct gk_config {
 };
 
 /* A flow entry can be in one of the following states: */
-enum gk_flow_state { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_BPF };
+enum { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_BPF };
 
 struct flow_entry {
 	/* IP flow information. */
 	struct ip_flow flow;
 
 	/* The state of the entry. */
-	enum gk_flow_state state;
+	uint8_t state;
+
+	/* Whether this entry is currently in use in ip_flow_entry_table. */
+	uint8_t in_use;
 
 	/*
 	 * The fib entry that instructs where


### PR DESCRIPTION
Instead of iterating over the hash table map, iterate over
the flow entries directly.

To do so, add a field to each flow entry which marks whether
that entry is actively in use. To keep the size of the flow
entry <= 128 bytes, change the state to be a uint8_t.

Before this patch, the performance is:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^15  |  3.53  |  1.68  |  9.95  |  4.74  |
|  1  |  2^20  |  3.49  |  1.66  |  10.13  |  4.83  |
|  1  |  2^22  |  1.89  |  0.9  |  11.06  |  5.28  |
|        |            |              |              |                  |                  |
|  2  |  2^15  |  7.26  |  3.46  |  9.85  |  4.69  |
|  2  |  2^20  |  5.32  |  2.54  |  10.41  |  4.96  |
|  2  |  2^22  |  4.0  |  1.91  |  10.03  |  4.78  |
|        |            |              |              |                  |                  |
|  3  |  2^15  |  8.96  |  4.27  |  10.18  |  4.85  |
|  3  |  2^20  |  5.79  |  2.76  |  10.41  |  4.97  |
|  3  |  2^22  |  5.04  |  2.4  |  10.00  |  4.77  |
|        |            |              |              |                  |                  |

After this patch, the performance is:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^15  |  3.74  |  1.78  |  10.76  |  5.13  |
|  1  |  2^20  |  3.28  |  1.56  |  10.24  |  4.88  |
|  1  |  2^22  |  2.4  |  1.15  |  10.41  |  4.96  |
|        |            |              |              |                  |                  |
|  2  |  2^15  |  6.82  |  3.25  |  10.36  |  4.94  |
|  2  |  2^20  |  5.85  |  2.79  |  10.29  |  4.91  |
|  2  |  2^22  |  4.37  |  2.08  |  10.20  |  4.87  |
|        |            |              |              |                  |                  |
|  3  |  2^15  |  9.53  |  4.54  |  10.14  |  4.84  |
|  3  |  2^20  |  8.18  |  3.9  |  10.02  |  4.78  |
|  3  |  2^22  |  6.1  |  2.91  |  10.18  |  4.85  |
|        |            |              |              |                  |                  |

These tests were run with 16 bots. I found that 2^22 was the greatest table size that Gatekeeper can support on XIA1 without any allocation failures across all tests.