### PR TITLE
gkctl: implement connect wait timeout

### DIFF
--- a/gkctl/main.c
+++ b/gkctl/main.c
@@ -277,14 +277,14 @@ main(int argc, char *argv[])
 	*(uint16_t *)send_buff = htons(ret);
 
 	if ((sock_fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
-		perror("Error : Could not create socket\n");
+		perror("Error: Could not create socket");
 		ret = -1;
 		goto out;
 	}
 
 	if (connect_wait(sock_fd, (struct sockaddr *)&serv_addr,
 			sizeof(serv_addr), args.connect_timeout) < 0) {
-		perror("Error : Connect failed\n");
+		perror("Error: Connect failed");
 		ret = -1;
 		goto close_sock;
 	}

--- a/gkctl/main.c
+++ b/gkctl/main.c
@@ -25,7 +25,7 @@
 #include <netinet/in.h>
 #include <netdb.h>
 #include <unistd.h>
-#include <arpa/inet.h> 
+#include <arpa/inet.h>
 #include <error.h>
 #include <argp.h>
 #include <assert.h>
@@ -194,9 +194,9 @@ main(int argc, char *argv[])
 	char recv_buff[MSG_MAX_LEN + 1];
 	size_t len;
 	size_t total_file_len;
-	struct sockaddr_un serv_addr; 
+	struct sockaddr_un serv_addr;
 
-    	struct args args = {
+	struct args args = {
 		/* Defaults. */
 		.server_path = "/var/run/gatekeeper/dyn_cfg.socket",
 	};

--- a/gkctl/main.c
+++ b/gkctl/main.c
@@ -320,6 +320,7 @@ main(int argc, char *argv[])
 	if (recv_buff[ret - 1] != '\0')
 		recv_buff[ret] = '\0';
 	printf("%s\n", recv_buff);
+	ret = 0;
 
 close_sock:
 	close(sock_fd);


### PR DESCRIPTION
This PR implements a connection timeout command-line option for `gkctl`. This is useful when running this command right after starting gatekeeper (e.g. via a systemd post-start command). Since it takes a while for gatekeeper to be ready to listen for connections in the dynamic configuration socket, it would be otherwise necessary to run a `sleep` command before `gkctl` in the hopes that we have waited enough for the socket to be ready.

The PR also includes a commit to change `gkctl`'s success return code to `0`, to ease handling errors in shell scripts, and trivial spacing fixes.