### PR TITLE
log_ratelimit: allow all startup logs

### DIFF
--- a/include/gatekeeper_log_ratelimit.h
+++ b/include/gatekeeper_log_ratelimit.h
@@ -23,6 +23,14 @@
 #include <stdint.h>
 
 /*
+ * At startup, log ratelimiting is disabled so that all
+ * startup logs are captured. Before the blocks start,
+ * the launch routine calls this function to enable log
+ * ratelimiting during operation.
+ */
+void log_ratelimit_enable(void);
+
+/*
  * Check whether a log entry will be permitted, according to the level
  * of the log entry and the configured level of the system's log.
  * Note that even when this test passes, log entries may not occur


### PR DESCRIPTION
Before the functional blocks launch (at the end of stage 3),
they are all run on the master lcore (0). Therefore, the rate
limit for lcore 0 is applied to all block initialization and
the network initialization.

In practice, lcore 0 is always assigned to the LLS block,
since we initialize it first. Therefore, the LLS rate limit
is applied to all startup logs.

This patch adds a flag to the log ratelimiting library,
which is only set when initialization is complete. Therefore,
all startup logs will be captured.