### PR TITLE
cps: forward all TCP packets the KNI interfaces

### DIFF
--- a/include/gatekeeper_cps.h
+++ b/include/gatekeeper_cps.h
@@ -38,8 +38,6 @@ extern int cps_logtype;
 struct cps_config {
 	/* lcore that the CPS block runs on. */
 	unsigned int       lcore_id;
-	/* Source and destination TCP ports to capture BGP traffic. */
-	uint16_t           tcp_port_bgp;
 
 	/* Log level for CPS block. */
 	uint32_t           log_level;

--- a/lua/cps.lua
+++ b/lua/cps.lua
@@ -19,7 +19,6 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	local nd_max_entries_exp = 10
 
 	-- These variables are unlikely to need to be changed.
-	local tcp_port_bgp = 179
 	local num_attempts_kni_link_set = 5
 	local max_rt_update_pkts = 8
 	local scan_interval_sec = 5
@@ -46,7 +45,6 @@ return function (net_conf, gk_conf, gt_conf, lls_conf, numa_table)
 	cps_conf.front_max_pkt_burst = front_max_pkt_burst
 	cps_conf.back_max_pkt_burst = back_max_pkt_burst
 
-	cps_conf.tcp_port_bgp = tcp_port_bgp
 	cps_conf.num_attempts_kni_link_set = num_attempts_kni_link_set
 	cps_conf.max_rt_update_pkts = max_rt_update_pkts
 	cps_conf.scan_interval_sec = scan_interval_sec

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -368,7 +368,6 @@ struct gt_config {
 
 struct cps_config {
 	unsigned int lcore_id;
-	uint16_t     tcp_port_bgp;
 	uint32_t     log_level;
 	int          log_type;
 	uint32_t     log_ratelimit_interval_ms;


### PR DESCRIPTION
Instead of having a filter for a given TCP port, this patch forwards all TCP packets to the KNI interfaces. This way, even fragmented packets are delivered to the KNI interfaces and Gatekeeper users can use multiple daemons.
