### PR TITLE
Remove UDP checksum hardware requirement

### DIFF
--- a/bpf/grantedv2.h
+++ b/bpf/grantedv2.h
@@ -133,7 +133,7 @@ grantedv2_pkt_begin(const struct gk_bpf_pkt_ctx *ctx,
 		int64_t epochs = cycles / cycles_per_sec;
 
 		state->budget_renew_at = ctx->now + cycles_per_sec -
-		       (cycles % cycles_per_sec);
+			(cycles % cycles_per_sec);
 		state->budget1_byte += max_budget1 * (epochs + 1);
 		if (state->budget1_byte > max_budget1)
 			state->budget1_byte = max_budget1;

--- a/bpf/web.c
+++ b/bpf/web.c
@@ -85,7 +85,7 @@ web_pkt(struct gk_bpf_pkt_ctx *ctx)
 		return GK_BPF_PKT_RET_DECLINE;
 	}
 	tcp_hdr = rte_pktmbuf_mtod_offset(pkt, struct tcphdr *,
-	       pkt->l2_len + pkt->l3_len);
+		pkt->l2_len + pkt->l3_len);
 
 	/*
 	 * For information on active and passive modes of FTP,

--- a/config/dynamic.c
+++ b/config/dynamic.c
@@ -559,7 +559,7 @@ run_dynamic_config(struct net_config *net_conf,
 	}
 
 	/* Init the server socket. */
-    	dy_conf->sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	dy_conf->sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (dy_conf->sock_fd < 0) {
 		DYC_LOG(ERR, "Failed to initialize the server socket - (%s)\n",
 			strerror(errno));
@@ -568,8 +568,8 @@ run_dynamic_config(struct net_config *net_conf,
 	}
 
 	/* Name the socket. */
-    	memset(&server_addr, 0, sizeof(server_addr));
-    	server_addr.sun_family = AF_UNIX;
+	memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sun_family = AF_UNIX;
 
 	if (sizeof(server_addr.sun_path) <= strlen(dy_conf->server_path)) {
 		DYC_LOG(ERR,
@@ -579,9 +579,9 @@ run_dynamic_config(struct net_config *net_conf,
 		goto free_sock;
 	}
 
-    	strcpy(server_addr.sun_path, dy_conf->server_path);
+	strcpy(server_addr.sun_path, dy_conf->server_path);
 
-    	ret = bind(dy_conf->sock_fd,
+	ret = bind(dy_conf->sock_fd,
 		(struct sockaddr *)&server_addr, sizeof(server_addr));
 	if (ret < 0) {
 		DYC_LOG(ERR, "Failed to bind the server socket - (%s)\n",
@@ -594,7 +594,7 @@ run_dynamic_config(struct net_config *net_conf,
 	 * The Dynamic config component listens to a Unix socket
 	 * for request from the local host.
 	 */
-    	ret = listen(dy_conf->sock_fd, 10);
+	ret = listen(dy_conf->sock_fd, 10);
 	if (ret < 0) {
 		DYC_LOG(ERR, "Failed to listen on the server socket - (%s)\n",
 			strerror(errno));

--- a/cps/main.c
+++ b/cps/main.c
@@ -83,9 +83,9 @@ cleanup_cps(void)
 	destroy_mailbox(&cps_conf.mailbox);
 	rm_kni();
 	if (cps_conf.nd_mp)
-	    rte_mempool_free(cps_conf.nd_mp);
+		rte_mempool_free(cps_conf.nd_mp);
 	if (cps_conf.arp_mp)
-	    rte_mempool_free(cps_conf.arp_mp);
+		rte_mempool_free(cps_conf.arp_mp);
 	return 0;
 }
 

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -380,7 +380,7 @@ custom_ipv4_hash_func(const void *key,
 	__attribute__((unused)) uint32_t length,
 	__attribute__((unused)) uint32_t initval)
 {
-        return ntohl(*(const uint32_t *)key);
+	return ntohl(*(const uint32_t *)key);
 }
 
 int

--- a/gk/main.c
+++ b/gk/main.c
@@ -57,9 +57,9 @@ static inline uint8_t
 integer_log_base_2(uint64_t delta_time)
 {
 #if __WORDSIZE == 64
-    return (8 * sizeof(uint64_t) - 1) - __builtin_clzl(delta_time);
+	return (8 * sizeof(uint64_t) - 1) - __builtin_clzl(delta_time);
 #else
-    return (8 * sizeof(uint64_t) - 1) - __builtin_clzll(delta_time);
+	return (8 * sizeof(uint64_t) - 1) - __builtin_clzll(delta_time);
 #endif
 }
 
@@ -614,7 +614,7 @@ setup_gk_instance(unsigned int lcore_id, struct gk_config *gk_conf)
 	ret = init_mailbox("gk", gk_conf->mailbox_max_entries_exp,
 		sizeof(struct gk_cmd_entry), gk_conf->mailbox_mem_cache_size,
 		lcore_id, &instance->mb);
-    	if (ret < 0)
+	if (ret < 0)
 		goto flow_entry;
 
 	tb_ratelimit_state_init(&instance->front_icmp_rs,
@@ -628,8 +628,8 @@ setup_gk_instance(unsigned int lcore_id, struct gk_config *gk_conf)
 	goto out;
 
 flow_entry:
-    	rte_free(instance->ip_flow_entry_table);
-    	instance->ip_flow_entry_table = NULL;
+	rte_free(instance->ip_flow_entry_table);
+	instance->ip_flow_entry_table = NULL;
 flow_hash:
 	rte_hash_free(instance->ip_flow_hash_table);
 	instance->ip_flow_hash_table = NULL;
@@ -1204,7 +1204,8 @@ static void
 send_request_to_grantor(struct ipacket *packet, uint32_t flow_hash_val,
 		struct gk_fib *fib, struct rte_mbuf **req_bufs,
 		uint16_t *num_reqs, struct gk_instance *instance,
-		struct gk_config *gk_conf) {
+		struct gk_config *gk_conf)
+{
 	int ret;
 	struct flow_entry temp_fe;
 
@@ -1302,7 +1303,8 @@ lookup_fe_from_lpm(struct ipacket *packet, uint32_t ip_flow_hash_val,
 		uint16_t *num_pkts, struct rte_mbuf **icmp_bufs,
 		struct rte_mbuf **req_bufs, uint16_t *num_reqs,
 		struct gatekeeper_if *front, struct gatekeeper_if *back,
-		struct gk_instance *instance, struct gk_config *gk_conf) {
+		struct gk_instance *instance, struct gk_config *gk_conf)
+{
 	struct rte_mbuf *pkt = packet->pkt;
 	struct ether_cache *eth_cache;
 	struct gk_measurement_metrics *stats = &instance->traffic_stats;
@@ -1606,15 +1608,15 @@ process_pkts_front(uint16_t port_front, uint16_t rx_queue_front,
 
 	stats->tot_pkts_num += num_rx;
 
-       /*
-        * This prefetch is enough to load Ethernet header (14 bytes),
-        * optional Ethernet VLAN header (8 bytes), and either
-        * an IPv4 header without options (20 bytes), or
-        * an IPv6 header without options (40 bytes).
-        * IPv4: 14 + 8 + 20 = 42
-        * IPv6: 14 + 8 + 40 = 62
-        */
-       for (i = 0; i < PREFETCH_OFFSET && i < num_rx; i++)
+	/*
+	 * This prefetch is enough to load Ethernet header (14 bytes),
+	 * optional Ethernet VLAN header (8 bytes), and either
+	 * an IPv4 header without options (20 bytes), or
+	 * an IPv6 header without options (40 bytes).
+	 * IPv4: 14 + 8 + 20 = 42
+	 * IPv6: 14 + 8 + 40 = 62
+	 */
+	for (i = 0; i < PREFETCH_OFFSET && i < num_rx; i++)
 		rte_prefetch0(rte_pktmbuf_mtod_offset(rx_bufs[i], void *, 0));
 
 	/* Extract packet and flow information. */
@@ -1752,7 +1754,8 @@ process_fib(struct ipacket *packet, struct gk_fib *fib,
 		struct acl_search *acl4, struct acl_search *acl6,
 		uint16_t *num_pkts, struct rte_mbuf **icmp_bufs,
 		struct gatekeeper_if *front, struct gatekeeper_if *back,
-		struct gk_instance *instance) {
+		struct gk_instance *instance)
+{
 	struct rte_mbuf *pkt = packet->pkt;
 	struct ether_cache *eth_cache;
 
@@ -1894,16 +1897,16 @@ process_pkts_back(uint16_t port_back, uint16_t rx_queue_back,
 	if (unlikely(num_rx == 0))
 		return;
 
-       /*
-        * This prefetch is enough to load Ethernet header (14 bytes),
-        * optional Ethernet VLAN header (8 bytes), and either
-        * an IPv4 header without options (20 bytes), or
-        * an IPv6 header without options (40 bytes).
-        * IPv4: 14 + 8 + 20 = 42
-        * IPv6: 14 + 8 + 40 = 62
-        */
-       for (i = 0; i < num_rx; i++)
-               rte_prefetch0(rte_pktmbuf_mtod_offset(rx_bufs[i], void *, 0));
+	/*
+	 * This prefetch is enough to load Ethernet header (14 bytes),
+	 * optional Ethernet VLAN header (8 bytes), and either
+	 * an IPv4 header without options (20 bytes), or
+	 * an IPv6 header without options (40 bytes).
+	 * IPv4: 14 + 8 + 20 = 42
+	 * IPv6: 14 + 8 + 40 = 62
+	 */
+	for (i = 0; i < num_rx; i++)
+		rte_prefetch0(rte_pktmbuf_mtod_offset(rx_bufs[i], void *, 0));
 
 	for (i = 0; i < num_rx; i++) {
 		struct ipacket *packet = &pkt_arr[num_ip_flows];
@@ -2147,10 +2150,10 @@ process_cmds_from_mailbox(
 	struct gk_add_policy *policies[mailbox_burst_size];
 
 	/* Load a set of commands from its mailbox ring. */
-        num_cmd = mb_dequeue_burst(&instance->mb,
+	num_cmd = mb_dequeue_burst(&instance->mb,
 		(void **)gk_cmds, mailbox_burst_size);
 
-        for (i = 0; i < num_cmd; i++)
+	for (i = 0; i < num_cmd; i++)
 		process_gk_cmd(gk_cmds[i], policies, &num_policies, instance);
 
 	if (num_policies > 0)

--- a/gt/main.c
+++ b/gt/main.c
@@ -122,11 +122,11 @@ gt_parse_incoming_pkt(struct rte_mbuf *pkt, struct gt_packet_headers *info)
 		outer_ipv6_hdr = (struct rte_ipv6_hdr *)info->outer_l3_hdr;
 		outer_ipv6_hdr_len = ipv6_skip_exthdr(outer_ipv6_hdr,
 			pkt->data_len - parsed_len, &encapsulated_proto);
-                if (outer_ipv6_hdr_len < 0) {
-                        GT_LOG(ERR,
-                                "Failed to parse the packet's outer IPv6 extension headers\n");
+		if (outer_ipv6_hdr_len < 0) {
+			GT_LOG(ERR,
+				"Failed to parse the packet's outer IPv6 extension headers\n");
 			return -1;
-                }
+		}
 
 		if (encapsulated_proto != IPPROTO_IPV6)
 			return -1;
@@ -177,11 +177,11 @@ gt_parse_incoming_pkt(struct rte_mbuf *pkt, struct gt_packet_headers *info)
 		inner_ipv6_hdr = (struct rte_ipv6_hdr *)info->inner_l3_hdr;
 		inner_ipv6_len = ipv6_skip_exthdr(inner_ipv6_hdr,
 			pkt->data_len - parsed_len, &info->l4_proto);
-                if (inner_ipv6_len < 0) {
-                        GT_LOG(ERR,
-                                "Failed to parse the packet's inner IPv6 extension headers\n");
+		if (inner_ipv6_len < 0) {
+			GT_LOG(ERR,
+				"Failed to parse the packet's inner IPv6 extension headers\n");
 			return -1;
-                }
+		}
 
 		info->inner_ip_ver = RTE_ETHER_TYPE_IPV6;
 		info->l4_hdr = (uint8_t *)inner_ipv6_hdr + inner_ipv6_len;
@@ -1101,7 +1101,7 @@ find_cookie_len_4by(struct gk_bpf_cookie *cookie, unsigned int cookie_len)
 
 	n = cookie_len / 4;
 	if (unlikely(cookie_len % 4 != 0))
-	       n++;
+		n++;
 
 	for (i = n - 1; i >= 0; i--)
 		if (p[i] != 0)

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -187,6 +187,20 @@ struct gatekeeper_if {
 	uint16_t        num_tx_desc;
 
 	/*
+	 * Whether IPv4 UDP checksums should be enabled in hardware.
+	 * Technically, this only affects the front interface, since
+	 * only the GT block (on Grantor servers) uses UDP checksums.
+	 */
+	bool            ipv4_hw_udp_cksum;
+
+	/*
+	 * Whether IPv6 UDP checksums should be enabled in hardware.
+	 * Technically, this only affects the front interface, since
+	 * only the GT block (on Grantor servers) uses UDP checksums.
+	 */
+	bool            ipv6_hw_udp_cksum;
+
+	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */

--- a/lib/flow.c
+++ b/lib/flow.c
@@ -80,7 +80,7 @@ gk_softrss_be(const uint32_t *input_tuple, uint32_t input_len,
 uint32_t
 rss_ip_flow_hf(const void *data,
 	__attribute__((unused)) uint32_t data_len,
-        __attribute__((unused)) uint32_t init_val)
+	__attribute__((unused)) uint32_t init_val)
 {
 	const struct ip_flow *flow = (const struct ip_flow *)data;
 

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -41,7 +41,7 @@ init_mailbox(const char *tag, int mailbox_max_entries_exp,
 	mb->ring = (struct rte_ring *)rte_ring_create(
 		ring_name, 1 << mailbox_max_entries_exp,
 		socket_id, RING_F_SC_DEQ);
-    	if (mb->ring == NULL) {
+	if (mb->ring == NULL) {
 		G_LOG(ERR,
 			"mailbox: can't create ring %s (len = %d) at lcore %u\n",
 			ring_name, ret, lcore_id);
@@ -112,7 +112,7 @@ destroy_mailbox(struct mailbox *mb)
 {
 	if (mb) {
 		if (mb->ring)
-    			rte_ring_free(mb->ring);
+			rte_ring_free(mb->ring);
 		if (mb->pool)
 			rte_mempool_free(mb->pool);
 	}

--- a/lib/net.c
+++ b/lib/net.c
@@ -487,13 +487,13 @@ get_ip_type(const char *ip_addr)
 	hint.ai_flags = AI_NUMERICHOST;
 
 	ret = getaddrinfo(ip_addr, NULL, &hint, &res);
-    	if (ret) {
+	if (ret) {
 		G_LOG(ERR, "net: invalid ip address %s; %s\n",
 			ip_addr, gai_strerror(ret));
 		return AF_UNSPEC;
-    	}
+	}
 
-    	if (res->ai_family != AF_INET && res->ai_family != AF_INET6)
+	if (res->ai_family != AF_INET && res->ai_family != AF_INET6)
 		G_LOG(ERR, "net: %s is an is unknown address format %d\n",
 			ip_addr, res->ai_family);
 

--- a/lib/net.c
+++ b/lib/net.c
@@ -880,11 +880,12 @@ check_port_cksum(struct gatekeeper_if *iface, unsigned int port_idx,
 	if ((port_conf->txmode.offloads & DEV_TX_OFFLOAD_UDP_CKSUM) &&
 			!(dev_info->tx_offload_capa &
 			DEV_TX_OFFLOAD_UDP_CKSUM)) {
-		G_LOG(NOTICE, "net: port %hu (%s) on the %s interface doesn't support offloading UDP checksumming\n",
+		G_LOG(NOTICE, "net: port %hu (%s) on the %s interface doesn't support offloading UDP checksumming; will use software UDP checksums\n",
 			iface->ports[port_idx], iface->pci_addrs[port_idx],
 			iface->name);
 		port_conf->txmode.offloads &= ~DEV_TX_OFFLOAD_UDP_CKSUM;
-		return -1;
+		iface->ipv4_hw_udp_cksum = false;
+		iface->ipv6_hw_udp_cksum = false;
 	}
 
 	return 0;
@@ -943,11 +944,13 @@ check_port_offloads(struct gatekeeper_if *iface,
 	 * If IPv4 is supported, both Grantor and Gatekeeper
 	 * need to support IPv4 checksumming in hardware.
 	 *
-	 * Grantor needs to support UDP checksumming.
+	 * Grantor uses UDP checksumming if available. Assume
+	 * UDP checksumming is supported until shown otherwise.
 	 */
 	if (ipv4_if_configured(iface))
 		port_conf->txmode.offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
-	if (!config.back_iface_enabled)
+	if (!config.back_iface_enabled &&
+			(iface->ipv4_hw_udp_cksum || iface->ipv6_hw_udp_cksum))
 		port_conf->txmode.offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
 
 	for (i = 0; i < iface->num_ports; i++) {

--- a/lls/main.c
+++ b/lls/main.c
@@ -214,7 +214,7 @@ submit_arp(struct rte_mbuf **pkts, unsigned int num_pkts,
 }
 
 #define ND_REQ_SIZE(num_pkts) (offsetof(struct lls_request, end_of_header) + \
-        sizeof(struct lls_nd_req) + sizeof(struct rte_mbuf *) * num_pkts)
+	sizeof(struct lls_nd_req) + sizeof(struct rte_mbuf *) * num_pkts)
 
 static int
 submit_nd_neigh(struct rte_mbuf **pkts, unsigned int num_pkts,
@@ -803,8 +803,9 @@ lls_proc(void *arg)
 		if (net_conf->back_iface_enabled &&
 				hw_filter_eth_available(back)) {
 			num_tx = process_pkts(lls_conf, back,
-			    lls_conf->rx_queue_back, lls_conf->tx_queue_back,
-			    lls_conf->back_max_pkt_burst);
+				lls_conf->rx_queue_back,
+				lls_conf->tx_queue_back,
+				lls_conf->back_max_pkt_burst);
 			if ((num_tx > 0) && lacp_enabled(net_conf, back)) {
 				if (lacp_timer_reset(lls_conf, back) < 0)
 					LLS_LOG(NOTICE, "Can't reset back LACP timer to skip cycle\n");

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -264,6 +264,8 @@ struct gatekeeper_if {
 	uint8_t  ipv6_default_hop_limits;
 	uint16_t num_rx_desc;
 	uint16_t num_tx_desc;
+	bool     ipv4_hw_udp_cksum;
+	bool     ipv6_hw_udp_cksum;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -15,6 +15,8 @@ return function (gatekeeper_server)
 	local front_vlan_tag = 0x123
 	local front_vlan_insert = true
 	local front_mtu = 1500
+	local front_ipv4_hw_udp_cksum = true
+	local front_ipv6_hw_udp_cksum = true
 
 	local back_ports = {"enp133s0f1"}
 	local back_ips  = {"10.0.2.1/24", "2001:db8:2::1/48"}
@@ -22,6 +24,8 @@ return function (gatekeeper_server)
 	local back_vlan_tag = 0x456
 	local back_vlan_insert = true
 	local back_mtu = 2048
+	local back_ipv4_hw_udp_cksum = true
+	local back_ipv6_hw_udp_cksum = true
 
 	-- XXX #155 These parameters should only be changed for performance reasons.
 	local front_arp_cache_timeout_sec = 7200 -- (2 hours)
@@ -66,6 +70,8 @@ return function (gatekeeper_server)
 	front_iface.ipv6_default_hop_limits = front_ipv6_default_hop_limits
 	front_iface.num_rx_desc = front_num_rx_desc
 	front_iface.num_tx_desc = front_num_tx_desc
+	front_iface.ipv4_hw_udp_cksum = front_ipv4_hw_udp_cksum
+	front_iface.ipv6_hw_udp_cksum = front_ipv6_hw_udp_cksum
 	local ret = staticlib.init_iface(front_iface, "front",
 		front_ports, front_ips, front_vlan_tag)
 	if ret < 0 then
@@ -84,6 +90,8 @@ return function (gatekeeper_server)
 			back_ipv6_default_hop_limits
 		back_iface.num_rx_desc = back_num_rx_desc
 		back_iface.num_tx_desc = back_num_tx_desc
+		back_iface.ipv4_hw_udp_cksum = back_ipv4_hw_udp_cksum
+		back_iface.ipv6_hw_udp_cksum = back_ipv6_hw_udp_cksum
 		ret = staticlib.init_iface(back_iface, "back",
 			back_ports, back_ips, back_vlan_tag)
 		if ret < 0 then


### PR DESCRIPTION
Grantor blocks currently require hardware support for UDP checksumming. This patch removes that requirement. See the documentation here:

https://github.com/AltraMayor/gatekeeper/wiki/Network#UDP_Checksum_Offloading