### PR TITLE
Improve the FIB iterator available for the dynamic configuration block

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -2044,6 +2044,7 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 	while (index >= 0) {
 		unsigned int num_addrs;
 		size_t new_dentry_size;
+		int done;
 
 		fib = &ltbl->fib_tbl[re4->next_hop];
 		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
@@ -2086,11 +2087,16 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		*(struct gk_fib_dump_entry **)cdata = dentry;
 		lua_insert(l, 4);
 
-		if (lua_pcall(l, 2, 1, 0) != 0) {
+		if (lua_pcall(l, 2, 2, 0) != 0) {
 			rte_free(dentry);
 			rte_spinlock_unlock_tm(&ltbl->lock);
 			lua_error(l);
 		}
+
+		done = lua_toboolean(l, -2);
+		lua_remove(l, -2);
+		if (unlikely(done))
+			break;
 
 		index = rte_lpm_rule_iterate(&state, &re4);
 	}
@@ -2123,6 +2129,7 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 	while (index >= 0) {
 		unsigned int num_addrs;
 		size_t new_dentry_size;
+		int done;
 
 		fib = &ltbl->fib_tbl6[re6.next_hop];
 		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
@@ -2166,11 +2173,16 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		*(struct gk_fib_dump_entry **)cdata = dentry;
 		lua_insert(l, 4);
 
-		if (lua_pcall(l, 2, 1, 0) != 0) {
+		if (lua_pcall(l, 2, 2, 0) != 0) {
 			rte_free(dentry);
 			rte_spinlock_unlock_tm(&ltbl->lock);
 			lua_error(l);
 		}
+
+		done = lua_toboolean(l, -2);
+		lua_remove(l, -2);
+		if (unlikely(done))
+			break;
 
 		index = rte_lpm6_rule_iterate(&state6, &re6);
 	}

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -2026,7 +2026,8 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 	struct gk_fib *fib;
 	const struct rte_lpm_rule *re4;
 	struct rte_lpm_iterator_state state;
-	struct gk_fib_dump_entry *dentry;
+	struct gk_fib_dump_entry *dentry = NULL;
+	size_t dentry_size = 0;
 	void *cdata;
 	uint32_t correct_ctypeid_fib_dump_entry = luaL_get_ctypeid(l,
 		CTYPE_STRUCT_FIB_DUMP_ENTRY_PTR);
@@ -2042,7 +2043,7 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 	index = rte_lpm_rule_iterate(&state, &re4);
 	while (index >= 0) {
 		unsigned int num_addrs;
-		size_t dentry_size;
+		size_t new_dentry_size;
 
 		fib = &ltbl->fib_tbl[re4->next_hop];
 		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
@@ -2052,20 +2053,26 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		}
 
 		num_addrs = num_addrs_entry_type(fib);
-		dentry_size = sizeof(*dentry) +
+		new_dentry_size = sizeof(*dentry) +
 			num_addrs * sizeof(*dentry->addr_sets);
 
-		/*
-		 * We don't need rte_zmalloc_socket() here because
-		 * the memory is not being used by the GK block.
-		 */
-		dentry = rte_zmalloc("fib4_dump", dentry_size, 0);
-		if (unlikely(dentry == NULL)) {
-			rte_spinlock_unlock_tm(&ltbl->lock);
-			luaL_error(l,
-				"gk: failed to allocate memory for the IPv4 FIB dump at %s",
-				__func__);
-		}
+		if (new_dentry_size > dentry_size) {
+			dentry_size = new_dentry_size;
+			rte_free(dentry);
+			/*
+			 * We don't need rte_zmalloc_socket() here because
+			 * the memory is not being used by the GK block.
+			 */
+			dentry = rte_zmalloc("fib4_dump", dentry_size, 0);
+			if (unlikely(dentry == NULL)) {
+				rte_spinlock_unlock_tm(&ltbl->lock);
+				luaL_error(l,
+					"gk: failed to allocate memory for the IPv4 FIB dump at %s",
+					__func__);
+			}
+		} else
+			memset(dentry, 0, new_dentry_size);
+
 		dentry->addr.proto = RTE_ETHER_TYPE_IPV4;
 		dentry->addr.ip.v4.s_addr = htonl(re4->ip);
 		dentry->prefix_len = state.depth;
@@ -2085,9 +2092,9 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 			lua_error(l);
 		}
 
-		rte_free(dentry);
 		index = rte_lpm_rule_iterate(&state, &re4);
 	}
+	rte_free(dentry);
 	rte_spinlock_unlock_tm(&ltbl->lock);
 }
 
@@ -2098,7 +2105,8 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 	struct gk_fib *fib;
 	struct rte_lpm6_rule re6;
 	struct rte_lpm6_iterator_state state6;
-	struct gk_fib_dump_entry *dentry;
+	struct gk_fib_dump_entry *dentry = NULL;
+	size_t dentry_size = 0;
 	void *cdata;
 	uint32_t correct_ctypeid_fib_dump_entry = luaL_get_ctypeid(l,
 		CTYPE_STRUCT_FIB_DUMP_ENTRY_PTR);
@@ -2114,7 +2122,7 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 	index = rte_lpm6_rule_iterate(&state6, &re6);
 	while (index >= 0) {
 		unsigned int num_addrs;
-		size_t dentry_size;
+		size_t new_dentry_size;
 
 		fib = &ltbl->fib_tbl6[re6.next_hop];
 		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
@@ -2124,20 +2132,26 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		}
 
 		num_addrs = num_addrs_entry_type(fib);
-		dentry_size = sizeof(*dentry) +
+		new_dentry_size = sizeof(*dentry) +
 			num_addrs * sizeof(*dentry->addr_sets);
 
-		/*
-		 * We don't need rte_zmalloc_socket() here because
-		 * the memory is not being used by the GK block.
-		 */
-		dentry = rte_zmalloc("fib6_dump", dentry_size, 0);
-		if (unlikely(dentry == NULL)) {
-			rte_spinlock_unlock_tm(&ltbl->lock);
-			luaL_error(l,
-				"gk: failed to allocate memory for the IPv6 FIB dump at %s",
-				__func__);
-		}
+		if (new_dentry_size > dentry_size) {
+			dentry_size = new_dentry_size;
+			rte_free(dentry);
+			/*
+			 * We don't need rte_zmalloc_socket() here because
+			 * the memory is not being used by the GK block.
+			 */
+			dentry = rte_zmalloc("fib6_dump", dentry_size, 0);
+			if (unlikely(dentry == NULL)) {
+				rte_spinlock_unlock_tm(&ltbl->lock);
+				luaL_error(l,
+					"gk: failed to allocate memory for the IPv6 FIB dump at %s",
+					__func__);
+			}
+		} else
+			memset(dentry, 0, new_dentry_size);
+
 		dentry->addr.proto = RTE_ETHER_TYPE_IPV6;
 		rte_memcpy(&dentry->addr.ip.v6, re6.ip,
 			sizeof(dentry->addr.ip.v6));
@@ -2158,9 +2172,9 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 			lua_error(l);
 		}
 
-		rte_free(dentry);
 		index = rte_lpm6_rule_iterate(&state6, &re6);
 	}
+	rte_free(dentry);
 	rte_spinlock_unlock_tm(&ltbl->lock);
 }
 

--- a/gkctl/scripts/show_fib6_grantor.lua
+++ b/gkctl/scripts/show_fib6_grantor.lua
@@ -1,0 +1,18 @@
+require "gatekeeper/staticlib"
+
+local dyc = staticlib.c.get_dy_conf()
+if dyc == nil then
+	return "No dynamic configuration block available"
+end
+if dyc.gk == nil then
+	return "No GK block available; not a Gatekeeper server"
+end
+
+local function print_only_grantor(fib_dump_entry, acc)
+	if fib_dump_entry.action ~= dylib.c.GK_FWD_GRANTOR then
+		return false, acc
+	end
+	return dylib.print_fib_dump_entry(fib_dump_entry, acc)
+end
+
+return table.concat(dylib.list_gk_fib6(dyc.gk, print_only_grantor, {}))

--- a/gkctl/scripts/show_fib_grantor.lua
+++ b/gkctl/scripts/show_fib_grantor.lua
@@ -1,0 +1,18 @@
+require "gatekeeper/staticlib"
+
+local dyc = staticlib.c.get_dy_conf()
+if dyc == nil then
+	return "No dynamic configuration block available"
+end
+if dyc.gk == nil then
+	return "No GK block available; not a Gatekeeper server"
+end
+
+local function print_only_grantor(fib_dump_entry, acc)
+	if fib_dump_entry.action ~= dylib.c.GK_FWD_GRANTOR then
+		return false, acc
+	end
+	return dylib.print_fib_dump_entry(fib_dump_entry, acc)
+end
+
+return table.concat(dylib.list_gk_fib4(dyc.gk, print_only_grantor, {}))

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -122,10 +122,6 @@ end
 -- or any of the data reachable through its fields.
 
 function print_fib_dump_entry(fib_dump_entry, acc)
-	if acc.done then
-		return acc
-	end
-
 	acc[#acc + 1] = "FIB entry for IP prefix: "
 	acc[#acc + 1] = dylib.ip_format_addr(fib_dump_entry.addr)
 	acc[#acc + 1] = "/"
@@ -153,16 +149,13 @@ function print_fib_dump_entry(fib_dump_entry, acc)
 	acc[#acc + 1] = "\n"
 
 	if #acc < 1000 then
-		return acc
+		return false, acc
 	end
 
 	-- If the FIB table is too big to dump into a single message
 	-- of the dynamic configuration block, ignore the following entries.
-	acc = { [1] = table.concat(acc) }
-	if string.len(acc[1]) >= c.MSG_MAX_LEN then
-		acc.done = true
-	end
-	return acc
+	local output = table.concat(acc)
+	return string.len(output) >= c.MSG_MAX_LEN, { [1] = output }
 end
 
 -- The following is an example function that can be used as

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -114,6 +114,17 @@ function fib_action_to_str(fib_action)
 	return res
 end
 
+-- Bound the output of the FIB table to the maximum size of
+-- a message of the dynamic configuration block.
+function bound_fib_dump_output(acc)
+	if #acc < 1000 then
+		return false, acc
+	end
+
+	local output = table.concat(acc)
+	return string.len(output) >= c.MSG_MAX_LEN, { [1] = output }
+end
+
 -- The following is an example function that can be used as
 -- the callback function of list_gk_fib4() and list_gk_fib6().
 
@@ -148,14 +159,7 @@ function print_fib_dump_entry(fib_dump_entry, acc)
 	end
 	acc[#acc + 1] = "\n"
 
-	if #acc < 1000 then
-		return false, acc
-	end
-
-	-- If the FIB table is too big to dump into a single message
-	-- of the dynamic configuration block, ignore the following entries.
-	local output = table.concat(acc)
-	return string.len(output) >= c.MSG_MAX_LEN, { [1] = output }
+	return bound_fib_dump_output(acc)
 end
 
 -- The following is an example function that can be used as


### PR DESCRIPTION
As pull request #489 brought up, the FIB iterator is the most demanding iterator available through the dynamic configuration block. This pull request improves the code of this iterator to further save time.

This pull request also adds two new `gkctl` scripts to only list grantor FIB entries. Not only are these new scripts useful in production, but they also serve as examples of how to filter any subset of FIB entries.