### PR TITLE
lua: improve IPv6 address handling

### DIFF
--- a/gt/lua_lpm.c
+++ b/gt/lua_lpm.c
@@ -51,6 +51,7 @@ l_str_to_prefix(lua_State *l)
 }
 
 #define CTYPE_STRUCT_IN6_ADDR_REF "struct in6_addr &"
+#define CTYPE_STRUCT_IN6_ADDR "struct in6_addr"
 
 static int
 l_str_to_prefix6(lua_State *l)
@@ -72,7 +73,7 @@ l_str_to_prefix6(lua_State *l)
 		luaL_error(l, "gk: failed to parse an IPv6 prefix");
 
 	correct_ctypeid_in6_addr = luaL_get_ctypeid(l,
-		CTYPE_STRUCT_IN6_ADDR_REF);
+		CTYPE_STRUCT_IN6_ADDR);
 	cdata = luaL_pushcdata(l, correct_ctypeid_in6_addr,
 		sizeof(struct in6_addr));
 	*cdata = ip_addr.ip.v6;

--- a/lua/gatekeeper/policylib.lua
+++ b/lua/gatekeeper/policylib.lua
@@ -283,3 +283,17 @@ function decision_web(policy, tx_rate_kib_sec, cap_expire_sec,
 		policy, tx_rate_kib_sec, tx_rate_kib_sec * 0.05, -- 5%
 		cap_expire_sec, next_renewal_ms, renewal_step_ms, false)
 end
+
+-- There is no -> operator in Lua. The . operator works
+-- equivalently for accessing members of a struct AND
+-- accessing members of a struct through a reference.
+-- Therefore, the arguments to this function can be of type
+-- struct in6_addr or struct in6_addr &.
+function ipv6_addrs_equal(addr1, addr2)
+	for i=0,15 do
+		if addr1.s6_addr[i] ~= addr2.s6_addr[i] then
+			return false
+		end
+	end
+	return true
+end


### PR DESCRIPTION
This is a draft pull request to review this option for fixing this issue. My main concerns are that (1) there's probably a more elegant solution and (2) I don't have a strong understanding or justification for why we're using `struct in6_addr &` as opposed to `struct in6_addr` or `struct in6_addr *`.

Text of commit included below:

The use of references in str_to_prefix6() in Lua is good enough
for getting an IPv6 address struct from C and passing it to
the lpm6_add() function, but they are not sufficient for keeping
those IPv6 addresses in memory to later refer to. Therefore,
when we need to inspect the bytes of the result of str_to_prefix6(),
we need an actual struct in6_addr. This patch expands the return
value of str_to_prefix6() to also return the actual struct in6_addr.

An example of this new usage is shown with the function
ipv6_addrs_equal(). One address is a reference taken from a chunk
of memory allocated by C, and one address is a struct in6_addr
created by the result of str_to_prefix6().

This allows str_to_prefix6() to be used when we need the actual
bytes of the result and to be used when we need a reference to
the result.