### PR TITLE
cps: avoid deadlock after listing IPv6 LPM table

### DIFF
--- a/cps/rd.c
+++ b/cps/rd.c
@@ -878,6 +878,7 @@ rd_getroute_ipv6(struct cps_config *cps_conf, struct gk_lpm *ltbl,
 		index = rte_lpm6_rule_iterate(&state6, &re6);
 	}
 
+	rte_spinlock_unlock_tm(&ltbl->lock);
 	return 0;
 }
 


### PR DESCRIPTION
`rd_getroute_ipv6()` is not releasing the lock after listing the IPv6 LPM table.  This patch unlocks the lock before `rd_getroute_ipv6()` returns.

Pull request #529 introduced this bug.