### PR TITLE
debian: don't enable/start service on installation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -59,6 +59,9 @@ clean_gatekeeper:
 clean_bpf:
 	cd bpf; rm -f *.bpf
 
+override_dh_installsystemd:
+	dh_installsystemd --no-enable --no-start
+
 override_dh_auto_install:
 
 override_dh_auto_clean:


### PR DESCRIPTION
Don't start/enable the systemd unit on package installation, since running gatekeeper before having an adequate configuration is a guaranteed startup error.