### PR TITLE
gt: allow policies to request more hugepages after boot

### DIFF
--- a/gkctl/scripts/reload_policy.lua
+++ b/gkctl/scripts/reload_policy.lua
@@ -1,0 +1,12 @@
+require "gatekeeper/staticlib"
+
+local dyc = staticlib.c.get_dy_conf()
+if dyc == nil then
+	return "No dynamic configuration block available"
+end
+if dyc.gt == nil then
+	return "No GT block available; not a Grator server"
+end
+
+dylib.update_gt_lua_states(dyc.gt)
+return "Successfully reloaded the Lua policy"

--- a/gt/main.c
+++ b/gt/main.c
@@ -2242,7 +2242,7 @@ l_update_gt_lua_states(lua_State *l)
 		if (entry == NULL) {
 			lua_close(lua_state);
 
-			luaL_error(l, "gt: failed to send new lua state to GT block %d at lcore %d\n",
+			luaL_error(l, "gt: failed to allocate a mailbox entry to send new lua state to GT block %d at lcore %d\n",
 				i, lcore_id);
 
 			continue;

--- a/gt/main.c
+++ b/gt/main.c
@@ -1549,6 +1549,15 @@ gt_proc(void *arg)
 	struct rte_ip_frag_death_row death_row;
 	uint16_t gt_max_pkt_burst;
 	bool reassembling_enabled = gt_conf->reassembling_enabled;
+	/*
+	 * GT instances need capabilities CAP_DAC_OVERRIDE and CAP_SYS_ADMIN
+	 * to allow policies to allocate more hugepages from the kernel
+	 * when dylib.update_gt_lua_states_incrementally() is called from
+	 * the dynamic configuration block.
+	 * More details on why these capabilities are needed are found in
+	 * dyn_cfg_proc().
+	 */
+	cap_value_t caps[] = {CAP_DAC_OVERRIDE, CAP_SYS_ADMIN};
 
 	death_row.cnt = 0;
 	gt_max_pkt_burst = gt_conf->max_pkt_burst;
@@ -1556,7 +1565,7 @@ gt_proc(void *arg)
 	GT_LOG(NOTICE, "The GT block is running at: lcore = %u; tid = %u\n",
 		lcore, gettid());
 
-	if (needed_caps("GT", 0, NULL) < 0) {
+	if (needed_caps("GT", RTE_DIM(caps), caps) < 0) {
 		GT_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}


### PR DESCRIPTION
When more hugepages are needed after boot and a Grantor server is running with a non-root user, the following log entry may show up in the log: `EAL: Couldn't get fd on hugepage file`. The previous log entry is likely followed by the following entry: `LPM: LPM memory allocation failed`.

This pull request addresses this problem and adds a `gkctl` script to request the reload of the policy.