### PR TITLE
gatekeeper: fix a compilation error with strncpy

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -221,7 +221,7 @@ parse_ip_prefix(const char *ip_prefix, struct ipaddr *res)
 	if (ip_prefix == NULL)
 		return -1;
 
-	strncpy(ip_prefix_copy, ip_prefix, ip_prefix_len + 1);
+	strcpy(ip_prefix_copy, ip_prefix);
 
 	ip_addr = strtok_r(ip_prefix_copy, "/", &saveptr);
 	if (ip_addr == NULL) {

--- a/lib/net.c
+++ b/lib/net.c
@@ -607,7 +607,7 @@ lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,
 		int gk_type;
 		int max_prefix;
 
-		strncpy(ip_cidr_copy, ip_cidrs[i], ip_cidr_len + 1);
+		strcpy(ip_cidr_copy, ip_cidrs[i]);
 
 		ip_addr = strtok_r(ip_cidr_copy, "/", &saveptr);
 		if (ip_addr == NULL)


### PR DESCRIPTION
When compiling Gatekeeper on new XIA server with Linux 5.4.0-54-generic
and GCC, there is a compilation error with strncpy(). The issue is
explained here: https://stackoverflow.com/questions/56782248/gcc-specified-bound-depends-on-the-length-of-the-source-argument.