### PR TITLE
Add prefix "BLOCK/LCORE:" to log entries

### DIFF
--- a/config/dynamic.c
+++ b/config/dynamic.c
@@ -623,8 +623,7 @@ dyn_cfg_proc(void *arg)
 	uint32_t lcore = dy_conf->lcore_id;
 
 	G_LOG(NOTICE,
-		"The Dynamic Config block is running at: lcore = %u; tid = %u\n",
-		lcore, gettid());
+		"The Dynamic Config block is running at tid = %u\n", gettid());
 
 	if (dy_conf->gt != NULL) {
 		/*
@@ -705,8 +704,7 @@ dyn_cfg_proc(void *arg)
 		handle_client(dy_conf->sock_fd, dy_conf);
 	}
 
-	G_LOG(NOTICE,
-		"The Dynamic Config block at lcore = %u is exiting\n", lcore);
+	G_LOG(NOTICE, "The Dynamic Config block is exiting\n");
 
 	cleanup_dy(dy_conf);
 

--- a/config/dynamic.c
+++ b/config/dynamic.c
@@ -657,12 +657,12 @@ dyn_cfg_proc(void *arg)
 		 * its Unix socket while exiting.
 		 */
 		cap_value_t caps[] = {CAP_DAC_OVERRIDE, CAP_SYS_ADMIN};
-		if (needed_caps("DYC", RTE_DIM(caps), caps) < 0) {
+		if (needed_caps(RTE_DIM(caps), caps) < 0) {
 			G_LOG(ERR, "Could not set needed capabilities for Grantor\n");
 			exiting = true;
 		}
 	} else {
-		if (needed_caps("DYC", 0, NULL) < 0) {
+		if (needed_caps(0, NULL) < 0) {
 			G_LOG(ERR, "Could not set needed capabilities\n");
 			exiting = true;
 		}

--- a/cps/main.c
+++ b/cps/main.c
@@ -501,7 +501,7 @@ cps_proc(void *arg)
 	G_LOG(NOTICE, "The CPS block is running at: lcore = %u; tid = %u\n",
 		cps_conf->lcore_id, gettid());
 
-	if (needed_caps("CPS", RTE_DIM(caps), caps) < 0) {
+	if (needed_caps(RTE_DIM(caps), caps) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}

--- a/cps/main.c
+++ b/cps/main.c
@@ -498,8 +498,7 @@ cps_proc(void *arg)
 	 */
 	cap_value_t caps[] = {CAP_NET_ADMIN, CAP_SYS_MODULE};
 
-	G_LOG(NOTICE, "The CPS block is running at: lcore = %u; tid = %u\n",
-		cps_conf->lcore_id, gettid());
+	G_LOG(NOTICE, "The CPS block is running at tid = %u\n", gettid());
 
 	if (needed_caps(RTE_DIM(caps), caps) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
@@ -554,8 +553,7 @@ cps_proc(void *arg)
 		rd_process_events(cps_conf);
 	}
 
-	G_LOG(NOTICE, "The CPS block at lcore = %u is exiting\n",
-		cps_conf->lcore_id);
+	G_LOG(NOTICE, "The CPS block is exiting\n");
 
 	return cleanup_cps();
 }

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -606,8 +606,7 @@ ggu_proc(void *arg)
 	uint16_t rx_queue = ggu_conf->rx_queue_back;
 	uint16_t max_pkt_burst = ggu_conf->max_pkt_burst;
 
-	G_LOG(NOTICE, "The GT-GK unit is running at: lcore = %u; tid = %u\n",
-		lcore, gettid());
+	G_LOG(NOTICE, "The GT-GK unit is running at tid = %u\n", gettid());
 
 	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
@@ -628,7 +627,7 @@ ggu_proc(void *arg)
 			process_mb(ggu_conf);
 	}
 
-	G_LOG(NOTICE, "The GT-GK unit at lcore = %u is exiting\n", lcore);
+	G_LOG(NOTICE, "The GT-GK unit is exiting\n");
 	return cleanup_ggu(ggu_conf);
 }
 

--- a/ggu/main.c
+++ b/ggu/main.c
@@ -609,7 +609,7 @@ ggu_proc(void *arg)
 	G_LOG(NOTICE, "The GT-GK unit is running at: lcore = %u; tid = %u\n",
 		lcore, gettid());
 
-	if (needed_caps("GGU", 0, NULL) < 0) {
+	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}

--- a/gk/main.c
+++ b/gk/main.c
@@ -2491,8 +2491,7 @@ gk_proc(void *arg)
 	uint32_t scan_iter = gk_conf->flow_table_scan_iter;
 	uint32_t iter_count = 0;
 
-	G_LOG(NOTICE, "The GK block is running at: lcore = %u; tid = %u\n",
-		lcore, gettid());
+	G_LOG(NOTICE, "The GK block is running at tid = %u\n", gettid());
 
 	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
@@ -2576,7 +2575,7 @@ gk_proc(void *arg)
 		}
 	}
 
-	G_LOG(NOTICE, "The GK block at lcore = %u is exiting\n", lcore);
+	G_LOG(NOTICE, "The GK block is exiting\n");
 
 	return gk_conf_put(gk_conf);
 }

--- a/gk/main.c
+++ b/gk/main.c
@@ -2494,7 +2494,7 @@ gk_proc(void *arg)
 	G_LOG(NOTICE, "The GK block is running at: lcore = %u; tid = %u\n",
 		lcore, gettid());
 
-	if (needed_caps("GK", 0, NULL) < 0) {
+	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}

--- a/gt/main.c
+++ b/gt/main.c
@@ -1558,8 +1558,7 @@ gt_proc(void *arg)
 	death_row.cnt = 0;
 	gt_max_pkt_burst = gt_conf->max_pkt_burst;
 
-	G_LOG(NOTICE, "The GT block is running at: lcore = %u; tid = %u\n",
-		lcore, gettid());
+	G_LOG(NOTICE, "The GT block is running at tid = %u\n", gettid());
 
 	if (needed_caps(RTE_DIM(caps), caps) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
@@ -1744,7 +1743,7 @@ gt_proc(void *arg)
 			flush_notify_pkts(gt_conf, instance);
 	}
 
-	G_LOG(NOTICE, "The GT block at lcore = %u is exiting\n", lcore);
+	G_LOG(NOTICE, "The GT block is exiting\n");
 
 	return gt_conf_put(gt_conf);
 }

--- a/gt/main.c
+++ b/gt/main.c
@@ -1561,7 +1561,7 @@ gt_proc(void *arg)
 	G_LOG(NOTICE, "The GT block is running at: lcore = %u; tid = %u\n",
 		lcore, gettid());
 
-	if (needed_caps("GT", RTE_DIM(caps), caps) < 0) {
+	if (needed_caps(RTE_DIM(caps), caps) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}

--- a/include/gatekeeper_log_ratelimit.h
+++ b/include/gatekeeper_log_ratelimit.h
@@ -87,4 +87,18 @@ int set_log_level_per_lcore(unsigned int lcore_id, uint32_t log_level);
 /* Get the block name for the corresponding lcore. */
 const char *get_block_name(unsigned int lcore_id);
 
+struct log_ratelimit_state {
+	uint64_t       interval_cycles;
+	uint32_t       burst;
+	uint32_t       printed;
+	uint32_t       suppressed;
+	uint64_t       end;
+	rte_atomic32_t log_level;
+	char           block_name[16];
+} __rte_cache_aligned;
+
+/* Only use these variables in file lib/log_ratelimit.c and in macro G_LOG(). */
+extern struct log_ratelimit_state log_ratelimit_states[RTE_MAX_LCORE];
+extern bool log_ratelimit_enabled;
+
 #endif /* _GATEKEEPER_LOG_RATELIMIT_H_ */

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -33,10 +33,20 @@
 #include "list.h"
 
 #define BLOCK_LOGTYPE RTE_LOGTYPE_USER1
+#define G_LOG_PREFIX "%s/%u: "
 
-#define G_LOG(level, ...)			\
-	rte_log_ratelimit(RTE_LOG_ ## level,	\
-	BLOCK_LOGTYPE, "GATEKEEPER: " __VA_ARGS__)
+#define G_LOG(level, fmt, ...)						\
+	do {								\
+		unsigned int __g_log_lcore_id = rte_lcore_id();		\
+		const char *__g_log_block_name =			\
+			likely(log_ratelimit_enabled)			\
+			? log_ratelimit_states[__g_log_lcore_id]	\
+				.block_name				\
+			: "Main";					\
+		rte_log_ratelimit(RTE_LOG_ ## level, BLOCK_LOGTYPE,	\
+			G_LOG_PREFIX fmt, __g_log_block_name,		\
+			__g_log_lcore_id __VA_OPT__(,) __VA_ARGS__);	\
+	} while (0)
 
 #define G_LOG_CHECK(level) check_log_allowed(RTE_LOG_ ## level)
 

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -550,11 +550,9 @@ int ipv6_pkt_filter_add(struct gatekeeper_if *iface,
  * except for those needed by a block.
  *
  * @caps contains the @ncap number of entries that
- * the block wants to keep. @block is the name of
- * the calling block, used for logging purposes,
- * and must not be NULL.
+ * the block wants to keep.
  */
-int needed_caps(const char *block, int ncap, const cap_value_t *caps);
+int needed_caps(int ncap, const cap_value_t *caps);
 
 struct net_config *get_net_conf(void);
 struct gatekeeper_if *get_if_front(struct net_config *net_conf);

--- a/lls/main.c
+++ b/lls/main.c
@@ -608,7 +608,7 @@ lls_proc(void *arg)
 	G_LOG(NOTICE, "The LLS block is running at: lcore = %u; tid = %u\n",
 		lls_conf->lcore_id, gettid());
 
-	if (needed_caps("LLS", 0, NULL) < 0) {
+	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}

--- a/lls/main.c
+++ b/lls/main.c
@@ -605,8 +605,7 @@ lls_proc(void *arg)
 	uint64_t timer_resolution_cycles =
 		net_conf->rotate_log_interval_sec * cycles_per_sec;
 
-	G_LOG(NOTICE, "The LLS block is running at: lcore = %u; tid = %u\n",
-		lls_conf->lcore_id, gettid());
+	G_LOG(NOTICE, "The LLS block is running at tid = %u\n", gettid());
 
 	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
@@ -679,8 +678,7 @@ lls_proc(void *arg)
 		}
 	}
 
-	G_LOG(NOTICE, "The LLS block at lcore = %u is exiting\n",
-		lls_conf->lcore_id);
+	G_LOG(NOTICE, "The LLS block is exiting\n");
 
 	return cleanup_lls();
 }

--- a/main/main.c
+++ b/main/main.c
@@ -281,7 +281,7 @@ time_resolution_init(void)
 	picosec_per_cycle = 1000UL * diff_ns / cycles;
 
 	G_LOG(NOTICE,
-		"main: cycles/second = %" PRIu64 ", cycles/millisecond = %" PRIu64 ", picosec/cycle = %" PRIu64 "\n",
+		"cycles/second = %" PRIu64 ", cycles/millisecond = %" PRIu64 ", picosec/cycle = %" PRIu64 "\n",
 		cycles_per_sec, cycles_per_ms, picosec_per_cycle);
 
 	return 0;
@@ -421,7 +421,7 @@ main(int argc, char **argv)
 
 	ret = config_gatekeeper(args.lua_base_dir, args.gatekeeper_config_file);
 	if (ret < 0) {
-		G_LOG(ERR, "main: failed to configure Gatekeeper\n");
+		G_LOG(ERR, "Failed to configure Gatekeeper\n");
 		goto net;
 	}
 

--- a/sol/main.c
+++ b/sol/main.c
@@ -567,7 +567,7 @@ sol_proc(void *arg)
 		"The Solicitor block is running at: lcore = %u; tid = %u\n",
 		lcore, gettid());
 
-	if (needed_caps("SOL", 0, NULL) < 0) {
+	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
 		exiting = true;
 	}

--- a/sol/main.c
+++ b/sol/main.c
@@ -563,9 +563,7 @@ sol_proc(void *arg)
 	struct sol_instance *instance = &sol_conf->instances[block_idx];
 	uint8_t tx_port_back = sol_conf->net->back.id;
 
-	G_LOG(NOTICE,
-		"The Solicitor block is running at: lcore = %u; tid = %u\n",
-		lcore, gettid());
+	G_LOG(NOTICE, "The Solicitor block is running at tid = %u\n", gettid());
 
 	if (needed_caps(0, NULL) < 0) {
 		G_LOG(ERR, "Could not set needed capabilities\n");
@@ -579,8 +577,7 @@ sol_proc(void *arg)
 		dequeue_reqs(sol_conf, instance, tx_port_back);
 	}
 
-	G_LOG(NOTICE,
-		"The Solicitor block at lcore = %u is exiting\n", lcore);
+	G_LOG(NOTICE, "The Solicitor block is exiting\n");
 
 	return sol_conf_put(sol_conf);
 }


### PR DESCRIPTION
This pull request improves the format of log entries and takes advantage of the new format to polish several log entries. The new format prefixes all log entries with "BLOCK/LCORE:". Notice that only log entries that Gatekeeper produces are affected, log entries coming from DPDK are not.

This pull request closes #497