### PR TITLE
debian: don't run generate_if_map if file exists

### DIFF
--- a/debian/gatekeeper.postinst
+++ b/debian/gatekeeper.postinst
@@ -6,7 +6,7 @@ if [ "$1" = "configure" ]; then
         adduser --quiet --system --group --no-create-home --home /run/gatekeeper gatekeeper
     fi
 
-    generate_if_map /etc/gatekeeper/if_map.lua
+    [ -f /etc/gatekeeper/if_map.lua ] || generate_if_map /etc/gatekeeper/if_map.lua
 
     dpkg-statoverride --list /usr/share/gatekeeper/devbind.sh > /dev/null || \
       dpkg-statoverride --update --add root root 0755 /usr/share/gatekeeper/devbind.sh


### PR DESCRIPTION
During upgrades, generate_if_map will generate an interface map file that's missing the gatekeeper interfaces, because they are already under control of DPDK.

This PR makes it so that generate_if_map will only be executed if the destination file does not exist.