### PR TITLE
lua/dylib: return value from update_gt_lua_states_incrementally

### DIFF
--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -238,6 +238,6 @@ function print_lls_dump_entry(lls_dump_entry, acc)
 end
 
 function update_gt_lua_states_incrementally(gt_conf, lua_code, is_returned)
-	dylib.internal_update_gt_lua_states_incrementally(gt_conf,
+	return dylib.internal_update_gt_lua_states_incrementally(gt_conf,
 		string.dump(lua_code), is_returned)
 end


### PR DESCRIPTION
This change allow the function to actually return a value when `is_returned` is `true`.