### PR TITLE
gk: add dylib.c.gk_unload_bpf_flow_handler()

### DIFF
--- a/gk/bpf.h
+++ b/gk/bpf.h
@@ -32,6 +32,16 @@
 int gk_load_bpf_flow_handler(struct gk_config *gk_conf, unsigned int index,
 	const char *filename, int jit);
 
+/*
+ * Unload the BPF program that handles flows into @gk_conf at
+ * position @index.
+ *
+ * RETURN
+ * 	Zero on success;
+ * 	Negative on failure.
+ */
+int gk_unload_bpf_flow_handler(struct gk_config *gk_conf, unsigned int index);
+
 int gk_bpf_decide_pkt(struct gk_config *gk_conf, uint8_t program_index,
 	struct flow_entry *fe, struct ipacket *packet, uint64_t now,
 	uint64_t *p_bpf_ret);

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -144,13 +144,6 @@ struct gk_fib {
 	/* The fib action. */
 	enum gk_fib_action action;
 
-	/*
-	 * The callee that finished processing the notification
-	 * needs to increment this counter, so that the block
-	 * that is updating the FIB entry can finish its operation.
-	 */
-	rte_atomic16_t     num_updated_instances;
-
 	union {
 		/*
 	 	 * The nexthop information when the action is

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -352,6 +352,7 @@ enum gk_cmd_op {
 	GK_SYNCH_WITH_LPM,
 	GK_FLUSH_FLOW_TABLE,
 	GK_LOG_FLOW_STATE,
+	GK_FLUSH_BPF,
 	GK_CMD_OP_MAX,
 };
 
@@ -376,6 +377,11 @@ struct gk_log_flow {
 	uint32_t flow_hash_val;
 };
 
+struct gk_flush_bpf {
+	uint8_t        program_index;
+	rte_atomic32_t *done_counter;
+};
+
 /*
  * Structure for each command.
  *
@@ -393,6 +399,8 @@ struct gk_cmd_entry {
 		struct gk_flush_request flush;
 		/* Flow state logging request with GK_LOG_FLOW_STATE op. */
 		struct gk_log_flow log;
+		/* Flow table flush request with GK_FLUSH_BPF op. */
+		struct gk_flush_bpf flush_bpf;
 	} u;
 };
 

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -428,4 +428,10 @@ choose_grantor_per_flow(struct flow_entry *fe)
 	];
 }
 
+typedef void (*fill_in_gk_cmd_entry_t)(struct gk_cmd_entry *entry,
+	rte_atomic32_t *done_counter, void *arg);
+
+void synchronize_gk_instances(struct gk_config *gk_conf,
+	fill_in_gk_cmd_entry_t fill_f, void *arg);
+
 #endif /* _GATEKEEPER_GK_H_ */

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -361,8 +361,9 @@ struct gk_add_policy {
 };
 
 struct gk_synch_request {
-	struct gk_fib *fib;
-	int update_only;
+	struct gk_fib  *fib;
+	bool           update_only;
+	rte_atomic32_t *done_counter;
 };
 
 struct gk_flush_request {

--- a/lua/examples/example_of_dynamic_config_request.lua
+++ b/lua/examples/example_of_dynamic_config_request.lua
@@ -180,16 +180,18 @@ if ret < 0 then
 	-- The error below may be triggered for a number reasons,
 	-- the reasons below should be the most common ones:
 	--
-	-- 1. This example program runs more than once,
-	--	this is an expected error;
-	--
-	-- 2. Running Gatekeeper in a folder different from
+	-- 1. Running Gatekeeper in a folder different from
 	--	the root of the repository requires to adjust the path passed
 	--	to dylib.c.gk_load_bpf_flow_handler();
 	--
-	-- 3. The BPF programs in folder ROOT_OF_REPOSITORY/bpf are
+	-- 2. The BPF programs in folder ROOT_OF_REPOSITORY/bpf are
 	--	not compiled.
 	return "gk: failed to load a BPF program in runtime"
+end
+
+ret = dylib.c.gk_unload_bpf_flow_handler(dyc.gk, 255)
+if ret < 0 then
+	return "gk: failed to unload a BPF program in runtime"
 end
 
 return "gk: successfully processed all the FIB entries\n" .. reply_msg

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -86,6 +86,7 @@ int gk_log_flow_state(const char *src_addr,
 
 int gk_load_bpf_flow_handler(struct gk_config *gk_conf, unsigned int index,
 	const char *filename, int jit);
+int gk_unload_bpf_flow_handler(struct gk_config *gk_conf, unsigned int index);
 ]]
 
 c = ffi.C


### PR DESCRIPTION
The Lua function `dylib.c.gk_unload_bpf_flow_handler()` enables the dynamic configuration block to unload a BPF program in runtime.