### PR TITLE
debian: fix cron log cleanup command

### DIFF
--- a/debian/gatekeeper.cron.daily
+++ b/debian/gatekeeper.cron.daily
@@ -3,6 +3,6 @@
 /usr/bin/find /var/log/gatekeeper \
   -maxdepth 1                     \
   -type f                         \
-  -name gatekeeper_*.log          \
-  -mtime +1                       \
+  -name gatekeeper_\*.log         \
+  -mtime 1                        \
   -delete


### PR DESCRIPTION
Two fixes in the log cleanup command:

1) The wildcard must be escaped, i.e. `gatekeeper_\*.log`;
2) `-mtime +1` results in only logs older than **2** days being deleted; switch to `-mtime 1` for the intended 24h interval.