### PR TITLE
gk: send requests to SOL in batch

### DIFF
--- a/include/gatekeeper_sol.h
+++ b/include/gatekeeper_sol.h
@@ -159,7 +159,7 @@ struct sol_config {
 
 struct sol_config *alloc_sol_conf(void);
 int run_sol(struct net_config *net_conf, struct sol_config *sol_conf);
-int gk_solicitor_enqueue(struct sol_config *sol_conf, struct rte_mbuf *pkt,
-	uint8_t priority);
+int gk_solicitor_enqueue_bulk(struct sol_config *sol_conf,
+	struct rte_mbuf **pkts, uint8_t *priorities, uint16_t num_pkts);
 
 #endif /* _GATEKEEPER_SOL_H_ */


### PR DESCRIPTION
With our new [test environment](https://github.com/cjdoucette/gatekeeper/tree/xia1_gk_test), the mailbox operations are dominating the CPU cycles according to Gatekeeper profiling using Linux perf. To solve the performance issue here, we batch the mailbox operations to send packets to the SOL block in the GK block.

This is the performance before this patch:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^15  |  3.17  |  1.51  |  11.69  |  5.57  |
|  1  |  2^20  |  3.07  |  1.46  |  12.08  |  5.76  |
|  1  |  2^22  |  2.15  |  1.03  |  11.98  |  5.71  |
|        |            |              |              |                  |                  |
|  2  |  2^15  |  4.88  |  2.33  |  11.90  |  5.67  |
|  2  |  2^20  |  3.39  |  1.62  |  11.99  |  5.72  |
|  2  |  2^22  |  3.28  |  1.56  |  12.12  |  5.78  |
|        |            |              |              |                  |                  |
|  3  |  2^15  |  4.46  |  2.13  |  11.54  |  5.50  |
|  3  |  2^20  |  3.19  |  1.52  |  11.45  |  5.46  |
|  3  |  2^22  |  3.68  |  1.76  |  11.59  |  5.53  |
|        |            |              |              |                  |                  |

Below is the performance with this patch:

| lcores | table size | GK Mpps rcvd | GK Gibps rcvd | client Mpps sent | client Gibps sent |
|--------|------------|--------------|---------------|------------------|-------------------|
|  1  |  2^15  |  4.56  |  2.18  |  12.09  |  5.77  |
|  1  |  2^20  |  4.66  |  2.22  |  12.11  |  5.77  |
|  1  |  2^22  |  3.12  |  1.49  |  11.99  |  5.72  |
|        |            |              |              |                  |                  |
|  2  |  2^15  |  4.72  |  2.25  |  12.06  |  5.75  |
|  2  |  2^20  |  7.14  |  3.41  |  11.25  |  5.36  |
|  2  |  2^22  |  3.89  |  1.86  |  10.43  |  4.97  |
|        |            |              |              |                  |                  |
|  3  |  2^15  |  9.79  |  4.67  |  10.38  |  4.95  |
|  3  |  2^20  |  4.25  |  2.03  |  9.69  |  4.62  |
|  3  |  2^22  |  4.23  |  2.02  |  10.00  |  4.77  |
|        |            |              |              |                  |                  |

Therefore, we saw performance improvement by up to ``2.2x``.