### PR TITLE
gk: drop field neigh6 of struct gk_fib

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -522,7 +522,7 @@ setup_net_prefix_fib(int identifier,
 
 		ret = setup_neighbor_tbl(socket_id, (identifier * 2 + 1),
 			RTE_ETHER_TYPE_IPV6, gk_conf->max_num_ipv6_neighbors,
-			&neigh_fib_ipv6->u.neigh6, DEFAULT_HASH_FUNC);
+			&neigh_fib_ipv6->u.neigh, DEFAULT_HASH_FUNC);
 		if (ret < 0)
 			goto init_fib_ipv6;
 
@@ -627,7 +627,7 @@ free_front_fibs:
 		struct gatekeeper_if *iface = &gk_conf->net->front;
 		RTE_VERIFY(rte_lpm6_delete(gk_conf->lpm_tbl.lpm6,
 			iface->ip6_addr.s6_addr, iface->ip6_addr_plen) == 0);
-		destroy_neigh_hash_table(&neigh6_fib_front->u.neigh6);
+		destroy_neigh_hash_table(&neigh6_fib_front->u.neigh);
 		initialize_fib_entry(neigh6_fib_front);
 		neigh6_fib_front = NULL;
 	}
@@ -948,8 +948,7 @@ ether_cache_put(struct gk_fib *neigh_fib,
 	}
 
 	if (addr.proto == RTE_ETHER_TYPE_IPV4) {
-		ret = put_arp((struct in_addr *)
-			&addr.ip.v4, gk_conf->lcores[0]);
+		ret = put_arp(&addr.ip.v4, gk_conf->lcores[0]);
 		if (ret < 0)
 			return ret;
 
@@ -964,12 +963,11 @@ ether_cache_put(struct gk_fib *neigh_fib,
 	}
 
 	if (likely(addr.proto == RTE_ETHER_TYPE_IPV6)) {
-		ret = put_nd((struct in6_addr *)
-			&addr.ip.v6, gk_conf->lcores[0]);
+		ret = put_nd(&addr.ip.v6, gk_conf->lcores[0]);
 		if (ret < 0)
 			return ret;
 
-		ret = rte_hash_del_key(neighbor_fib->u.neigh6.hash_table,
+		ret = rte_hash_del_key(neighbor_fib->u.neigh.hash_table,
 			addr.ip.v6.s6_addr);
 		if (ret < 0) {
 			GK_LOG(CRIT,
@@ -2336,8 +2334,7 @@ list_ipv6_if_neighbors(lua_State *l, struct gatekeeper_if *iface,
 	neigh_fib = &ltbl->fib_tbl6[fib_id];
 	RTE_VERIFY(neigh_fib->action == action);
 
-	list_hash_table_neighbors_unlock(l, action,
-		&neigh_fib->u.neigh6, ltbl);
+	list_hash_table_neighbors_unlock(l, action, &neigh_fib->u.neigh, ltbl);
 }
 
 static void

--- a/gk/main.c
+++ b/gk/main.c
@@ -1360,24 +1360,12 @@ lookup_fe_from_lpm(struct ipacket *packet, uint32_t ip_flow_hash_val,
 	struct gk_measurement_metrics *stats = &instance->traffic_stats;
 
 	if (fib == NULL || fib->action == GK_FWD_NEIGHBOR_FRONT_NET) {
-		if (packet->flow.proto == RTE_ETHER_TYPE_IPV4) {
-			stats->tot_pkts_num_distributed++;
-			stats->tot_pkts_size_distributed +=
-				rte_pktmbuf_pkt_len(pkt);
-
+		stats->tot_pkts_num_distributed++;
+		stats->tot_pkts_size_distributed += rte_pktmbuf_pkt_len(pkt);
+		if (packet->flow.proto == RTE_ETHER_TYPE_IPV4)
 			add_pkt_acl(acl4, pkt);
-		} else if (likely(packet->flow.proto ==
-				RTE_ETHER_TYPE_IPV6)) {
-			stats->tot_pkts_num_distributed++;
-			stats->tot_pkts_size_distributed +=
-				rte_pktmbuf_pkt_len(pkt);
-
+		else
 			add_pkt_acl(acl6, pkt);
-		} else {
-			print_flow_err_msg(&packet->flow,
-				"gk: failed to get the fib entry");
-			drop_packet_front(pkt, instance);
-		}
 		return NULL;
 	}
 
@@ -1454,12 +1442,10 @@ lookup_fe_from_lpm(struct ipacket *packet, uint32_t ip_flow_hash_val,
 		 * the back network, forward accordingly.
 		 */
 		if (packet->flow.proto == RTE_ETHER_TYPE_IPV4) {
-			eth_cache = lookup_ether_cache(
-				&fib->u.neigh,
+			eth_cache = lookup_ether_cache(&fib->u.neigh,
 				&packet->flow.f.v4.dst);
 		} else {
-			eth_cache = lookup_ether_cache(
-				&fib->u.neigh6,
+			eth_cache = lookup_ether_cache(&fib->u.neigh,
 				&packet->flow.f.v6.dst);
 		}
 
@@ -1865,12 +1851,10 @@ process_fib(struct ipacket *packet, struct gk_fib *fib,
 		 * the front network, forward accordingly.
 		 */
 		if (packet->flow.proto == RTE_ETHER_TYPE_IPV4) {
-			eth_cache = lookup_ether_cache(
-				&fib->u.neigh,
+			eth_cache = lookup_ether_cache(&fib->u.neigh,
 				&packet->flow.f.v4.dst);
 		} else {
-			eth_cache = lookup_ether_cache(
-				&fib->u.neigh6,
+			eth_cache = lookup_ether_cache(&fib->u.neigh,
 				&packet->flow.f.v6.dst);
 		}
 
@@ -2387,7 +2371,7 @@ cleanup_gk(struct gk_config *gk_conf)
 			if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
 					fib->action ==
 						GK_FWD_NEIGHBOR_BACK_NET) {
-				destroy_neigh_hash_table(&fib->u.neigh6);
+				destroy_neigh_hash_table(&fib->u.neigh);
 			}
 		}
 	}

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -173,6 +173,7 @@ struct gk_fib {
 			struct route_properties props;
 		} gateway;
 
+		/* Route information when the action is GK_FWD_GRANTOR. */
 		struct {
 			/*
 			 * Set of Grantors that packets to this
@@ -187,8 +188,6 @@ struct gk_fib {
 		 * The entries can be accessed according to its IP address.
 		 */
 		struct neighbor_hash_table neigh;
-
-		struct neighbor_hash_table neigh6;
 
 		/* Route information when the action is GK_DROP. */
 		struct {


### PR DESCRIPTION
Field neigh6 is ONLY an alias to field neigh.