### PR TITLE
gk: add FIB ID to iterators

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -2058,6 +2058,7 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		dentry->addr.proto = RTE_ETHER_TYPE_IPV4;
 		dentry->addr.ip.v4.s_addr = htonl(re4->ip);
 		dentry->prefix_len = state.depth;
+		dentry->fib_id = re4->next_hop;
 		dentry->num_addr_sets = num_addrs;
 		fillup_gk_fib_dump_entry(dentry, fib);
 
@@ -2143,6 +2144,7 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		rte_memcpy(&dentry->addr.ip.v6, re6.ip,
 			sizeof(dentry->addr.ip.v6));
 		dentry->prefix_len = re6.depth;
+		dentry->fib_id = re6.next_hop;
 		dentry->num_addr_sets = num_addrs;
 		fillup_gk_fib_dump_entry(dentry, fib);
 

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -2007,12 +2007,10 @@ static void
 list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 {
 	int ret, index;
-	struct gk_fib *fib;
 	const struct rte_lpm_rule *re4;
 	struct rte_lpm_iterator_state state;
 	struct gk_fib_dump_entry *dentry = NULL;
 	size_t dentry_size = 0;
-	void *cdata;
 	uint32_t correct_ctypeid_fib_dump_entry = luaL_get_ctypeid(l,
 		CTYPE_STRUCT_FIB_DUMP_ENTRY_PTR);
 
@@ -2029,8 +2027,9 @@ list_ipv4_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		unsigned int num_addrs;
 		size_t new_dentry_size;
 		int done;
+		void *cdata;
 
-		fib = &ltbl->fib_tbl[re4->next_hop];
+		struct gk_fib *fib = &ltbl->fib_tbl[re4->next_hop];
 		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
 				fib->action == GK_FWD_NEIGHBOR_BACK_NET) {
 			index = rte_lpm_rule_iterate(&state, &re4);
@@ -2092,12 +2091,10 @@ static void
 list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 {
 	int ret, index;
-	struct gk_fib *fib;
 	struct rte_lpm6_rule re6;
 	struct rte_lpm6_iterator_state state6;
 	struct gk_fib_dump_entry *dentry = NULL;
 	size_t dentry_size = 0;
-	void *cdata;
 	uint32_t correct_ctypeid_fib_dump_entry = luaL_get_ctypeid(l,
 		CTYPE_STRUCT_FIB_DUMP_ENTRY_PTR);
 
@@ -2114,8 +2111,9 @@ list_ipv6_fib_entries(lua_State *l, struct gk_lpm *ltbl)
 		unsigned int num_addrs;
 		size_t new_dentry_size;
 		int done;
+		void *cdata;
 
-		fib = &ltbl->fib_tbl6[re6.next_hop];
+		struct gk_fib *fib = &ltbl->fib_tbl6[re6.next_hop];
 		if (fib->action == GK_FWD_NEIGHBOR_FRONT_NET ||
 				fib->action == GK_FWD_NEIGHBOR_BACK_NET) {
 			index = rte_lpm6_rule_iterate(&state6, &re6);

--- a/gk/fib.c
+++ b/gk/fib.c
@@ -1944,10 +1944,9 @@ fillup_gk_fib_dump_entry_ether(struct fib_dump_addr_set *addr_set,
 	struct ether_cache *eth_cache)
 {
 	addr_set->stale = eth_cache->stale;
-	rte_memcpy(&addr_set->nexthop_ip, &eth_cache->ip_addr,
-		sizeof(addr_set->nexthop_ip));
-	rte_memcpy(&addr_set->d_addr, &eth_cache->l2_hdr.eth_hdr.d_addr,
-		sizeof(addr_set->d_addr));
+	addr_set->nexthop_ip = eth_cache->ip_addr;
+	rte_ether_addr_copy(&eth_cache->l2_hdr.eth_hdr.d_addr,
+		&addr_set->d_addr);
 }
 
 static void
@@ -1958,9 +1957,8 @@ fillup_gk_fib_dump_entry(struct gk_fib_dump_entry *dentry, struct gk_fib *fib)
 	case GK_FWD_GRANTOR: {
 		unsigned int i;
 		for (i = 0; i < dentry->num_addr_sets; i++) {
-			rte_memcpy(&dentry->addr_sets[i].grantor_ip,
-				&fib->u.grantor.set->entries[i].gt_addr,
-				sizeof(dentry->addr_sets[i].grantor_ip));
+			dentry->addr_sets[i].grantor_ip =
+				fib->u.grantor.set->entries[i].gt_addr;
 			fillup_gk_fib_dump_entry_ether(&dentry->addr_sets[i],
 				fib->u.grantor.set->entries[i].eth_cache);
 		}

--- a/gkctl/scripts/check_fibs.lua
+++ b/gkctl/scripts/check_fibs.lua
@@ -1,0 +1,47 @@
+require "gatekeeper/staticlib"
+
+local dyc = staticlib.c.get_dy_conf()
+if dyc == nil then
+	return "No dynamic configuration block available"
+end
+if dyc.gk == nil then
+	return "No GK block available; not a Gatekeeper server"
+end
+
+local function new_summary()
+	return { dup_fib_ids = {}, present_fib_ids = {} }
+end
+
+local function summarize_fib(fib_dump_entry, acc)
+	local fib_id = fib_dump_entry.fib_id
+	local present_fib_ids = acc.present_fib_ids
+
+	if present_fib_ids[fib_id] == nil then
+		present_fib_ids[fib_id] = 1
+	else
+		present_fib_ids[fib_id] = present_fib_ids[fib_id] + 1
+		if present_fib_ids[fib_id] == 2 then
+			table.insert(acc.dup_fib_ids, fib_id)
+		end
+	end
+
+	return false, acc
+end
+
+local function report_summary(output, summary)
+	table.sort(summary.dup_fib_ids)
+	for _, fib_id in ipairs(summary.dup_fib_ids) do
+		output[#output + 1] = "\t"
+		output[#output + 1] = tostring(fib_id)
+		output[#output + 1] = ": "
+		output[#output + 1] = tostring(summary.present_fib_ids[fib_id])
+		output[#output + 1] = "\n"
+	end
+end
+
+local output = {}
+output[#output + 1] = "IPv4 summary (Duplicate FIB ID: count):\n"
+report_summary(output, dylib.list_gk_fib4(dyc.gk, summarize_fib, new_summary()))
+output[#output + 1] = "\nIPv6 summary (Duplicate FIB ID: count):\n"
+report_summary(output, dylib.list_gk_fib6(dyc.gk, summarize_fib, new_summary()))
+return table.concat(output)

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -255,6 +255,9 @@ struct gk_fib_dump_entry {
 	/* The FIB action. */
 	enum gk_fib_action action;
 
+	/* Unique ID of this FIB entry. */
+	unsigned int  fib_id;
+
 	/*
 	 * The number of entries starting at @addr_sets.
 	 *

--- a/lua/gatekeeper/dylib.lua
+++ b/lua/gatekeeper/dylib.lua
@@ -53,6 +53,7 @@ struct gk_fib_dump_entry {
 	struct ipaddr addr;
 	int           prefix_len;
 	enum gk_fib_action action;
+	unsigned int  fib_id;
 	unsigned int  num_addr_sets;
 	struct fib_dump_addr_set addr_sets[0];
 };


### PR DESCRIPTION
The first two patches tighten up the code in `gk/fib.c`, whereas the third patch adds the FIB IDs of the FIB entries to the iterators available to the dynamic configuration block.