### PR TITLE
Debian fixes

### DIFF
--- a/debian/gatekeeper.cron.daily
+++ b/debian/gatekeeper.cron.daily
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/usr/bin/find /var/log/gatekeeper \
+  -maxdepth 1                     \
+  -type f                         \
+  -name gatekeeper_*.log          \
+  -mtime +1                       \
+  -delete

--- a/debian/gatekeeper.service
+++ b/debian/gatekeeper.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/gatekeeper/envvars
-ExecStartPre=/bin/mkdir -p /var/run/gatekeeper
+ExecStartPre=/usr/bin/install -oroot -ggatekeeper -m0770 -d /var/run/gatekeeper /var/run/dpdk/rte
 
 # We ignore dpdk-devbind errors on ExecStartPre to allow Gatekeeper
 # to be restarted, as dpdk-devbind will fail due to the interfaces

--- a/debian/patches/01_require_if_map.patch
+++ b/debian/patches/01_require_if_map.patch
@@ -1,0 +1,13 @@
+Index: gatekeeper/lua/gatekeeper/staticlib.lua
+===================================================================
+--- gatekeeper.orig/lua/gatekeeper/staticlib.lua
++++ gatekeeper/lua/gatekeeper/staticlib.lua
+@@ -481,7 +481,7 @@ c = ffi.C
+ -- Network configuration functions
+ --
+ 
+-local ifaces = require("if_map")
++local ifaces = dofile("/etc/gatekeeper/if_map.lua")
+ 
+ function check_ifaces(front_ports, back_ports)
+ 	for i1, v1 in ipairs(front_ports) do

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+01_require_if_map.patch


### PR DESCRIPTION
Some fixes and enhancements for debian packages:

1) Ensure the `gatekeeper` unprivileged user has access to `/var/run/gatekeeper` and `/var/run/dpdk/rte`.

This prevents errors such as `GATEKEEPER DYN CFG: Failed to unlink(/var/run/gatekeeper/dyn_cfg.socket) - (Permission denied)` and `EAL: Unable to open directory /var/run/dpdk/rte`.

2) Patch `staticlib.lua` so that it can find `if_map.lua` in the package installation path (`/etc/gatekeeper/if_map.lua`).

3) Add a cron job that removes log files older than 24h. Since gatekeeper "rotates" its own log files (i.e. creates log files names using the current date), this is better handled by a simple `find` command rather than by logrotate.