### PR TITLE
gt: fix luaL_error() output

### DIFF
--- a/gt/lua_lpm.c
+++ b/gt/lua_lpm.c
@@ -142,7 +142,7 @@ l_lpm_add(lua_State *l)
 
 	ret = rte_lpm_add(lpm, ntohl(ip), depth, label);
 	if (ret < 0) {
-		luaL_error(l, "lpm: failed to add network policy [ip: %u, depth: %%hhu, label: %u] to the lpm table at %s",
+		luaL_error(l, "lpm: failed to add network policy [ip: %d, depth: %d, label: %d] to the lpm table at %s",
 			ip, depth, label, __func__);
 	}
 
@@ -212,7 +212,7 @@ l_ip_mask_addr(lua_State *l)
 	/* Second argument must be a Lua number. */
 	uint8_t depth = luaL_checknumber(l, 2);
 	if ((depth == 0) || (depth > RTE_LPM_MAX_DEPTH))
-		luaL_error(l, "Expected a depth value between 1 and 32, however it is %hhu",
+		luaL_error(l, "Expected a depth value between 1 and 32, however it is %d",
 			depth);
 
 	if (lua_gettop(l) != 2)
@@ -408,7 +408,7 @@ l_ip6_mask_addr(lua_State *l)
 	/* Second argument must be a Lua number. */
 	depth = luaL_checknumber(l, 2);
 	if ((depth == 0) || (depth > RTE_LPM6_MAX_DEPTH))
-		luaL_error(l, "Expected a depth value between 1 and 128, however it is %hhu",
+		luaL_error(l, "Expected a depth value between 1 and 128, however it is %d",
 			depth);
 
 	if (lua_gettop(l) != 2)

--- a/gt/main.c
+++ b/gt/main.c
@@ -2178,7 +2178,7 @@ l_update_gt_lua_states(lua_State *l)
 		lua_State *lua_state = alloc_and_setup_lua_state(gt_conf,
 			lcore_id);
 		if (lua_state == NULL) {
-			luaL_error(l, "gt: failed to allocate new lua state to GT block %u at lcore %u\n",
+			luaL_error(l, "gt: failed to allocate new lua state to GT block %d at lcore %d\n",
 				i, lcore_id);
 
 			continue;
@@ -2188,7 +2188,7 @@ l_update_gt_lua_states(lua_State *l)
 		if (entry == NULL) {
 			lua_close(lua_state);
 
-			luaL_error(l, "gt: failed to send new lua state to GT block %u at lcore %u\n",
+			luaL_error(l, "gt: failed to send new lua state to GT block %d at lcore %d\n",
 				i, lcore_id);
 
 			continue;
@@ -2201,7 +2201,7 @@ l_update_gt_lua_states(lua_State *l)
 		if (ret != 0) {
 			lua_close(lua_state);
 
-			luaL_error(l, "gt: failed to send new lua state to GT block %u at lcore %u\n",
+			luaL_error(l, "gt: failed to send new lua state to GT block %d at lcore %d\n",
 				i, lcore_id);
 		}
 	}
@@ -2246,7 +2246,7 @@ l_update_gt_lua_states_incrementally(lua_State *l)
 		char *lua_bytecode_buff = rte_malloc_socket("lua_bytecode",
 			len, 0, rte_lcore_to_socket_id(lcore_id));
 		if (lua_bytecode_buff == NULL) {
-			luaL_error(l, "gt: failed to send new lua update chunk bytecode to GT block %u at lcore %u due to failure of allocating memory\n",
+			luaL_error(l, "gt: failed to send new lua update chunk bytecode to GT block %d at lcore %d due to failure of allocating memory\n",
 				i, lcore_id);
 			continue;
 		}
@@ -2255,7 +2255,7 @@ l_update_gt_lua_states_incrementally(lua_State *l)
 		if (entry == NULL) {
 			rte_free(lua_bytecode_buff);
 
-			luaL_error(l, "gt: failed to send new lua update chunk bytecode to GT block %u at lcore %u\n",
+			luaL_error(l, "gt: failed to send new lua update chunk bytecode to GT block %d at lcore %d\n",
 				i, lcore_id);
 			continue;
 		}
@@ -2269,7 +2269,7 @@ l_update_gt_lua_states_incrementally(lua_State *l)
 		if (ret != 0) {
 			rte_free(lua_bytecode_buff);
 
-			luaL_error(l, "gt: failed to send new lua update chunk to GT block %u at lcore %u\n",
+			luaL_error(l, "gt: failed to send new lua update chunk to GT block %d at lcore %d\n",
 				i, lcore_id);
 		}
 	}


### PR DESCRIPTION
The luaL_error() function calls lj_str_pushvf() function to format
the output string. However, lj_str_pushvf() only handles %s, %c, %d,
%f and %p formats.

This patch closes #410.