### PR TITLE
Scan over flow table entries directly

### DIFF
--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -240,14 +240,17 @@ struct gk_config {
 };
 
 /* A flow entry can be in one of the following states: */
-enum gk_flow_state { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_BPF };
+enum { GK_REQUEST, GK_GRANTED, GK_DECLINED, GK_BPF };
 
 struct flow_entry {
 	/* IP flow information. */
 	struct ip_flow flow;
 
 	/* The state of the entry. */
-	enum gk_flow_state state;
+	uint8_t state;
+
+	/* Whether this entry is currently in use in ip_flow_entry_table. */
+	bool    in_use;
 
 	/*
 	 * The fib entry that instructs where

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -114,7 +114,7 @@ struct gk_instance {
 	/* Data structures used to limit the rate of icmp messages. */
 	struct token_bucket_ratelimit_state front_icmp_rs;
 	struct token_bucket_ratelimit_state back_icmp_rs;
-	bool has_insertion_failed;
+	unsigned int num_scan_del;
 } __rte_cache_aligned;
 
 #define GK_MAX_BPF_FLOW_HANDLERS	(UINT8_MAX + 1)
@@ -168,6 +168,13 @@ struct gk_config {
 	 * 0 to scan an entry every iteration of the loop.
 	 */
 	unsigned int       flow_table_scan_iter;
+
+	/*
+	 * When the flow hash table is full, Gatekeeper will
+	 * enable the insertion again only after cleaning up
+	 * a number of expired flow entries.
+	 */
+	unsigned int       scan_del_thresh;
 
 	/* The maximum number of packets to retrieve/transmit. */
 	uint16_t           front_max_pkt_burst;

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -196,6 +196,7 @@ struct gk_config {
 	unsigned int max_num_ipv4_fib_entries;
 	unsigned int max_num_ipv6_fib_entries;
 	unsigned int flow_table_scan_iter;
+	unsigned int scan_del_thresh;
 	uint16_t     front_max_pkt_burst;
 	uint16_t     back_max_pkt_burst;
 	uint32_t     front_icmp_msgs_per_sec;

--- a/lua/gk.lua
+++ b/lua/gk.lua
@@ -25,6 +25,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 
 	local flow_ht_size = 1024
 	local flow_table_scan_iter = 1000
+	local scan_del_thresh = flow_ht_size * 0.01
 
 	local max_num_ipv4_rules = 1024
 	local num_ipv4_tbl8s = 256
@@ -85,6 +86,7 @@ return function (net_conf, lls_conf, sol_conf, gk_lcores)
 
 	gk_conf.flow_table_scan_iter = flow_table_scan_iter
 	gk_conf.basic_measurement_logging_ms = basic_measurement_logging_ms
+	gk_conf.scan_del_thresh = scan_del_thresh
 
 	gk_conf.front_icmp_msgs_per_sec = math.floor(front_icmp_msgs_per_sec /
 		num_lcores + 0.5)


### PR DESCRIPTION
This pull request incorporated Cody's pull request #347. Moreover, it adds memory prefetching for flow entry while iterating over the flow table. Also, it heuristically holds the insertion failure state until a certain number of flow entries have expired and been cleaned up.