### PR TITLE
Add flow entry expiration for requests

### DIFF
--- a/gk/bpf.c
+++ b/gk/bpf.c
@@ -498,7 +498,7 @@ gk_bpf_decide_pkt(struct gk_config *gk_conf, uint8_t program_index,
 		.ready_to_tx = false,
 		.ctx = {
 			.now = now,
-			.expire_at = fe->u.bpf.expire_at,
+			.expire_at = fe->expire_at,
 		},
 	};
 	const struct gk_bpf_flow_handler *handler =

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -282,6 +282,11 @@ struct flow_entry {
 	 */
 	struct gk_fib *grantor_fib;
 
+	/*
+	 * The time at which this flow entry expires (in cycles).
+	 */
+	uint64_t expire_at;
+
 	union {
 		struct {
 			/* The time the last packet of the entry was seen. */
@@ -301,8 +306,6 @@ struct flow_entry {
 		} request;
 
 		struct {
-			/* When the granted capability expires. */
-			uint64_t cap_expire_at;
 			/* When @budget_byte is reset. */
 			uint64_t budget_renew_at;
 			/*
@@ -327,16 +330,6 @@ struct flow_entry {
 		} granted;
 
 		struct {
-			/*
-			 * When the punishment (i.e. the declined capability)
-			 * expires.
-			 */
-			uint64_t expire_at;
-		} declined;
-
-		struct {
-			/* When this state is no longer valid. */
-			uint64_t expire_at;
 			/*
 			 * Memory to be passed to the BPF proram each time
 			 * it is executed.


### PR DESCRIPTION
I anticipate that the implementation of `calc_request_expire_at()` will change, perhaps to something that calculates the number of cycles that are equivalent to three priorities above the current priority (if I understood the instructions correctly). But I'll wait for further directions there. 