### PR TITLE
sol: solve the contention issue

### DIFF
--- a/lib/net.c
+++ b/lib/net.c
@@ -1666,7 +1666,8 @@ init_net_stage1(void *arg)
 		net_conf->gatekeeper_pktmbuf_pool[i] =
 			rte_pktmbuf_pool_create(pool_name,
 				net_conf->gatekeeper_num_mbuf,
-				net_conf->gatekeeper_per_lcore_cache_size, 0,
+				net_conf->gatekeeper_per_lcore_cache_size,
+				sizeof(struct list_head),
 				RTE_MBUF_DEFAULT_BUF_SIZE, (unsigned)i);
 
 		/*

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -311,7 +311,6 @@ struct sol_config {
 	unsigned int deq_burst_size;
 	double       tb_rate_approx_err;
 	double       req_channel_bw_mbps;
-	unsigned int mailbox_mem_cache_size;
 	uint32_t     log_level;
 	int          log_type;
 	uint32_t     log_ratelimit_interval_ms;

--- a/lua/sol.lua
+++ b/lua/sol.lua
@@ -8,7 +8,6 @@ return function (net_conf, lcore)
 	local log_level = staticlib.c.RTE_LOG_DEBUG
 
 	-- XXX #155 These parameters should only be changed for performance reasons.
-	local mailbox_mem_cache_size = 0
 	local log_ratelimit_interval_ms = 5000
 	local log_ratelimit_burst = 10
 	local pri_req_max_len = 1024
@@ -33,7 +32,6 @@ return function (net_conf, lcore)
 
 	sol_conf.log_level = log_level
 
-	sol_conf.mailbox_mem_cache_size = mailbox_mem_cache_size
 	sol_conf.log_ratelimit_interval_ms = log_ratelimit_interval_ms
 	sol_conf.log_ratelimit_burst = log_ratelimit_burst
 	sol_conf.pri_req_max_len = pri_req_max_len


### PR DESCRIPTION
The function call common_ring_mc_queue() has very high memory loads
according to Linux perf profiling. This patch tries to remove the use
of struct priority_req, and make struct rte_mbuf itself carry all the
information. Specifically, it uses the private data of the mbuf to carry
the list information and uses the field udata64 in rte_mbuf to carry
the priority inforation. With this optimization, it removes the need for
struct priority_req as well as the mailbox. Instead, it uses the Ring library
to transfer request packets to the SOL block.