### PR TITLE
gatekeeper: have a VLAN tag for IPv4 and another for IPv6

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -130,8 +130,9 @@ get_new_ether_cache_locked(struct neighbor_hash_table *neigh,
 	eth_cache->stale = true;
 	rte_memcpy(&eth_cache->ip_addr, addr, sizeof(eth_cache->ip_addr));
 	if (iface->vlan_insert) {
-		fill_vlan_hdr(&eth_cache->l2_hdr.eth_hdr, iface->vlan_tag_be,
-			addr->proto);
+		uint16_t vlan_tag_be = addr->proto == RTE_ETHER_TYPE_IPV4 ?
+			iface->ipv4_vlan_tag_be : iface->ipv6_vlan_tag_be;
+		fill_vlan_hdr(&eth_cache->l2_hdr.eth_hdr, vlan_tag_be, addr->proto);
 	} else {
 		eth_cache->l2_hdr.eth_hdr.ether_type =
 			rte_cpu_to_be_16(addr->proto);

--- a/gk/main.c
+++ b/gk/main.c
@@ -1053,7 +1053,7 @@ xmit_icmp(struct gatekeeper_if *iface, struct ipacket *packet,
 	rte_ether_addr_copy(&icmp_eth->d_addr, &icmp_eth->s_addr);
 	rte_ether_addr_copy(&eth_addr_tmp, &icmp_eth->d_addr);
 	if (iface->vlan_insert) {
-		fill_vlan_hdr(icmp_eth, iface->vlan_tag_be,
+		fill_vlan_hdr(icmp_eth, iface->ipv4_vlan_tag_be,
 			RTE_ETHER_TYPE_IPV4);
 	}
 
@@ -1125,7 +1125,7 @@ xmit_icmpv6(struct gatekeeper_if *iface, struct ipacket *packet,
 	rte_ether_addr_copy(&icmp_eth->d_addr, &icmp_eth->s_addr);
 	rte_ether_addr_copy(&eth_addr_tmp, &icmp_eth->d_addr);
 	if (iface->vlan_insert) {
-		fill_vlan_hdr(icmp_eth, iface->vlan_tag_be,
+		fill_vlan_hdr(icmp_eth, iface->ipv6_vlan_tag_be,
 			RTE_ETHER_TYPE_IPV6);
 	}
 

--- a/include/gatekeeper_l2.h
+++ b/include/gatekeeper_l2.h
@@ -120,6 +120,6 @@ struct rte_ether_hdr *adjust_pkt_len(struct rte_mbuf *pkt,
 	struct gatekeeper_if *iface, int bytes_to_add);
 
 int verify_l2_hdr(struct gatekeeper_if *iface, struct rte_ether_hdr *eth_hdr,
-	uint32_t l2_type, const char *proto_name);
+	uint32_t l2_type, const char *proto_name, uint16_t vlan_tag_be);
 
 #endif /* _GATEKEEPER_L2_H_ */

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -138,7 +138,10 @@ struct gatekeeper_if {
 	/* The type of bonding used for this interface, if needed. */
 	uint32_t        bonding_mode;
 
-	/* Whether @vlan_tag should be applied to egress traffic. */
+	/*
+	 * Whether @ipv4_vlan_tag/@ipv6_vlan_tag should be applied to egress
+	 * traffic.
+	 */
 	int             vlan_insert;
 
 	/*
@@ -211,8 +214,11 @@ struct gatekeeper_if {
 	/* Link layer header length for egress packets from this interface. */
 	size_t          l2_len_out;
 
-	/* VLAN tag to be applied to all outbound packets, in network order. */
-	uint16_t        vlan_tag_be;
+	/* VLAN tag to be applied to all outbound IPv4 packets, in network order. */
+	uint16_t        ipv4_vlan_tag_be;
+
+	/* VLAN tag to be applied to all outbound IPv6 packets, in network order. */
+	uint16_t        ipv6_vlan_tag_be;
 
 	/* Ethernet address of this interface. */
 	struct rte_ether_addr eth_addr;
@@ -428,8 +434,8 @@ lacp_enabled(struct net_config *net, struct gatekeeper_if *iface)
 }
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
-	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_cidrs, uint8_t num_ip_cidrs, uint16_t vlan_tag);
+	const char **pci_addrs, uint8_t num_pci_addrs, const char **ip_cidrs,
+	uint8_t num_ip_cidrs, uint16_t ipv4_vlan_tag, uint16_t ipv6_vlan_tag);
 
 int get_ip_type(const char *ip_addr);
 int convert_str_to_ip(const char *ip_addr, struct ipaddr *res);

--- a/lib/l2.c
+++ b/lib/l2.c
@@ -85,7 +85,7 @@ adjust_pkt_len(struct rte_mbuf *pkt, struct gatekeeper_if *iface,
  */
 int
 verify_l2_hdr(struct gatekeeper_if *iface, struct rte_ether_hdr *eth_hdr,
-	uint32_t l2_type, const char *proto_name)
+	uint32_t l2_type, const char *proto_name, uint16_t vlan_tag_be)
 {
 	if (iface->vlan_insert) {
 		struct rte_vlan_hdr *vlan_hdr;
@@ -106,13 +106,13 @@ verify_l2_hdr(struct gatekeeper_if *iface, struct rte_ether_hdr *eth_hdr,
 		 * the VLAN tag in case we reuse this packet.
 		 */
 		vlan_hdr = (struct rte_vlan_hdr *)&eth_hdr[1];
-		if (unlikely(vlan_hdr->vlan_tci != iface->vlan_tag_be)) {
+		if (unlikely(vlan_hdr->vlan_tci != vlan_tag_be)) {
 			G_LOG(WARNING,
 				"l2: %s interface received an %s packet with an incorrect VLAN tag (0x%02x but should be 0x%02x)\n",
 				iface->name, proto_name,
 				rte_be_to_cpu_16(vlan_hdr->vlan_tci),
-				rte_be_to_cpu_16(iface->vlan_tag_be));
-			vlan_hdr->vlan_tci = iface->vlan_tag_be;
+				rte_be_to_cpu_16(vlan_tag_be));
+			vlan_hdr->vlan_tci = vlan_tag_be;
 		}
 	} else if (unlikely(l2_type != RTE_PTYPE_UNKNOWN)) {
 		/*

--- a/lib/net.c
+++ b/lib/net.c
@@ -549,8 +549,8 @@ convert_ip_to_str(const struct ipaddr *ip_addr, char *res, int n)
 
 int
 lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
-	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_cidrs, uint8_t num_ip_cidrs, uint16_t vlan_tag)
+	const char **pci_addrs, uint8_t num_pci_addrs, const char **ip_cidrs,
+	uint8_t num_ip_cidrs, uint16_t ipv4_vlan_tag, uint16_t ipv6_vlan_tag)
 {
 	uint8_t i, j;
 
@@ -665,7 +665,8 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 
 	iface->l2_len_out = sizeof(struct rte_ether_hdr);
 	if (iface->vlan_insert) {
-		iface->vlan_tag_be = rte_cpu_to_be_16(vlan_tag);
+		iface->ipv4_vlan_tag_be = rte_cpu_to_be_16(ipv4_vlan_tag);
+		iface->ipv6_vlan_tag_be = rte_cpu_to_be_16(ipv6_vlan_tag);
 		iface->l2_len_out += sizeof(struct rte_vlan_hdr);
 	}
 

--- a/lls/arp.c
+++ b/lls/arp.c
@@ -72,7 +72,7 @@ xmit_arp_req(struct gatekeeper_if *iface, const struct ipaddr *addr,
 
 	/* Set-up VLAN header. */
 	if (iface->vlan_insert)
-		fill_vlan_hdr(eth_hdr, iface->vlan_tag_be, RTE_ETHER_TYPE_ARP);
+		fill_vlan_hdr(eth_hdr, iface->ipv4_vlan_tag_be, RTE_ETHER_TYPE_ARP);
 	else
 		eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
 
@@ -122,7 +122,8 @@ process_arp(struct lls_config *lls_conf, struct gatekeeper_if *iface,
 		return -1;
 	}
 
-	ret = verify_l2_hdr(iface, eth_hdr, buf->l2_type, "ARP");
+	ret = verify_l2_hdr(iface, eth_hdr, buf->l2_type, "ARP",
+		iface->ipv4_vlan_tag_be);
 	if (ret < 0)
 		return ret;
 

--- a/lls/cache.c
+++ b/lls/cache.c
@@ -347,7 +347,7 @@ xmit_icmp_ping_reply(struct gatekeeper_if *iface, struct rte_mbuf *pkt)
 	rte_ether_addr_copy(&icmp_eth->d_addr, &icmp_eth->s_addr);
 	rte_ether_addr_copy(&eth_addr_tmp, &icmp_eth->d_addr);
 	if (iface->vlan_insert) {
-		fill_vlan_hdr(icmp_eth, iface->vlan_tag_be,
+		fill_vlan_hdr(icmp_eth, iface->ipv4_vlan_tag_be,
 			RTE_ETHER_TYPE_IPV4);
 	}
 
@@ -513,7 +513,7 @@ xmit_icmp6_ping_reply(struct gatekeeper_if *iface, struct rte_mbuf *pkt)
 	rte_ether_addr_copy(&icmp_eth->d_addr, &icmp_eth->s_addr);
 	rte_ether_addr_copy(&eth_addr_tmp, &icmp_eth->d_addr);
 	if (iface->vlan_insert) {
-		fill_vlan_hdr(icmp_eth, iface->vlan_tag_be,
+		fill_vlan_hdr(icmp_eth, iface->ipv6_vlan_tag_be,
 			RTE_ETHER_TYPE_IPV6);
 	}
 

--- a/lls/nd.c
+++ b/lls/nd.c
@@ -172,7 +172,7 @@ xmit_nd_req(struct gatekeeper_if *iface, const struct ipaddr *addr,
 
 	/* Set-up VLAN header. */
 	if (iface->vlan_insert)
-		fill_vlan_hdr(eth_hdr, iface->vlan_tag_be, RTE_ETHER_TYPE_IPV6);
+		fill_vlan_hdr(eth_hdr, iface->ipv6_vlan_tag_be, RTE_ETHER_TYPE_IPV6);
 	else
 		eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
 
@@ -395,7 +395,8 @@ process_nd_neigh_solicitation(struct lls_config *lls_conf, struct rte_mbuf *buf,
 		}
 	}
 
-	ret = verify_l2_hdr(iface, eth_hdr, buf->l2_type, "ND");
+	ret = verify_l2_hdr(iface, eth_hdr, buf->l2_type, "ND",
+		iface->ipv6_vlan_tag_be);
 	if (ret < 0)
 		return ret;
 

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -429,8 +429,8 @@ int rte_log_set_level(uint32_t type, uint32_t level);
 int rte_log_get_level(uint32_t type);
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
-	const char **pci_addrs, uint8_t num_pci_addrs,
-	const char **ip_cidrs, uint8_t num_ip_cidrs, uint16_t vlan_tag);
+	const char **pci_addrs, uint8_t num_pci_addrs, const char **ip_cidrs,
+	uint8_t num_ip_cidrs, uint16_t ipv4_vlan_tag, uint16_t ipv6_vlan_tag);
 
 bool ipv4_configured(struct net_config *net_conf);
 bool ipv6_configured(struct net_config *net_conf);
@@ -505,7 +505,7 @@ function check_ifaces(front_ports, back_ports)
 	end
 end
 
-function init_iface(iface, name, ports, cidrs, vlan_tag)
+function init_iface(iface, name, ports, cidrs, ipv4_vlan_tag, ipv6_vlan_tag)
 	local pci_strs = ffi.new("const char *[" .. #ports .. "]")
 	for i, v in ipairs(ports) do
 		local pci_addr = ifaces[v]
@@ -528,7 +528,7 @@ function init_iface(iface, name, ports, cidrs, vlan_tag)
 	end
 
 	local ret = c.lua_init_iface(iface, name, pci_strs, #ports,
-		ip_cidrs, #cidrs, vlan_tag)
+		ip_cidrs, #cidrs, ipv4_vlan_tag, ipv6_vlan_tag)
 	if ret < 0 then
 		error("Failed to initilialize " .. name .. " interface")
 	end

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -12,14 +12,16 @@ return function (gatekeeper_server)
 	local front_ports = {"enp133s0f0"}
 	local front_ips  = {"10.0.1.1/24", "2001:db8:1::1/48"}
 	local front_bonding_mode = staticlib.c.BONDING_MODE_ROUND_ROBIN
-	local front_vlan_tag = 0x123
+	local front_ipv4_vlan_tag = 0x123
+	local front_ipv6_vlan_tag = front_ipv4_vlan_tag
 	local front_vlan_insert = true
 	local front_mtu = 1500
 
 	local back_ports = {"enp133s0f1"}
 	local back_ips  = {"10.0.2.1/24", "2001:db8:2::1/48"}
 	local back_bonding_mode = staticlib.c.BONDING_MODE_ROUND_ROBIN
-	local back_vlan_tag = 0x456
+	local back_ipv4_vlan_tag = 0x456
+	local back_ipv6_vlan_tag = back_ipv4_vlan_tag
 	local back_vlan_insert = true
 	local back_mtu = 2048
 
@@ -76,7 +78,7 @@ return function (gatekeeper_server)
 	front_iface.ipv6_hw_udp_cksum = front_ipv6_hw_udp_cksum
 	front_iface.ipv4_hw_cksum = front_ipv4_hw_cksum
 	local ret = staticlib.init_iface(front_iface, "front",
-		front_ports, front_ips, front_vlan_tag)
+		front_ports, front_ips, front_ipv4_vlan_tag, front_ipv6_vlan_tag)
 	if ret < 0 then
 		error("Failed to initialize the front interface")
 	end
@@ -97,7 +99,7 @@ return function (gatekeeper_server)
 		back_iface.ipv6_hw_udp_cksum = back_ipv6_hw_udp_cksum
 		back_iface.ipv4_hw_cksum = back_ipv4_hw_cksum
 		ret = staticlib.init_iface(back_iface, "back",
-			back_ports, back_ips, back_vlan_tag)
+			back_ports, back_ips, back_ipv4_vlan_tag, back_ipv6_vlan_tag)
 		if ret < 0 then
 			error("Failed to initialize the back interface")
 		end


### PR DESCRIPTION
This patch closes #437.