### PR TITLE
Add continuous integration for compiling

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,34 @@
+name: compile
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    env:
+      rte_sdk: ${{ format('{0}/{1}', github.workspace, 'dependencies/dpdk') }}
+      rte_target: ${{ 'x86_64-native-linuxapp-gcc' }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout submodules
+      uses: textbook/git-checkout-submodule-action@master
+
+    - name: Update packages
+      run: sudo apt-get update
+
+    - name: Install dependencies
+      run: sudo apt-get -y -q install git clang devscripts doxygen hugepages build-essential linux-headers-`uname -r` libmnl0 libmnl-dev libkmod2 libkmod-dev libnuma-dev libelf1 libelf-dev libc6-dev-i386 autoconf flex bison libncurses5-dev libreadline-dev
+
+    - name: Setup Gatekeeper
+      run: sudo ./setup.sh
+
+    - name: Build Gatekeeper
+      run: sudo RTE_SDK="$rte_sdk" RTE_TARGET="$rte_target" make

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Gatekeeper
 
+<a href="https://github.com/AltraMayor/gatekeeper/actions?query=workflow%3compile">
+  <img alt="Gatekeeper compilation status"
+       src="https://github.com/AltraMayor/gatekeeper/workflows/compile/badge.svg">
+</a>
+
 ## What is Gatekeeper?
 
 Gatekeeper is the first open source DoS protection system. It is designed to


### PR DESCRIPTION
This adds automatic compilation for all commits pushed to the `master` branch and for all pull requests to the `master` branch.

It also adds a badge to reflect the current build status.

An example of it running is here:

https://github.com/cjdoucette/gatekeeper/actions/runs/244833770