### PR TITLE
gt: correct NUMA node of LPM tables

### DIFF
--- a/gt/main.c
+++ b/gt/main.c
@@ -1822,8 +1822,7 @@ alloc_lua_mem_in_dpdk(void *ud, void *ptr,
 #endif
 
 static lua_State *
-alloc_and_setup_lua_state(struct gt_config *gt_conf,
-	__attribute__((unused))unsigned int lcore_id)
+alloc_and_setup_lua_state(struct gt_config *gt_conf, unsigned int lcore_id)
 {
 	int ret;
 	char lua_entry_path[128];
@@ -1848,6 +1847,11 @@ alloc_and_setup_lua_state(struct gt_config *gt_conf,
 			__func__);
 		goto out;
 	}
+
+	/* Add lcore_id information to the registry of @lua_state. */
+	lua_pushstring(lua_state, GT_LUA_LCORE_ID_NAME);
+	lua_pushnumber(lua_state, lcore_id);
+	lua_settable(lua_state, LUA_REGISTRYINDEX);
 
 	luaL_openlibs(lua_state);
 	lualpm_openlib(lua_state);

--- a/include/gatekeeper_gt.h
+++ b/include/gatekeeper_gt.h
@@ -234,4 +234,10 @@ gt_conf_hold(struct gt_config *gt_conf)
 	rte_atomic32_inc(&gt_conf->ref_cnt);
 }
 
+/*
+ * Key in the registry of a Lua state used to run policies that points to
+ * the lcore_id where the policy runs.
+ */
+#define GT_LUA_LCORE_ID_NAME "lcore_id"
+
 #endif /* _GATEKEEPER_GT_H_ */


### PR DESCRIPTION
The Lua states that run policies are created during the initialization of Grantor, and during policy reloads. In the former case, the creation is done on the master lcore. In the latter case, on the lcore of the dynamic configuration block. Thus, the code has to guess the lcore that actually runs the policy while creating LPM tables.

This patch avoids the guessing by adding the running lcore ID to the registry of the lua states, and making the Lua LPM library to
use this information.