### PR TITLE
lib: fix a bug in mailbox

### DIFF
--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -78,8 +78,9 @@ mb_alloc_entry(struct mailbox *mb)
 {
 	void *obj = NULL;
 	int ret = rte_mempool_get(mb->pool, &obj);
-	if (ret == -ENOENT) {
-		G_LOG(ERR, "mailbox: not enough entries in the mempool\n");
+	if (ret < 0) {
+		G_LOG(ERR, "mailbox: failed to get a new entry from the mempool - %s\n",
+			strerror(-ret));
 		return NULL;
 	}
 


### PR DESCRIPTION
When testing Gatekeeper under simulated DDoS attack with
repo https://github.com/cjdoucette/gatekeeper/tree/xia1_gk_test,
Gatekeeper aborted due to too many requests.

After tracing the call graph of the function call ``mb_alloc_entry()``,
we found that the documentation in both the DPDK documentation
http://doc.dpdk.org/api/rte__mempool_8h.html#a6150c041e889498a08d0e0d0769292cb
and its comment for function ``rte_mempool_get()`` were wrong: its return
value is either ``0`` or ``-ENOENT``. However, the true return value is either ``0``
or ``-ENOBUFS`` according to DPDK file ``drivers/mempool/ring/rte_mempool_ring.c``

This patch closes #349.