### PR TITLE
gatekeeper: create a mbuf pool for each lcore

### DIFF
--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -36,42 +36,42 @@ extern int cps_logtype;
 /* Configuration for the Control Plane Support functional block. */
 struct cps_config {
 	/* lcore that the CPS block runs on. */
-	unsigned int      lcore_id;
+	unsigned int       lcore_id;
 	/* Source and destination TCP ports to capture BGP traffic. */
-	uint16_t          tcp_port_bgp;
+	uint16_t           tcp_port_bgp;
 
 	/* Log level for CPS block. */
-	uint32_t          log_level;
+	uint32_t           log_level;
 	/* Dynamic logging type, assigned at runtime. */
-	int               log_type;
+	int                log_type;
 	/* Log ratelimit interval in ms for CPS block. */
-	uint32_t          log_ratelimit_interval_ms;
+	uint32_t           log_ratelimit_interval_ms;
 	/* Log ratelimit burst size for CPS block. */
-	uint32_t          log_ratelimit_burst;
+	uint32_t           log_ratelimit_burst;
 
 	/* The maximum number of packets to retrieve/transmit. */
-	uint16_t          front_max_pkt_burst;
-	uint16_t          back_max_pkt_burst;
+	uint16_t           front_max_pkt_burst;
+	uint16_t           back_max_pkt_burst;
 
 	/* Number of times to attempt bring a KNI interface up or down. */
-	unsigned int      num_attempts_kni_link_set;
+	unsigned int       num_attempts_kni_link_set;
 
 	/* Maximum number of route update packets to serve at once. */
-	unsigned int      max_rt_update_pkts;
+	unsigned int       max_rt_update_pkts;
 
 	/*
 	 * Period between scans of the outstanding
 	 * resolution requests from KNIs.
 	 */
-	unsigned int      scan_interval_sec;
+	unsigned int       scan_interval_sec;
 
 	/* Parameters to setup the mailbox instance. */
-	unsigned int      mailbox_max_entries_exp;
-	unsigned int      mailbox_mem_cache_size;
-	unsigned int      mailbox_burst_size;
+	unsigned int       mailbox_max_entries_exp;
+	unsigned int       mailbox_mem_cache_size;
+	unsigned int       mailbox_burst_size;
 
 	/* Netlink port ID for communicating with routing daemon. */
-	uint32_t          nl_pid;
+	uint32_t           nl_pid;
 
 	/*
 	 * The fields below are for internal use.
@@ -79,44 +79,48 @@ struct cps_config {
 	 */
 
 	/* The maximum number of packets submitted to CPS mailbox. */
-	unsigned int      mailbox_max_pkt_burst;
+	unsigned int       mailbox_max_pkt_burst;
 
-	struct net_config *net;
-	struct lls_config *lls;
+	struct net_config  *net;
+	struct lls_config  *lls;
 
 	/* Kernel NIC interfaces for control plane messages */
-	struct rte_kni    *front_kni;
-	struct rte_kni    *back_kni;
+	struct rte_kni     *front_kni;
+	struct rte_kni     *back_kni;
 
 	/* Output interface IDs for the KNIs; used with routing daemons. */
-	unsigned int      front_kni_index;
-	unsigned int      back_kni_index;
+	unsigned int       front_kni_index;
+	unsigned int       back_kni_index;
 
 	/* Mailbox to hold requests from other blocks. */
-	struct mailbox    mailbox;
+	struct mailbox     mailbox;
 
 	/* Receive and transmit queues for both interfaces. */
-	uint16_t          rx_queue_front;
-	uint16_t          tx_queue_front;
-	uint16_t          rx_queue_back;
-	uint16_t          tx_queue_back;
+	uint16_t           rx_queue_front;
+	uint16_t           tx_queue_front;
+	uint16_t           rx_queue_back;
+	uint16_t           tx_queue_back;
 
 	/* Unanswered resolution requests from the KNIs. */
-	struct list_head  arp_requests;
-	struct list_head  nd_requests;
+	struct list_head   arp_requests;
+	struct list_head   nd_requests;
 
 	/* Timer to scan over outstanding resolution requests. */
-	struct rte_timer  scan_timer;
+	struct rte_timer   scan_timer;
 
 	/*
 	 * Netlink socket for receiving from the routing daemon.
 	 * Bound to @nl_pid so that userspace routing daemons
 	 * can be configured to update Gatekeeper.
 	 */
-	struct mnl_socket *rd_nl;
+	struct mnl_socket  *rd_nl;
 
-	struct gk_config  *gk;
-	struct gt_config  *gt;
+	struct gk_config   *gk;
+	struct gt_config   *gt;
+
+	unsigned int       total_pkt_burst;
+	/* The packet mbuf pool for the CPS block. */
+	struct rte_mempool *mp;
 };
 
 /* Information needed to submit IPv6 BGP packets to the CPS block. */

--- a/include/gatekeeper_ggu.h
+++ b/include/gatekeeper_ggu.h
@@ -28,28 +28,28 @@
 
 /* Configuration for the GK-GT Unit functional block. */
 struct ggu_config {
-	unsigned int      lcore_id;
+	unsigned int       lcore_id;
 
 	/* The UDP source and destination port numbers for GGU. */
-	uint16_t          ggu_src_port;
-	uint16_t          ggu_dst_port;
+	uint16_t           ggu_src_port;
+	uint16_t           ggu_dst_port;
 
 	/* The maximum number of packets to retrieve/transmit. */
-	uint16_t          max_pkt_burst;
+	uint16_t           max_pkt_burst;
 
 	/* Parameters to setup the mailbox instance. */
-	unsigned int      mailbox_max_entries_exp;
-	unsigned int      mailbox_mem_cache_size;
-	unsigned int      mailbox_burst_size;
+	unsigned int       mailbox_max_entries_exp;
+	unsigned int       mailbox_mem_cache_size;
+	unsigned int       mailbox_burst_size;
 
 	/* Log level for GK-GT Unit block. */
-	uint32_t          log_level;
+	uint32_t           log_level;
 	/* Dynamic logging type, assigned at runtime. */
-	int               log_type;
+	int                log_type;
 	/* Log ratelimit interval in ms for GK-GT Unit block. */
-	uint32_t          log_ratelimit_interval_ms;
+	uint32_t           log_ratelimit_interval_ms;
 	/* Log ratelimit burst size for GK-GT Unit block. */
-	uint32_t          log_ratelimit_burst;
+	uint32_t           log_ratelimit_burst;
 
 	/*
 	 * The fields below are for internal use.
@@ -57,15 +57,19 @@ struct ggu_config {
 	 */
 
 	/* The maximum number of packets submitted to GGU mailbox. */
-	uint16_t          mailbox_max_pkt_burst;
+	uint16_t           mailbox_max_pkt_burst;
 
 	/* RX queue on the back interface. */
-	uint16_t          rx_queue_back;
-	struct net_config *net;
-	struct gk_config  *gk;
+	uint16_t           rx_queue_back;
+	struct net_config  *net;
+	struct gk_config   *gk;
 
 	/* Mailbox to hold requests from other blocks. */
-	struct mailbox    mailbox;
+	struct mailbox     mailbox;
+
+	unsigned int       total_pkt_burst;
+	/* The packet mbuf pool for the GGU block. */
+	struct rte_mempool *mp;
 };
 
 /* Enumeration of policy decisions the GGU block can process. */

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -113,6 +113,10 @@ struct gk_instance {
 	struct token_bucket_ratelimit_state front_icmp_rs;
 	struct token_bucket_ratelimit_state back_icmp_rs;
 	unsigned int num_scan_del;
+	/*
+	 * The memory pool used for packet buffers in this instance.
+	 */
+	struct rte_mempool *mp;
 } __rte_cache_aligned;
 
 #define GK_MAX_BPF_FLOW_HANDLERS	(UINT8_MAX + 1)

--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -105,6 +105,9 @@ struct gt_instance {
 	unsigned int          num_ggu_pkts;
 
 	struct mailbox        mb;
+
+	/* The packet mbuf pool for the GT instance. */
+	struct rte_mempool    *mp;
 } __rte_cache_aligned;
 
 /* Configuration for the GT functional block. */

--- a/include/gatekeeper_launch.h
+++ b/include/gatekeeper_launch.h
@@ -74,13 +74,6 @@ int
 launch_at_stage3(const char *name, lcore_function_t *f, void *arg,
 	unsigned int lcore_id);
 
-/*
- * Get the number of lcores used except for blocks @filtered_blocks.
- * This function can be called any time before stage 3 begins.
- */
-int
-launch_count_lcores(const char *filtered_blocks[], unsigned int num_blocks);
-
 /* Drop the @n last entries of stage3. */
 void
 pop_n_at_stage3(int n);

--- a/include/gatekeeper_lls.h
+++ b/include/gatekeeper_lls.h
@@ -180,67 +180,71 @@ struct lls_cache {
 
 struct lls_config {
 	/* lcore that the LLS block runs on. */
-	unsigned int      lcore_id;
+	unsigned int       lcore_id;
 
 	/* The maximum number of packets to retrieve/transmit. */
-	uint16_t          front_max_pkt_burst;
-	uint16_t          back_max_pkt_burst;
+	uint16_t           front_max_pkt_burst;
+	uint16_t           back_max_pkt_burst;
 
 	/* The maximum number of ARP or ND packets submitted by GK or GT. */
-	unsigned int      mailbox_max_pkt_sub;
+	unsigned int       mailbox_max_pkt_sub;
 
 	/* Parameters to setup the mailbox instance. */
-	unsigned int      mailbox_max_entries_exp;
-	unsigned int      mailbox_mem_cache_size;
-	unsigned int      mailbox_burst_size;
+	unsigned int       mailbox_max_entries_exp;
+	unsigned int       mailbox_mem_cache_size;
+	unsigned int       mailbox_burst_size;
 
 	/* Number of records that a LLS cache can hold. */
-	unsigned int      max_num_cache_records;
+	unsigned int       max_num_cache_records;
 
 	/* Length of time (in seconds) to wait between scans of the cache. */
-	unsigned int      cache_scan_interval_sec;
+	unsigned int       cache_scan_interval_sec;
 
 	/* Log level for LLS block. */
-	uint32_t          log_level;
+	uint32_t           log_level;
 	/* Dynamic logging type, assigned at runtime. */
-	int               log_type;
+	int                log_type;
 	/* Log ratelimit interval in ms for LLS block. */
-	uint32_t          log_ratelimit_interval_ms;
+	uint32_t           log_ratelimit_interval_ms;
 	/* Log ratelimit burst size for LLS block. */
-	uint32_t          log_ratelimit_burst;
+	uint32_t           log_ratelimit_burst;
 
 	/* The rate and burst size of the icmp messages. */
-	uint32_t          front_icmp_msgs_per_sec;
-	uint32_t          front_icmp_msgs_burst;
-	uint32_t          back_icmp_msgs_per_sec;
-	uint32_t          back_icmp_msgs_burst;
+	uint32_t           front_icmp_msgs_per_sec;
+	uint32_t           front_icmp_msgs_burst;
+	uint32_t           back_icmp_msgs_per_sec;
+	uint32_t           back_icmp_msgs_burst;
 
 	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */
-	struct net_config *net;
+	struct net_config  *net;
 
 	/* Mailbox to hold requests from other blocks. */
-	struct mailbox    requests;
+	struct mailbox     requests;
 
 	/* Cache of entries that map IPv4 addresses to Ethernet addresses. */
-	struct lls_cache  arp_cache;
+	struct lls_cache   arp_cache;
 
 	/* Cache of entries that map IPv6 addresses to Ethernet addresses. */
-	struct lls_cache  nd_cache;
+	struct lls_cache   nd_cache;
 
 	/* Timer to scan over LLS cache(s). */
-	struct rte_timer  scan_timer;
+	struct rte_timer   scan_timer;
 
 	/* Timer to create new log files. */
-	struct rte_timer  log_timer;
+	struct rte_timer   log_timer;
 
 	/* Receive and transmit queues for both interfaces. */
-	uint16_t          rx_queue_front;
-	uint16_t          tx_queue_front;
-	uint16_t          rx_queue_back;
-	uint16_t          tx_queue_back;
+	uint16_t           rx_queue_front;
+	uint16_t           tx_queue_front;
+	uint16_t           rx_queue_back;
+	uint16_t           tx_queue_back;
+
+	unsigned int       total_pkt_burst;
+	/* The packet mbuf pool for the LLS block. */
+	struct rte_mempool *mp;
 
 	/* Data structures used to limit the rate of icmp messages. */
 	struct token_bucket_ratelimit_state front_icmp_rs;

--- a/lib/launch.c
+++ b/lib/launch.c
@@ -185,31 +185,6 @@ fail:
 	return -1;
 }
 
-int
-launch_count_lcores(const char *filtered_blocks[], unsigned int num_blocks)
-{
-	int num_lcores = 0;
-
-	struct stage3_entry *entry, *next;
-
-	list_for_each_entry_safe(entry, next, &launch_heads.stage3, list) {
-		unsigned int i;
-		bool filter = false;
-
-		for (i = 0; i < num_blocks; i++) {
-			if (strcmp(entry->name, filtered_blocks[i]) == 0) {
-				filter = true;
-				break;
-			}
-		}
-
-		if (!filter)
-			num_lcores++;
-	}
-
-	return num_lcores;
-}
-
 static inline void
 free_stage3_entry(struct stage3_entry *entry)
 {

--- a/lls/arp.c
+++ b/lls/arp.c
@@ -52,9 +52,7 @@ xmit_arp_req(struct gatekeeper_if *iface, const struct ipaddr *addr,
 	struct lls_config *lls_conf = get_lls_conf();
 	int ret;
 
-	struct rte_mempool *mp = lls_conf->net->gatekeeper_pktmbuf_pool[
-		rte_lcore_to_socket_id(lls_conf->lcore_id)];
-	created_pkt = rte_pktmbuf_alloc(mp);
+	created_pkt = rte_pktmbuf_alloc(lls_conf->mp);
 	if (created_pkt == NULL) {
 		LLS_LOG(ERR, "Could not alloc a packet for an ARP request\n");
 		return;

--- a/lls/nd.c
+++ b/lls/nd.c
@@ -138,9 +138,7 @@ xmit_nd_req(struct gatekeeper_if *iface, const struct ipaddr *addr,
 	struct nd_opt_lladdr *nd_opt;
 	size_t l2_len;
 
-	struct rte_mempool *mp = lls_conf->net->gatekeeper_pktmbuf_pool[
-		rte_lcore_to_socket_id(lls_conf->lcore_id)];
-	struct rte_mbuf *created_pkt = rte_pktmbuf_alloc(mp);
+	struct rte_mbuf *created_pkt = rte_pktmbuf_alloc(lls_conf->mp);
 	if (created_pkt == NULL) {
 		LLS_LOG(ERR,
 			"Could not alloc a packet for an ND Neighbor Solicitation\n");

--- a/sol/main.c
+++ b/sol/main.c
@@ -505,7 +505,7 @@ sol_stage1(void *arg)
 {
 	struct sol_config *sol_conf = arg;
 	int ret = get_queue_id(&sol_conf->net->back, QUEUE_TYPE_TX,
-		sol_conf->lcore_id);
+		sol_conf->lcore_id, NULL);
 	if (ret < 0) {
 		SOL_LOG(ERR, "Cannot assign a TX queue for the back interface for lcore %u\n",
 			sol_conf->lcore_id);


### PR DESCRIPTION
Below is the performance evaluation of the master branch:

| lcores | table size | GK Mpps rcvd (0%) | GK Mpps rcvd (50%) | GK Mpps rcvd (99%) | GK Mpps rcvd (mean) | cli Mpps sent (0%) | cli Mpps sent (50%) | cli Mpps sent (99%) | cli Mpps sent (mean) |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|
|  1  |  2^15  |       6.69        |        6.69        |        6.7        |        6.69         |       9.94        |        10.99        |        11.52        |         10.99         | 
|  1  |  2^20  |       6.25        |        6.34        |        6.38        |        6.33         |       9.89        |        10.53        |        11.21        |         10.53         | 
|  1  |  2^25  |       4.4        |        4.41        |        4.49        |        4.43         |       9.81        |        10.7        |        11.34        |         10.67         | 
|        |            |                   |                    |                    |                     |                    |                     |                     |                      |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|
|  2  |  2^15  |       10.08        |        10.52        |        10.67        |        10.45         |       9.78        |        10.6        |        11.24        |         10.55         | 
|  2  |  2^20  |       9.93        |        10.13        |        10.4        |        10.15         |       9.94        |        10.52        |        11.19        |         10.51         | 
|  2  |  2^25  |       7.65        |        7.84        |        9.25        |        8.15         |       9.42        |        10.22        |        11.04        |         10.2         | 
|        |            |                   |                    |                    |                     |                    |                     |                     |                      |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|
|  3  |  2^15  |       6.94        |        8.77        |        10.57        |        8.77         |       9.56        |        10.51        |        11.11        |         10.5         | 
|  3  |  2^20  |       5.06        |        6.56        |        8.92        |        6.78         |       9.98        |        10.52        |        10.83        |         10.5         | 
|  3  |  2^25  |       4.96        |        8.18        |        9.74        |        7.95         |       9.56        |        10.24        |        10.73        |         10.23        | 
|        |            |                   |                    |                    |                     |                    |                     |                     |                      |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|


Below is the performance evaluation after applying this patch:

| lcores | table size | GK Mpps rcvd (0%) | GK Mpps rcvd (50%) | GK Mpps rcvd (99%) | GK Mpps rcvd (mean) | cli Mpps sent (0%) | cli Mpps sent (50%) | cli Mpps sent (99%) | cli Mpps sent (mean) |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|
|  1  |  2^15  |       6.86        |        6.92        |        7.06        |        6.94         |       9.73        |        10.61        |        11.38        |         10.63         | 
|  1  |  2^20  |       6.38        |        6.48        |        6.7        |        6.48         |       9.77        |        10.7        |        11.5        |         10.72         | 
|  1  |  2^25  |       3.29        |        4.84        |        5.4        |        4.72         |       9.48        |        10.6        |        11.26        |         10.58         | 
|        |            |                   |                    |                    |                     |                    |                     |                     |                      |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|
|  2  |  2^15  |       10.41        |        10.71        |        10.79        |        10.67         |       10.02        |        10.77        |        11.42        |         10.76         | 
|  2  |  2^20  |       5.19        |        10.2        |        10.5        |        9.7         |       9.87        |        10.55        |        11.33        |         10.55         | 
|  2  |  2^25  |       7.22        |        9.15        |        10.23        |        9.14         |       9.67        |        10.58        |        11.35        |         10.52         | 
|        |            |                   |                    |                    |                     |                    |                     |                     |                      |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|
|  3  |  2^15  |       6.82        |        10.43        |        10.76        |        9.59         |       9.66        |        10.64        |        11.34        |         10.61         | 
|  3  |  2^20  |       8.57        |        9.48        |        10.24        |        9.45         |       9.73        |        10.42        |        11.2        |         10.41         | 
|  3  |  2^25  |       3.19        |        8.04        |        10.33        |        7.25         |       9.13        |        10.4        |        11.29        |         10.3         | 
|        |            |                   |                    |                    |                     |                    |                     |                     |                      |
|--------|------------|-------------------|--------------------|--------------------|---------------------|--------------------|---------------------|---------------------|----------------------|