### PR TITLE
Streamline code of gk_proc()

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -2275,10 +2275,10 @@ gk_proc(void *arg)
 		} else
 			fe = NULL;
 
-		send_pkts(port_front, rx_queue_front,
+		send_pkts(port_front, tx_queue_front,
 			front_num_pkts, front_icmp_bufs);
 
-		send_pkts(port_back, rx_queue_back,
+		send_pkts(port_back, tx_queue_back,
 			back_num_pkts, back_icmp_bufs);
 
 		process_cmds_from_mailbox(instance, gk_conf);

--- a/include/gatekeeper_acl.h
+++ b/include/gatekeeper_acl.h
@@ -29,8 +29,23 @@ struct acl_search {
 	/* Fixed field here. */
 	const uint8_t   **data;
 	/* List of references to each packet's mbuf. */
-	struct rte_mbuf *mbufs[0];
+	struct rte_mbuf **mbufs;
 };
+
+/*
+ * Declare and initialize a struct acl_search.
+ *
+ * This struct must not be passed to destroy_acl_search().
+ * Assuming that it's empty, just let the struct go out of scope.
+ */
+#define DEFINE_ACL_SEARCH(name, num_pkts)			\
+	const uint8_t *name##_data_array[(num_pkts)];		\
+	struct rte_mbuf *name##_mbufs_array[(num_pkts)];	\
+	struct acl_search name = {				\
+		.num = 0,					\
+		.data = name##_data_array,			\
+		.mbufs = name##_mbufs_array,			\
+	}
 
 struct acl_search *alloc_acl_search(uint8_t num_pkts);
 void destroy_acl_search(struct acl_search *acl);

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -98,8 +98,6 @@ struct gk_measurement_metrics {
 struct gk_instance {
 	struct rte_hash   *ip_flow_hash_table;
 	struct flow_entry *ip_flow_entry_table;
-	struct acl_search *acl4;
-	struct acl_search *acl6;
 	/* RX queue on the front interface. */
 	uint16_t          rx_queue_front;
 	/* TX queue on the front interface. */

--- a/lib/acl.c
+++ b/lib/acl.c
@@ -37,6 +37,8 @@ alloc_acl_search(uint8_t num_pkts)
 	if (acl == NULL)
 		return NULL;
 
+	acl->mbufs = (struct rte_mbuf **)
+		((char *)acl + sizeof(struct acl_search));
 	acl->data = (const uint8_t **)&acl->mbufs[num_pkts];
 
 	return acl;


### PR DESCRIPTION
This first patch in this pull request fixes a subtle bug and the following patches streamline a few things in the code around `gk_proc()`. The central motivation for these rewrites is to smooth out the introduction of the upcoming coroutines.