### PR TITLE
gatekeeper: enable multicast on bonds when LACP is used

### DIFF
--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -440,16 +440,22 @@ extern uint8_t rss_key_be[RTE_DIM(default_rss_key)];
 		0xFF, ipv6[13], ipv6[14], ipv6[15],	\
 	}
 
+/* Call lacp_enabled() instead this function wherever possible. */
+static inline int
+__lacp_enabled(struct gatekeeper_if *iface)
+{
+	return	iface->bonding_mode == BONDING_MODE_8023AD;
+}
+
 static inline int
 lacp_enabled(struct net_config *net, struct gatekeeper_if *iface)
 {
 	/* When @iface is the back, need to make sure it's enabled. */
 	if (iface == &net->back)
-		return net->back_iface_enabled &&
-			iface->bonding_mode == BONDING_MODE_8023AD;
+		return net->back_iface_enabled && __lacp_enabled(iface);
 
 	/* @iface is the front interface. */
-	return iface->bonding_mode == BONDING_MODE_8023AD;
+	return __lacp_enabled(iface);
 }
 
 int lua_init_iface(struct gatekeeper_if *iface, const char *iface_name,


### PR DESCRIPTION
Before DPDK's commit [68218b87c184e2dbea1ca3540a92a849240c115f](https://git.dpdk.org/dpdk-stable/commit/?id=68218b87c184e2dbea1ca3540a92a849240c115f), the slaves of bond interfaces would run in promiscuous mode when LACP was used. Now, slaves use multicast when LACP is used. But, without enabling multicast at the bond interface,
`rx_burst_8023ad()` of the bonding driver of DPDK drops multicast packets such as ARP and ND packets.