### PR TITLE
lls: fix ICMPv6 checksum

### DIFF
--- a/lls/nd.c
+++ b/lls/nd.c
@@ -626,7 +626,7 @@ nd_pkt_valid(struct rte_ipv6_hdr *ipv6_hdr, struct icmpv6_hdr *icmpv6_hdr,
 	return ipv6_hdr->hop_limits == 255 &&
 		rte_be_to_cpu_16(ipv6_hdr->payload_len) == icmpv6_len &&
 		icmpv6_hdr->code == 0 &&
-		rte_ipv6_icmpv6_cksum(ipv6_hdr, icmpv6_hdr) == 0xFFFF;
+		rte_ipv6_icmpv6_cksum(ipv6_hdr, icmpv6_hdr) == 0;
 }
 
 int


### PR DESCRIPTION
DPDK's commit [d5df2ae0428a147b80bbb65d623f88f75d28b226](https://git.dpdk.org/dpdk-stable/commit/?id=d5df2ae0428a147b80bbb65d623f88f75d28b226) corrected the checksum of TCP by not turning a zero checksum into `0xFFFF` as it is done for UDP.  That fix also corrects the ICMPv6 checksum used in Gatekeeper, but `nd_pkt_valid()` was relying on the return being `0xFFFF` to test that the checksum was correct.