### PR TITLE
lpm: add context to LPM lookup errors

### DIFF
--- a/cps/kni.c
+++ b/cps/kni.c
@@ -466,8 +466,14 @@ new_route(struct route_update *update, const struct cps_config *cps_conf)
 		if (update->rt_type != RTN_BLACKHOLE) {
 			ret = lpm_lookup_ipv4(ltbl->lpm,
 				update->gw.v4.s_addr);
-			if (ret < 0)
+			if (ret < 0) {
+				if (ret == -ENOENT) {
+					CPS_LOG(WARNING,
+						"%s: IPv4 route sent by routing daemon has no entry in LPM table",
+						__func__);
+				}
 				return ret;
+			}
 			gw_fib = &ltbl->fib_tbl[ret];
 		}
 
@@ -483,8 +489,14 @@ new_route(struct route_update *update, const struct cps_config *cps_conf)
 
 		if (update->rt_type != RTN_BLACKHOLE) {
 			ret = lpm_lookup_ipv6(ltbl->lpm6, &update->gw.v6);
-			if (ret < 0)
+			if (ret < 0) {
+				if (ret == -ENOENT) {
+					CPS_LOG(WARNING,
+						"%s: IPv6 route sent by routing daemon has no entry in LPM table",
+						__func__);
+				}
 				return ret;
+			}
 			gw_fib = &ltbl->fib_tbl6[ret];
 		}
 

--- a/include/gatekeeper_log_ratelimit.h
+++ b/include/gatekeeper_log_ratelimit.h
@@ -19,7 +19,24 @@
 #ifndef _GATEKEEPER_LOG_RATELIMIT_H_
 #define _GATEKEEPER_LOG_RATELIMIT_H_
 
+#include <stdbool.h>
 #include <stdint.h>
+
+/*
+ * Check whether a log entry will be permitted, according to the level
+ * of the log entry and the configured level of the system's log.
+ * Note that even when this test passes, log entries may not occur
+ * due to the rate limiting system.
+ */
+static inline bool
+check_log_allowed(uint32_t level, uint32_t logtype)
+{
+	int sys_level = rte_log_get_level(logtype);
+	if (unlikely(sys_level < 0))
+		false;
+
+	return level <= (typeof(level))sys_level;
+}
 
  /*
   * @lcore_id: initialize the log_ratelimit_state data for @lcore_id.

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -41,6 +41,9 @@ extern int gatekeeper_logtype;
 	rte_log_ratelimit(RTE_LOG_ ## level,	\
 	gatekeeper_logtype, "GATEKEEPER: " __VA_ARGS__)
 
+#define G_LOG_CHECK(level)	\
+	check_log_allowed(RTE_LOG_ ## level, gatekeeper_logtype)
+
 extern volatile int exiting;
 
 extern uint64_t cycles_per_sec;


### PR DESCRIPTION
Note that adding more context sometimes requires the caller of the caller (grandparent caller) of the lookup function to issue the log message, since that's the place where the context makes the most sense.

There is one place -- adding a valid FIB entry -- where this context is needed to clarify that the log message is for a validity check and is not an error. Before this patch, after successfully adding an entry, the log would look like:

```
GATEKEEPER: lpm: IPv4 lookup miss
GATEKEEPER: lpm: IPv4 lookup miss
```

Now it looks like:

```
GATEKEEPER: lpm: IPv4 lookup miss for 172.31.3.0
GATEKEEPER GK: Prefix lookup did not find existing neighbor FIB on front interface, as expected
GATEKEEPER: lpm: IPv4 lookup miss for 172.31.3.0
GATEKEEPER GK: Prefix lookup did not find existing neighbor FIB on back interface, as expected
```