### PR TITLE
gk: fix bug in flow entry deletion

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -563,12 +563,16 @@ get_block_idx(struct gk_config *gk_conf, unsigned int lcore_id)
 }
 
 static int
-gk_del_flow_entry_from_hash(struct rte_hash *h, struct flow_entry *fe)
+gk_del_flow_entry_from_hash(struct gk_instance *instance,
+	struct flow_entry *fe)
 {
+	struct rte_hash *h = instance->ip_flow_hash_table;
 	int ret = rte_hash_del_key_with_hash(h, &fe->flow, fe->flow_hash_val);
-	if (likely(ret >= 0))
+	if (likely(ret >= 0)) {
 		memset(fe, 0, sizeof(*fe));
-	else {
+		if (instance->num_scan_del > 0)
+			instance->num_scan_del--;
+	} else {
 		char err_msg[256];
 		int ret2 = snprintf(err_msg, sizeof(err_msg),
 			"The GK block failed to delete a key from hash table at %s: %s\n",
@@ -753,8 +757,7 @@ flush_flow_table(struct ip_prefix *src,
 		}
 
 		if (matched) {
-			gk_del_flow_entry_from_hash(
-				instance->ip_flow_hash_table, fe);
+			gk_del_flow_entry_from_hash(instance, fe);
 			num_flushed_flows++;
 		}
 
@@ -895,10 +898,8 @@ gk_synchronize(struct gk_fib *fib, struct gk_instance *instance)
 		while (index >= 0) {
 			struct flow_entry *fe =
 				&instance->ip_flow_entry_table[index];
-			if (fe->grantor_fib == fib) {
-				gk_del_flow_entry_from_hash(
-					instance->ip_flow_hash_table, fe);
-			}
+			if (fe->grantor_fib == fib)
+				gk_del_flow_entry_from_hash(instance, fe);
 
 			index = rte_hash_iterate(instance->ip_flow_hash_table,
 				(void *)&key, &data, &next);
@@ -2257,13 +2258,8 @@ gk_proc(void *arg)
 
 		process_cmds_from_mailbox(instance, gk_conf);
 
-		if (fe != NULL && fe->in_use && rte_rdtsc() >= fe->expire_at) {
-			gk_del_flow_entry_from_hash(
-				instance->ip_flow_hash_table, fe);
-
-			if (instance->num_scan_del > 0)
-				instance->num_scan_del--;
-		}
+		if (fe != NULL && fe->in_use && rte_rdtsc() >= fe->expire_at)
+			gk_del_flow_entry_from_hash(instance, fe);
 
 		if (rte_rdtsc() - last_measure_tsc >=
 				basic_measurement_logging_cycles) {

--- a/gk/main.c
+++ b/gk/main.c
@@ -756,8 +756,8 @@ flush_flow_table(struct ip_prefix *src,
 			}
 		}
 
-		if (matched) {
-			gk_del_flow_entry_from_hash(instance, fe);
+		if (matched && (gk_del_flow_entry_from_hash(
+				instance, fe) >= 0)) {
 			num_flushed_flows++;
 		}
 


### PR DESCRIPTION
After an expired entry is chosen to be deleted and the time
at which it is actually removed, the GK block processes
mailbox commands that could remove the entry. Therefore, we
must check whether the entry still exists before we remove it.

This patch also adds the flow information to the error
message when deleting a flow entry that is not found.