### PR TITLE
sol: proper deallocation of struct sol_config

### DIFF
--- a/ggu/main.c
+++ b/ggu/main.c
@@ -862,10 +862,13 @@ run_ggu(struct net_config *net_conf,
 		sizeof(struct rte_mbuf *), ggu_conf->mailbox_mem_cache_size,
 		ggu_conf->lcore_id, &ggu_conf->mailbox);
 	if (ret < 0)
-		goto stage3;
+		goto put_gk;
 
 	goto out;
-stage3:
+put_gk:
+	ggu_conf->gk = NULL;
+	gk_conf_put(gk_conf);
+/* stage3: */
 	pop_n_at_stage3(1);
 stage2:
 	pop_n_at_stage2(1);

--- a/gk/main.c
+++ b/gk/main.c
@@ -2377,7 +2377,7 @@ int
 gk_conf_put(struct gk_config *gk_conf)
 {
 	/*
-	 * Atomically decrements the atomic counter (v) by one and returns true 
+	 * Atomically decrements the atomic counter by one and returns true
 	 * if the result is 0, or false in all other cases.
 	 */
 	if (rte_atomic32_dec_and_test(&gk_conf->ref_cnt))

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -205,6 +205,15 @@ struct gk_config {
 	 * Configuration files should not refer to them.
 	 */
 
+	/*
+	 * Number of references to this struct.
+	 *
+	 * The resources associated to this struct are only freed
+	 * when field @ref_cnt reaches zero.
+	 *
+	 * Use gk_conf_hold() and gk_conf_put() to acquire and release
+	 * a reference to this struct.
+	 */
 	rte_atomic32_t     ref_cnt;
 
 	/* The lcore ids at which each instance runs. */

--- a/include/gatekeeper_sol.h
+++ b/include/gatekeeper_sol.h
@@ -19,11 +19,10 @@
 #ifndef _GATEKEEPER_SOL_H_
 #define _GATEKEEPER_SOL_H_
 
-#include <rte_approx.h>
-#include <rte_cycles.h>
-#include <rte_reciprocal.h>
+#include <stdint.h>
 
-#include "gatekeeper_log_ratelimit.h"
+#include <rte_atomic.h>
+
 #include "list.h"
 
 /*

--- a/include/gatekeeper_sol.h
+++ b/include/gatekeeper_sol.h
@@ -143,6 +143,17 @@ struct sol_config {
 	 * Configuration files should not refer to them.
 	 */
 
+	/*
+	 * Number of references to this struct.
+	 *
+	 * The resources associated to this struct are only freed
+	 * when field @ref_cnt reaches zero.
+	 *
+	 * Use sol_conf_hold() and sol_conf_put() to acquire and release
+	 * a reference to this struct.
+	 */
+	rte_atomic32_t      ref_cnt;
+
 	/* The lcore ids at which each instance runs. */
 	unsigned int        *lcores;
 
@@ -157,5 +168,13 @@ struct sol_config *alloc_sol_conf(void);
 int run_sol(struct net_config *net_conf, struct sol_config *sol_conf);
 int gk_solicitor_enqueue_bulk(struct sol_instance *instance,
 	struct rte_mbuf **pkts, uint16_t num_pkts);
+
+static inline void
+sol_conf_hold(struct sol_config *sol_conf)
+{
+	rte_atomic32_inc(&sol_conf->ref_cnt);
+}
+
+int sol_conf_put(struct sol_config *sol_conf);
 
 #endif /* _GATEKEEPER_SOL_H_ */

--- a/sol/main.c
+++ b/sol/main.c
@@ -18,10 +18,12 @@
 
 #include <math.h>
 
+#include <rte_approx.h>
 #include <rte_sched.h>
 
 #include "gatekeeper_gk.h"
 #include "gatekeeper_launch.h"
+#include "gatekeeper_log_ratelimit.h"
 #include "gatekeeper_sol.h"
 
 int sol_logtype;


### PR DESCRIPTION
The SOL block was originally designed to have a single instance, so the code was not accounting for multiple deallocations. This patch adds the reference count that is employed in the GK and GT blocks to deal with the issue.

While Gatekeeper was not finishing cleanly, this issue was ONLY creating stranger log entries.
