### PR TITLE
gatekeeper: report the right prefix length of FIB entries

### DIFF
--- a/cps/rd.c
+++ b/cps/rd.c
@@ -664,7 +664,7 @@ rd_getroute_ipv6_locked(struct cps_config *cps_conf, struct gk_lpm *ltbl,
 			mnl_nlmsg_put_header(mnl_nlmsg_batch_current(batch));
 
 		rd_fill_getroute_reply(cps_conf, reply, fib,
-			AF_INET6, req->nlmsg_seq, state6.depth, &gw_addr);
+			AF_INET6, req->nlmsg_seq, re6.depth, &gw_addr);
 
 		/* Add address. */
 		mnl_attr_put(reply, RTA_DST,

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -2162,7 +2162,7 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		dentry->addr.proto = RTE_ETHER_TYPE_IPV6;
 		rte_memcpy(&dentry->addr.ip.v6, re6.ip,
 			sizeof(dentry->addr.ip.v6));
-		dentry->prefix_len = state6.depth;
+		dentry->prefix_len = re6.depth;
 		dentry->num_addr_sets = num_addrs;
 		fillup_gk_fib_dump_entry(dentry, fib);
 


### PR DESCRIPTION
The iterators of the FIB implemented in the CPS and GK blocks were reporting a wrong prefix length of /0 for IPv6 FIB entries.