### PR TITLE
gk: change the value of mailbox_max_entries_exp to 14

### DIFF
--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -15,7 +15,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 	}
 
 	-- XXX #155 These parameters should only be changed for performance reasons.
-	local mailbox_max_entries_exp = 7
+	local mailbox_max_entries_exp = 14
 	local mailbox_mem_cache_size = 0
 	local mailbox_burst_size = 32
 	local log_ratelimit_interval_ms = 5000


### PR DESCRIPTION
This patch changes the value of mailbox_max_entries_exp in GK blocks to 14.
With its original value 7, GGU will report the following message:
``GATEKEEPER: mailbox: failed to get a new entry from the mempool - No buffer space available``.