### PR TITLE
Speed up the scripts of gkctl

### DIFF
--- a/gkctl/scripts/show_arp.lua
+++ b/gkctl/scripts/show_arp.lua
@@ -4,4 +4,4 @@ local llsc = staticlib.c.get_lls_conf()
 if llsc == nil then
 	return "No link layer support block available"
 end
-return dylib.list_lls_arp(llsc, dylib.print_lls_dump_entry, "")
+return table.concat(dylib.list_lls_arp(llsc, dylib.print_lls_dump_entry, {}))

--- a/gkctl/scripts/show_fib.lua
+++ b/gkctl/scripts/show_fib.lua
@@ -7,4 +7,4 @@ end
 if dyc.gk == nil then
 	return "No GK block available; not a Gatekeeper server"
 end
-return dylib.list_gk_fib4(dyc.gk, dylib.print_fib_dump_entry, "")
+return table.concat(dylib.list_gk_fib4(dyc.gk, dylib.print_fib_dump_entry, {}))

--- a/gkctl/scripts/show_fib6.lua
+++ b/gkctl/scripts/show_fib6.lua
@@ -7,4 +7,4 @@ end
 if dyc.gk == nil then
 	return "No GK block available; not a Gatekeeper server"
 end
-return dylib.list_gk_fib6(dyc.gk, dylib.print_fib_dump_entry, "")
+return table.concat(dylib.list_gk_fib6(dyc.gk, dylib.print_fib_dump_entry, {}))

--- a/gkctl/scripts/show_nd.lua
+++ b/gkctl/scripts/show_nd.lua
@@ -4,4 +4,4 @@ local llsc = staticlib.c.get_lls_conf()
 if llsc == nil then
 	return "No link layer support block available"
 end
-return dylib.list_lls_nd(llsc, dylib.print_lls_dump_entry, "")
+return table.concat(dylib.list_lls_nd(llsc, dylib.print_lls_dump_entry, {}))

--- a/gkctl/scripts/show_neigh.lua
+++ b/gkctl/scripts/show_neigh.lua
@@ -7,4 +7,5 @@ end
 if dyc.gk == nil then
 	return "No GK block available; not a Gatekeeper server"
 end
-return dylib.list_gk_neighbors4(dyc.gk, dylib.print_neighbor_dump_entry, "")
+return table.concat(dylib.list_gk_neighbors4(dyc.gk,
+	dylib.print_neighbor_dump_entry, {}))

--- a/gkctl/scripts/show_neigh6.lua
+++ b/gkctl/scripts/show_neigh6.lua
@@ -7,4 +7,5 @@ end
 if dyc.gk == nil then
 	return "No GK block available; not a Gatekeeper server"
 end
-return dylib.list_gk_neighbors6(dyc.gk, dylib.print_neighbor_dump_entry, "")
+return table.concat(dylib.list_gk_neighbors6(dyc.gk,
+	dylib.print_neighbor_dump_entry, {}))

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -173,14 +173,16 @@ end
 -- neighbor_dump_entry or any of the data reachable through its fields.
 
 function print_neighbor_dump_entry(neighbor_dump_entry, acc)
-	local stale = neighbor_dump_entry.stale and "stale" or "fresh"
-	local neigh_ip = dylib.ip_format_addr(neighbor_dump_entry.neigh_ip)
-	local d_buf = dylib.ether_format_addr(neighbor_dump_entry.d_addr)
-
-	return acc .. "Neighbor Ethernet cache entry: [state: " .. stale ..
-		", neighbor ip: " .. neigh_ip .. ", d_addr: " .. d_buf ..
-		", action: " ..
-		fib_action_to_str(neighbor_dump_entry.action) .. "]\n"
+	acc[#acc + 1] = "Neighbor Ethernet cache entry: [state: "
+	acc[#acc + 1] = neighbor_dump_entry.stale and "stale" or "fresh"
+	acc[#acc + 1] = ", neighbor ip: "
+	acc[#acc + 1] = dylib.ip_format_addr(neighbor_dump_entry.neigh_ip)
+	acc[#acc + 1] = ", d_addr: "
+	acc[#acc + 1] = dylib.ether_format_addr(neighbor_dump_entry.d_addr)
+	acc[#acc + 1] = ", action: "
+	acc[#acc + 1] = fib_action_to_str(neighbor_dump_entry.action)
+	acc[#acc + 1] = "]\n"
+	return acc
 end
 
 -- The following is an example function that can be used as

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -193,14 +193,16 @@ end
 -- lls_dump_entry or any of the data reachable through its fields.
 
 function print_lls_dump_entry(lls_dump_entry, acc)
-	local stale = lls_dump_entry.stale and "stale" or "fresh"
-	local ip = dylib.ip_format_addr(lls_dump_entry.addr)
-	local ha = dylib.ether_format_addr(lls_dump_entry.ha)
-	local port_id = lls_dump_entry.port_id
-
-	return acc .. "LLS cache entry:" .. ": [state: " .. stale ..
-		", ip: " .. ip .. ", mac: " .. ha ..
-		", port: " .. port_id .. "]\n"
+	acc[#acc + 1] = "LLS cache entry: [state: "
+	acc[#acc + 1] = lls_dump_entry.stale and "stale" or "fresh"
+	acc[#acc + 1] = ", ip: "
+	acc[#acc + 1] = dylib.ip_format_addr(lls_dump_entry.addr)
+	acc[#acc + 1] = ", mac: "
+	acc[#acc + 1] = dylib.ether_format_addr(lls_dump_entry.ha)
+	acc[#acc + 1] = ", port: "
+	acc[#acc + 1] = tostring(lls_dump_entry.port_id)
+	acc[#acc + 1] = "]\n"
+	return acc
 end
 
 function update_gt_lua_states_incrementally(gt_conf, lua_code, is_returned)


### PR DESCRIPTION
The scripts shipped with `gkctl` were very slow because they would copy the content of the accumulator string multiple times per record of the table being dumped. The new code only concatenates the strings at the very end by calling the efficient `table.concat()` of Lua. The original scripts would take a minute to dump a modest-sized routing table, while the new code accomplishes the same task in less than a second.