### PR TITLE
Update Gatekeeper Debian package to include gkctl scripts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gatekeeper (1.0.0~rc2-0) bionic; urgency=medium
+
+  * Rebuild for 1.0.0-rc2
+
+ -- Andre Nathan <andre@digirati.com.br>  Thu, 20 Aug 2020 10:03:55 -0300
+
 gatekeeper (1.0.0~rc1-0) bionic; urgency=medium
 
   * First build

--- a/debian/gatekeeper.install
+++ b/debian/gatekeeper.install
@@ -6,6 +6,7 @@ lua/examples/*.lua usr/share/doc/gatekeeper/examples
 build/gatekeeper usr/sbin/
 generate_if_map usr/sbin/
 gkctl/gkctl usr/sbin/
+gkctl/scripts/* usr/share/gatekeeper
 
 debian/devbind.sh usr/share/gatekeeper/
 debian/envvars etc/gatekeeper/


### PR DESCRIPTION
This PR updates the debian package to install the Lua in gkctl/scripts. It also bumps the package version to -rc2.