### PR TITLE
gk: heal corrupted flow tables

### DIFF
--- a/include/gatekeeper_flow.h
+++ b/include/gatekeeper_flow.h
@@ -45,6 +45,6 @@ uint32_t rss_ip_flow_hf(const void *data,
 
 int ip_flow_cmp_eq(const void *key1, const void *key2, size_t key_len);
 
-void print_flow_err_msg(struct ip_flow *flow, const char *err_msg);
+void print_flow_err_msg(const struct ip_flow *flow, const char *err_msg);
 
 #endif /* _GATEKEEPER_FLOW_H_ */

--- a/include/gatekeeper_flow.h
+++ b/include/gatekeeper_flow.h
@@ -45,6 +45,12 @@ uint32_t rss_ip_flow_hf(const void *data,
 
 int ip_flow_cmp_eq(const void *key1, const void *key2, size_t key_len);
 
+static inline bool
+flow_key_eq(const struct ip_flow *f1, const struct ip_flow *f2)
+{
+	return ip_flow_cmp_eq(f1, f2, sizeof(*f1)) == 0;
+}
+
 void print_flow_err_msg(const struct ip_flow *flow, const char *err_msg);
 
 #endif /* _GATEKEEPER_FLOW_H_ */

--- a/include/gatekeeper_gk.h
+++ b/include/gatekeeper_gk.h
@@ -113,11 +113,33 @@ struct gk_instance {
 	struct token_bucket_ratelimit_state front_icmp_rs;
 	struct token_bucket_ratelimit_state back_icmp_rs;
 	unsigned int num_scan_del;
-	/*
-	 * The memory pool used for packet buffers in this instance.
-	 */
+	/* The memory pool used for packet buffers in this instance. */
 	struct rte_mempool *mp;
 	struct sol_instance *sol_inst;
+	/*
+	 * Control of expired flow entries and healing flow table.
+	 *
+	 * When corruption is identified in the flow table, @scan_waiting_eoc
+	 * becomes true, and @scan_end_cycle_idx receives the value of
+	 * @scan_cur_flow_idx.
+	 *
+	 * "eoc" in @scan_waiting_eoc stands for end of cycle.
+	 *
+	 * A cycle is a full scan of the flow entries of this instance.
+	 * That is, a scan of @ip_flow_entry_table.
+	 * A cycle is only tracked when @scan_waiting_eoc is true.
+	 *
+	 * When a cycle completes, that is @scan_cur_flow_idx becomes equal to
+	 * @scan_end_cycle_idx after being incremented, @scan_waiting_eoc
+	 * becomes false. When a cycle is completed, the keys of the flow table
+	 * (i.e. a scan of @ip_flow_hash_table) are scanned for corruption.
+	 */
+	/* When true, field @scan_end_cycle_idx has a valid value. */
+	bool     scan_waiting_eoc;
+	/* Index of the current flow entry being tested for expiration. */
+	uint32_t scan_cur_flow_idx;
+	/* Index of the end of cycle. */
+	uint32_t scan_end_cycle_idx;
 } __rte_cache_aligned;
 
 #define GK_MAX_BPF_FLOW_HANDLERS	(UINT8_MAX + 1)


### PR DESCRIPTION
On rare occasions, the flow table of a GK instance may be corrupted. This has been seen in a Gatekeeper server in production running for a month without a reboot. The problem can be identified with the presence of log entries similar to the one below:
```
GATEKEEPER: flow: The GK block failed to delete a key from hash table at gk_del_flow_entry_from_hash: No such file or directory
 for the flow with IP source address 1.1.1.1, and destination address 2.2.2.2
```
The IP addresses in the log entry above have been anonymized.

While Gatekeeper keeps going, if corruption keeps happening, a reboot will be eventually required. If no more corruption is added, the log of Gatekeeper will be full of warnings and errors.

This patch identifies corruption, heal the flow table, and log information that will enable one to track down the source of corruption. Once the flow table is healed, Gatekeeper will keep working normally and without extra log entries besides the ones added during the healing process.