### PR TITLE
Gatekeeper: optimize logging for production

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -1595,7 +1595,7 @@ add_fib_entry_numerical(struct ip_prefix *prefix_info,
 		return -1;
 	} else {
 		/* Clarify LPM lookup miss that will occur in log. */
-		GK_LOG(NOTICE, "Prefix lookup did not find existing neighbor FIB on front interface, as expected\n");
+		GK_LOG(INFO, "Prefix lookup did not find existing neighbor FIB on front interface, as expected\n");
 	}
 
 	neigh_fib = find_fib_entry_for_neighbor_locked(
@@ -1605,7 +1605,7 @@ add_fib_entry_numerical(struct ip_prefix *prefix_info,
 		return -1;
 	} else {
 		/* Clarify LPM lookup miss that will occur in log. */
-		GK_LOG(NOTICE, "Prefix lookup did not find existing neighbor FIB on back interface, as expected\n");
+		GK_LOG(INFO, "Prefix lookup did not find existing neighbor FIB on back interface, as expected\n");
 	}
 
 	for (i = 0; i < num_addrs; i++) {

--- a/lls/main.c
+++ b/lls/main.c
@@ -572,7 +572,17 @@ process_pkts(struct lls_config *lls_conf, struct gatekeeper_if *iface,
 			 */
 
 		default:
-			LLS_LOG(ERR, "%s interface should not be seeing a packet with EtherType 0x%04hx\n",
+			/*
+			 * The log level of the following log entry cannot be
+			 * ERR because NICs typically send unmatched patckets
+			 * to queue 0, which the LLS block often serves.
+			 *
+			 * The log level cannot be WARNING either because
+			 * Gatekeeper servers have to tolerate unwanted
+			 * traffic at some vantage points and LLS blocks
+			 * typically run at WARNING level.
+			 */
+			LLS_LOG(NOTICE, "%s interface should not be seeing a packet with EtherType 0x%04hx\n",
 				iface->name, ether_type);
 			goto free_buf;
 		}


### PR DESCRIPTION
This pull request reduces log in production by lowering the priority of some log entries that do not add much in production,
are logged often, and are unavoidable.