### PR TITLE
cps: improve handling of RTNetlink edit requests

### DIFF
--- a/include/gatekeeper_lpm.h
+++ b/include/gatekeeper_lpm.h
@@ -21,6 +21,7 @@
 
 #include <rte_lpm.h>
 #include <rte_lpm6.h>
+#include <rte_byteorder.h>
 
 /*
  * The API here aims to be general and allow developers
@@ -32,11 +33,26 @@ struct rte_lpm *init_ipv4_lpm(const char *tag,
 	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
 int lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip);
 
+static inline int
+lpm_is_rule_present(struct rte_lpm *lpm, rte_be32_t ip, uint8_t depth,
+	uint32_t *next_hop)
+{
+	return rte_lpm_is_rule_present(lpm, rte_be_to_cpu_32(ip), depth,
+		next_hop);
+}
+
 /* Similar to init_ipv4_lpm(), see above. */
 struct rte_lpm6 *init_ipv6_lpm(const char *tag,
 	const struct rte_lpm6_config *lpm6_conf,
 	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
 int lpm_lookup_ipv6(struct rte_lpm6 *lpm, struct in6_addr *ip);
+
+static inline int
+lpm6_is_rule_present(struct rte_lpm6 *lpm, uint8_t *ip, uint8_t depth,
+	uint32_t *next_hop)
+{
+	return rte_lpm6_is_rule_present(lpm, ip, depth, next_hop);
+}
 
 static inline void
 destroy_ipv4_lpm(struct rte_lpm *lpm)


### PR DESCRIPTION
This pull request:
1. adds support to the RTNetlink flags `NLM_F_EXCL`, `NLM_F_REPLACE`, and `NLM_F_CREATE` for `RTM_NEWROUTE` requests;
2. Removes the requirement of interface information for `RTM_NEWROUTE` requests;
3. Protects grantor entries from being edited by routing daemons.