### PR TITLE
Add uint32_t flow_hash_val to struct flow_entry

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -447,7 +447,7 @@ gk_process_bpf(struct flow_entry *fe, struct ipacket *packet,
 	if (unlikely(now >= fe->u.bpf.expire_at))
 		goto expired;
 
-	program_index = fe->u.bpf.program_index;
+	program_index = fe->program_index;
 	rc = gk_bpf_decide_pkt(gk_conf, program_index, fe, packet, now,
 		&bpf_ret);
 	if (unlikely(rc != 0)) {
@@ -811,8 +811,7 @@ print_flow_state(struct flow_entry *fe)
 			"gk: log the flow state [state: GK_BPF (%hhu), expire_at: 0x%"PRIx64", program_index=%u, cookie="
 			"%016" PRIx64 ", %016" PRIx64 ", %016" PRIx64 ", %016" PRIx64
 			", %016" PRIx64 ", %016" PRIx64 ", %016" PRIx64 ", %016" PRIx64 ", grantor_ip: %s] in the flow table at %s with lcore %u",
-			fe->state, fe->u.bpf.expire_at,
-			fe->u.bpf.program_index,
+			fe->state, fe->u.bpf.expire_at, fe->program_index,
 			rte_cpu_to_be_64(c[0]), rte_cpu_to_be_64(c[1]),
 			rte_cpu_to_be_64(c[2]), rte_cpu_to_be_64(c[3]),
 			rte_cpu_to_be_64(c[4]), rte_cpu_to_be_64(c[5]),
@@ -2005,7 +2004,7 @@ update_flow_entry(struct flow_entry *fe, struct ggu_policy *policy)
 		fe->state = GK_BPF;
 		fe->u.bpf.expire_at = now +
 			policy->params.bpf.expire_sec * cycles_per_sec;
-		fe->u.bpf.program_index = policy->params.bpf.program_index;
+		fe->program_index = policy->params.bpf.program_index;
 		fe->u.bpf.cookie = policy->params.bpf.cookie;
 		break;
 

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -258,6 +258,18 @@ struct flow_entry {
 	bool    in_use;
 
 	/*
+	 * This field was moved from u.bpf.program_index below to solve the
+	 * structure padding issue that prevents us from adding new fields.
+	 *
+	 * More specifically, before this move, the sizeof(struct flow_entry)
+	 * is 128, so we cannot add new fields due to the compilation check
+	 * in gk/main.c (i.e., RTE_BUILD_BUG_ON(sizeof(*fe) > 128)).
+	 *
+	 * Index of the BPF program associated to the GK_BPF state.
+	 */
+	uint8_t	 program_index;
+
+	/*
 	 * The fib entry that instructs where
 	 * to send the packets for this flow entry.
 	 */
@@ -318,8 +330,6 @@ struct flow_entry {
 		struct {
 			/* When this state is no longer valid. */
 			uint64_t expire_at;
-			/* Index of the BPF program associated to this state. */
-			uint8_t	 program_index;
 			/*
 			 * Memory to be passed to the BPF proram each time
 			 * it is executed.

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -251,6 +251,9 @@ struct flow_entry {
 	/* IP flow information. */
 	struct ip_flow flow;
 
+	/* RSS hash value of the IP flow. */
+	uint32_t flow_hash_val;
+
 	/* The state of the entry. */
 	uint8_t state;
 


### PR DESCRIPTION
This pull request was motivated by the discussion [here](https://github.com/AltraMayor/gatekeeper/pull/354#discussion_r338535253). It adds a new field ``uint32_t flow_hash_val`` to ``struct flow_entry``, so that the hash value of the IP flow can be accessed directly and it could save CPU cycles, especially when deleting flow entries from the flow hash table.