### PR TITLE
cps: support the RTNetlink field RTA_PRIORITY

### DIFF
--- a/gkctl/scripts/summarize_fibs.lua
+++ b/gkctl/scripts/summarize_fibs.lua
@@ -1,0 +1,71 @@
+require "gatekeeper/staticlib"
+
+local dyc = staticlib.c.get_dy_conf()
+if dyc == nil then
+	return "No dynamic configuration block available"
+end
+if dyc.gk == nil then
+	return "No GK block available; not a Gatekeeper server"
+end
+
+local function new_summary()
+	return { actions = {}, prefix_lengths = {} }
+end
+
+local function summarize_fib(fib_dump_entry, acc)
+	local actions = acc.actions
+	-- fib_dump_entry.action is of type enum gk_fib_action,
+	-- so it must be casted into a number to avoid having
+	-- each instance as a unique value.
+	local action = tonumber(fib_dump_entry.action)
+	if actions[action] == nil then
+		actions[action] = 1
+	else
+		actions[action] = actions[action] + 1
+	end
+
+	local prefix_lengths = acc.prefix_lengths
+	local prefix_len = fib_dump_entry.prefix_len
+	if prefix_lengths[prefix_len] == nil then
+		prefix_lengths[prefix_len] = 1
+	else
+		prefix_lengths[prefix_len] = prefix_lengths[prefix_len] + 1
+	end
+
+	return false, acc
+end
+
+local function report_summary(output, summary)
+	local total1 = 0
+	for action, count in pairs(summary.actions) do
+		output[#output + 1] = "\t"
+		output[#output + 1] = dylib.fib_action_to_str(action)
+		output[#output + 1] = ": "
+		output[#output + 1] = tostring(count)
+		output[#output + 1] = "\n"
+		total1 = total1 + count
+	end
+	output[#output + 1] = "\n"
+
+	local total2 = 0
+	for prefix_length, count in pairs(summary.prefix_lengths) do
+		output[#output + 1] = "\t"
+		output[#output + 1] = tostring(prefix_length)
+		output[#output + 1] = ": "
+		output[#output + 1] = tostring(count)
+		output[#output + 1] = "\n"
+		total2 = total2 + count
+	end
+	output[#output + 1] = "Total entries: "
+	output[#output + 1] = tostring(total2)
+	output[#output + 1] = "\n"
+
+	assert(total1 == total2, "Totals are not equal")
+end
+
+local output = {}
+output[#output + 1] = "IPv4 summary:\n"
+report_summary(output, dylib.list_gk_fib4(dyc.gk, summarize_fib, new_summary()))
+output[#output + 1] = "\nIPv6 summary:\n"
+report_summary(output, dylib.list_gk_fib6(dyc.gk, summarize_fib, new_summary()))
+return table.concat(output)

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -138,6 +138,23 @@ struct grantor_set {
 	struct grantor_entry entries[0];
 };
 
+/*
+ * Route properties.
+ *
+ * Gatekeeper does not acts on these properties. They are needed to
+ * support routing daemons that expect them.
+ */
+struct route_properties {
+	/*
+	 * Routing table protocol -- origin of the route.
+	 * RTPROT_STATIC for routes added by user.
+	 * RTPROT_BIRD for routes added by BIRD daemon, etc.
+	 */
+	uint8_t  rt_proto;
+
+	uint32_t priority;
+};
+
 /* The gk forward information base (fib). */
 struct gk_fib {
 
@@ -153,12 +170,7 @@ struct gk_fib {
 			/* The cached Ethernet header. */
 			struct ether_cache *eth_cache;
 
-			/*
-			 * Routing table protocol - origin of the root.
-			 * RTPROT_STATIC for routes added by user.
-			 * RTPROT_BIRD for routes added by BIRD daemon, etc.
-			 */
-			uint8_t rt_proto;
+			struct route_properties props;
 		} gateway;
 
 		struct {
@@ -180,12 +192,7 @@ struct gk_fib {
 
 		/* Route information when the action is GK_DROP. */
 		struct {
-			/*
-			 * Routing table protocol - origin of the root.
-			 * RTPROT_STATIC for routes added by user.
-			 * RTPROT_BIRD for routes added by BIRD daemon, etc.
-			 */
-			uint8_t rt_proto;
+			struct route_properties props;
 		} drop;
 	} u;
 };
@@ -305,7 +312,7 @@ int parse_ip_prefix(const char *ip_prefix, struct ipaddr *res);
 int add_fib_entry_numerical(struct ip_prefix *prefix_info,
 	struct ipaddr *gt_addrs, struct ipaddr *gw_addrs,
 	unsigned int num_addrs, enum gk_fib_action action,
-	uint8_t protocol, struct gk_config *gk_conf);
+	const struct route_properties *props, struct gk_config *gk_conf);
 int add_fib_entry(const char *prefix, const char *gt_ip, const char *gw_ip,
 	enum gk_fib_action action, struct gk_config *gk_conf);
 int del_fib_entry_numerical(


### PR DESCRIPTION
While Gatekeeper ignores the RTNetlink field `RTA_PRIORITY`, routing daemons keep track of this field. So this pull request saves it in the FIB.

A script to quickly inspect the whole FIB is also added.