### PR TITLE
gk: add a Routing Information Base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SRCS-y += sol/main.c
 
 # Libraries.
 SRCS-y += lib/mailbox.c lib/net.c lib/flow.c lib/ipip.c \
-	lib/launch.c lib/lpm.c lib/acl.c lib/varip.c \
+	lib/launch.c lib/lpm.c lib/rib.c lib/acl.c lib/varip.c \
 	lib/l2.c lib/ratelimit.c lib/memblock.c lib/log_ratelimit.c lib/coro.c
 
 BUILD_DIR := build

--- a/gk/main.c
+++ b/gk/main.c
@@ -2614,11 +2614,13 @@ alloc_gk_conf(void)
 static void
 destroy_gk_lpm(struct gk_lpm *ltbl)
 {
+	rib_free(&ltbl->rib);
 	destroy_ipv4_lpm(ltbl->lpm);
 	ltbl->lpm = NULL;
 	rte_free(ltbl->fib_tbl);
 	ltbl->fib_tbl = NULL;
 
+	rib_free(&ltbl->rib6);
 	destroy_ipv6_lpm(ltbl->lpm6);
 	ltbl->lpm6 = NULL;
 	rte_free(ltbl->fib_tbl6);

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -28,6 +28,7 @@
 
 #include "gatekeeper_net.h"
 #include "gatekeeper_lpm.h"
+#include "gatekeeper_rib.h"
 #include "seqlock.h"
 
 enum gk_fib_action {
@@ -196,27 +197,27 @@ struct gk_fib {
 	} u;
 };
 
-/* Structure for the GK global LPM table. */
+/* The global LPM table of Gatekeeper servers (not Grantor servers). */
 struct gk_lpm {
 	/* Use a spin lock to edit the FIB table. */
 	rte_spinlock_t  lock;
 
-	/* The IPv4 LPM table shared by the GK instances on the same socket. */
+	/* The IPv4 RIB. */
+	struct rib_head rib;
+
+	/* The IPv4 FIB. */
 	struct rte_lpm  *lpm;
 
-	/*
-	 * The fib table for IPv4 LPM table that
-	 * decides the actions on packets.
-	 */
+	/* The IPv4 FIB table that decides the actions on packets. */
 	struct gk_fib   *fib_tbl;
 
-	/* The IPv6 LPM table shared by the GK instances on the same socket. */
+	/* The IPv6 RIB. */
+	struct rib_head rib6;
+
+	/* The IPv6 FIB. */
 	struct rte_lpm6 *lpm6;
 
-	/*
-	 * The fib table for IPv6 LPM table that
-	 * decides the actions on packets.
-	 */
+	/* The IPv6 FIB table that decides the actions on packets. */
 	struct gk_fib   *fib_tbl6;
 };
 

--- a/include/gatekeeper_log_ratelimit.h
+++ b/include/gatekeeper_log_ratelimit.h
@@ -22,6 +22,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <rte_atomic.h> /* Needed for rte_atomic32_t. */
+
 /*
  * At startup, log ratelimiting is disabled so that all
  * startup logs are captured. Before the blocks start,

--- a/include/gatekeeper_lpm.h
+++ b/include/gatekeeper_lpm.h
@@ -33,26 +33,11 @@ struct rte_lpm *init_ipv4_lpm(const char *tag,
 	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
 int lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip);
 
-static inline int
-lpm_is_rule_present(struct rte_lpm *lpm, rte_be32_t ip, uint8_t depth,
-	uint32_t *next_hop)
-{
-	return rte_lpm_is_rule_present(lpm, rte_be_to_cpu_32(ip), depth,
-		next_hop);
-}
-
 /* Similar to init_ipv4_lpm(), see above. */
 struct rte_lpm6 *init_ipv6_lpm(const char *tag,
 	const struct rte_lpm6_config *lpm6_conf,
 	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
 int lpm_lookup_ipv6(struct rte_lpm6 *lpm, struct in6_addr *ip);
-
-static inline int
-lpm6_is_rule_present(struct rte_lpm6 *lpm, uint8_t *ip, uint8_t depth,
-	uint32_t *next_hop)
-{
-	return rte_lpm6_is_rule_present(lpm, ip, depth, next_hop);
-}
 
 static inline void
 destroy_ipv4_lpm(struct rte_lpm *lpm)

--- a/include/gatekeeper_rib.h
+++ b/include/gatekeeper_rib.h
@@ -1,0 +1,351 @@
+/*
+ * Gatekeeper - DDoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GATEKEEPER_GK_RIB_H_
+#define _GATEKEEPER_GK_RIB_H_
+
+#include <stdint.h>
+#include <setjmp.h>
+
+#include <rte_mempool.h>
+
+typedef unsigned __int128 uint128_t;
+
+/*
+ * Internal representation of an address.
+ * Unless explicitly noticed, the bits are in host order.
+ */
+typedef uint128_t rib_address_t;
+
+#define RIB_MAX_ADDRESS_LENGTH ((int)sizeof(rib_address_t) * 8)
+
+typedef uint64_t rib_prefix_bits_t;
+
+#define RIB_MAX_PREFIX_BITS ((int)sizeof(rib_prefix_bits_t) * 8)
+
+struct rib_node {
+	/*
+	 * Bits of the prefix to be matched.
+	 * These bits are kept in host order,
+	 * so they can be directly operated on.
+	 */
+	rib_prefix_bits_t pfx_bits;
+	/* The number of bits present in @pfx_bits. */
+	uint8_t           matched_bits;
+	/* True if there is a value at @next_hop. */
+	bool              has_nh;
+	/* Next hop if the prefix matches all @matched_bits bits. */
+	uint32_t          next_hop;
+	/*
+	 * The branches after this node.
+	 * @branch[false] is the branch that follows this node when the first
+	 * not-matched bit is zero, and @branch[true] when the first
+	 * not-matched bit is one.
+	 * @branch[false] or @branch[true] is NULL when those branches
+	 * do not exist.
+	 */
+	struct rib_node   *branch[2];
+};
+
+struct rib_head {
+	/* Maximum length of a network address. */
+	uint8_t            max_length;
+
+	/*
+	 * Version of the RIB.
+	 * @version changes every time the RIB is edited.
+	 * The main purpose of this field is to support iterators.
+	 */
+	uint64_t           version;
+
+	/*
+	 * Root of the prefix tree.
+	 *
+	 * When the field @has_nh is true, the RIB has the default prefix
+	 * (i.e. the zero-length prefix). When the default prefix is present,
+	 * its next hop is at field @next_hop.
+	 *
+	 * This is the only node in the prefix tree that has field
+	 * @matched_bits equal to zero, all other nodes have a value
+	 * greater than zero at this field.
+	 */
+	struct rib_node    root_node;
+
+	/* Memory pool for instances of struct rib_node. */
+	struct rte_mempool *mp_nodes;
+};
+
+/*
+ * Create a new RIB.
+ *
+ * @name of the internal memory pool used to allocate the nodes of
+ * the prefix tree.
+ *
+ * @socket_id is the NUMA node on which internal memory is allocated.
+ * The value can be SOCKET_ID_ANY if there is no NUMA constraint.
+ *
+ * @max_length is the maximum length of a network address.
+ * @max_length must be a multiple of 8 and not greater than
+ * RIB_MAX_ADDRESS_LENGTH.
+ * Typical values: 32 for IPv4 and 128 for IPv6.
+ *
+ * @max_rules is the maximum number of rules (i.e. a prefix and a next hop)
+ * that this RIB is expected to have. If the RIB has space for more rules,
+ * it will take extra rules. Inspite of the name, this parameter is meant
+ * to mean the minimum number of rules that the RIB will support.
+ * The chosen name is meant to match the name of the field max_rules in
+ * struct rte_lpm_config and struct rte_lpm6_config.
+ */
+int rib_create(struct rib_head *rib, const char *name, int socket_id,
+	uint8_t max_length, uint32_t max_rules);
+
+/* Free all resources associated to @rib but the memory pointed by it. */
+void rib_free(struct rib_head *rib);
+
+/*
+ * Add a rule to the RIB.
+ * @address is in network order (big endian).
+ * @address == NULL is equivalent to the all-zero address.
+ * RETURN
+ * 	-EEXIST if prefix already exist in @rib.
+ * 	0 if it successfully adds the new rule.
+ */
+int rib_add(struct rib_head *rib, const uint8_t *address, uint8_t depth,
+	uint32_t next_hop);
+
+/*
+ * Delete a rule from the RIB.
+ * @address is in network order (big endian).
+ * @address == NULL is equivalent to the all-zero address.
+ * RETURN
+ * 	-ENOENT if the prefix does not exist in @rib.
+ * 	0 if it successfully deletes the rule.
+ */
+int rib_delete(struct rib_head *rib, const uint8_t *address, uint8_t depth);
+
+/*
+ * Look an address up on the RIB.
+ * @address is in network order (big endian).
+ * @address == NULL is equivalent to the all-zero address.
+ */
+int rib_lookup(const struct rib_head *rib, const uint8_t *address,
+	uint32_t *pnext_hop);
+
+/*
+ * Check if a rule is present in the RIB, and provide its next hop if it is.
+ * @address is in network order (big endian).
+ * @address == NULL is equivalent to the all-zero address.
+ * RETURN
+ * 	1 if the rule exists.
+ * 	0 if it does not.
+ * 	A negative value on failure.
+ */
+int rib_is_rule_present(const struct rib_head *rib, const uint8_t *address,
+	uint8_t depth, uint32_t *pnext_hop);
+
+/*
+ * Extra information about struct rib_node that can be computed as
+ * one navigates a RIB.
+ */
+struct rib_node_info {
+	/* Prefix in host order that has been matched up to the current node. */
+	rib_address_t haddr_matched;
+	/* Bit mask for field @haddr_matched. */
+	rib_address_t haddr_mask;
+	/* Number of bits set in field @haddr_mask. */
+	int           depth;
+	/*
+	 * Number of bits missing in field @haddr_mask to reach
+	 * the maximum mask.
+	 */
+	int           missing_bits;
+};
+
+struct rib_iterator_rule {
+	rib_address_t address_no; /* Address in network order. */
+	uint8_t       depth;
+	uint32_t      next_hop;
+};
+
+static inline uint32_t
+ipv4_from_rib_addr(rib_address_t address_no)
+{
+	uint32_t *p = (typeof(p))&address_no;
+	return *p;
+}
+
+struct rib_longer_iterator_state {
+	/* RIB with which the iterator is associated. */
+	const struct rib_head    *rib;
+
+	/*
+	 * RIB scope of the iterator.
+	 */
+
+	/* Version of the RIB for which field @start_node is valid. */
+	uint64_t                 version;
+	/* Node where the iterator starts. */
+	const struct rib_node    *start_node;
+	/* Information associated with field @start_node. */
+	struct rib_node_info     start_info;
+	/* The minimum depth of prefix in field @next_address; the scope. */
+	uint8_t                  min_depth;
+
+	/*
+	 * The following fields are used in between calls of
+	 * rib_longer_iterator_next().
+	 */
+
+	/*
+	 * The next prefix to be returned by rib_longer_iterator_next().
+	 *
+	 * If the prefix does not exist in the RIB,
+	 * the prefix immediately greater will be returned.
+	 */
+	rib_address_t            next_address;
+	/* The depth of the prefix in field @next_address. */
+	uint8_t                  next_depth;
+	/* The iterator has finished. */
+	bool                     has_ended;
+
+	/*
+	 * The following fields are set and only valid while execution is in
+	 * rib_longer_iterator_next().
+	 */
+
+	/* When true, keep looking for prefixes greater than @next_address. */
+	bool                     ignore_next_address;
+	/* A return for rib_longer_iterator_next() has been found. */
+	bool                     found_return;
+	/*
+	 * Pointer to the struct rib_iterator_rule that will receive
+	 * the found rule; the output.
+	 */
+	struct rib_iterator_rule *rule;
+	/* Long jump to unwind the recursion. */
+	jmp_buf                  jmp_found;
+};
+
+/*
+ * Initialize @state.
+ *
+ * The first call of rib_longer_iterator_next() returns a rule whose prefix
+ * is at least as deeper as @depth.
+ *
+ * Passing @address = NULL (or any other value) and @depth = 0 iterates
+ * over the whole RIB; including the default rule
+ * (i.e. the zero-length prefix).
+ *
+ * @address is in network order (big endian).
+ * @address == NULL is equivalent to the all-zero address.
+ *
+ * If the RIB changes (i.e. rules are added or deleted)
+ * between the call of this function and the call of
+ * rib_longer_iterator_next(), or between two consecutive calls of
+ * rib_longer_iterator_next(), the iterator will enumerate the changes that
+ * are within the scope of the iterator (i.e at least as deeper than
+ * the initial prefix) and that are after the next rule.
+ */
+int rib_longer_iterator_state_init(struct rib_longer_iterator_state *state,
+	const struct rib_head *rib, const uint8_t *address, uint8_t depth);
+
+/*
+ * When a rule is found, this function updates @rule and returns zero.
+ * Otherwise, this function returns -ENOENT.
+ */
+int rib_longer_iterator_next(struct rib_longer_iterator_state *state,
+	struct rib_iterator_rule *rule);
+
+/*
+ * Free all resources associated to @state but the memory pointed by it.
+ *
+ * CAUTION: This function should only be called on initialized states.
+ */
+static inline void
+rib_longer_iterator_end(struct rib_longer_iterator_state *state)
+{
+	/* At the current version of the code, there is nothing to do here. */
+	RTE_SET_USED(state);
+}
+
+struct rib_shorter_iterator_state {
+	/* RIB with which the iterator is associated. */
+	const struct rib_head *rib;
+	/* Version of the RIB for which field @cur_node is valid. */
+	uint64_t              version;
+	/* Current node of the iteration. */
+	const struct rib_node *cur_node;
+	/* Information associated with field @cur_node. */
+	struct rib_node_info  info;
+	/* Deepest prefix to consider. */
+	rib_address_t         haddr;
+	uint8_t               depth;
+	/* The iterator has finished. */
+	bool                  has_ended;
+};
+
+/*
+ * Initialize @state.
+ *
+ * The first call of rib_shorter_iterator_next() returns a rule whose prefix
+ * is at most as deep as @depth and includes @address.
+ *
+ * The prefix @address/@depth is returned if its rule is present in @rib.
+ *
+ * This iterator is an efficient version of the following loop:
+ *
+ * int i;
+ * for (i = 0; i <= @depth; i++) {
+ *	uint32_t next_hop;
+ *	if (rib_is_rule_present(rib, address, i, &next_hop) != 1)
+ *		continue;
+ *
+ *	=> These entries are the ones that this iterator returns.
+ * }
+ *
+ * @address is in network order (big endian).
+ * @address == NULL is equivalent to the all-zero address.
+ *
+ * If the RIB changes (i.e. rules are added or deleted)
+ * between the call of this function and the call of
+ * rib_shorter_iterator_next(), or between two consecutive calls of
+ * rib_shorter_iterator_next(), the iterator will return -EFAULT.
+ */
+int rib_shorter_iterator_state_init(struct rib_shorter_iterator_state *state,
+	const struct rib_head *rib, const uint8_t *address, uint8_t depth);
+
+/*
+ * When a rule is found, this function updates @rule and returns zero.
+ * Otherwise, this function returns -ENOENT.
+ */
+int rib_shorter_iterator_next(struct rib_shorter_iterator_state *state,
+	struct rib_iterator_rule *rule);
+
+/*
+ * Free all resources associated to @state but the memory pointed by it.
+ *
+ * CAUTION: This function should only be called on initialized states.
+ */
+static inline void
+rib_shorter_iterator_end(struct rib_shorter_iterator_state *state)
+{
+	/* At the current version of the code, there is nothing to do here. */
+	RTE_SET_USED(state);
+}
+
+#endif /* _GATEKEEPER_GK_RIB_H_ */

--- a/lib/rib.c
+++ b/lib/rib.c
@@ -171,8 +171,13 @@ rib_create(struct rib_head *rib, const char *name, int socket_id,
 void
 rib_free(struct rib_head *rib)
 {
-	/* TODO */
-	RTE_SET_USED(rib);
+	rib->root_node.has_nh = false;
+	rib->root_node.branch[false] = NULL;
+	rib->root_node.branch[true] = NULL;
+	rib->version++;
+
+	rte_mempool_free(rib->mp_nodes);
+	rib->mp_nodes = NULL;
 }
 
 int

--- a/lib/rib.c
+++ b/lib/rib.c
@@ -1,0 +1,128 @@
+/*
+ * Gatekeeper - DDoS protection system.
+ * Copyright (C) 2016 Digirati LTDA.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gatekeeper_rib.h"
+
+int
+rib_create(struct rib_head *rib, const char *name, int socket_id,
+	uint8_t max_length, uint32_t max_rules)
+{
+	/* TODO */
+	RTE_SET_USED(rib);
+	RTE_SET_USED(name);
+	RTE_SET_USED(socket_id);
+	RTE_SET_USED(max_length);
+	RTE_SET_USED(max_rules);
+	return -1;
+}
+
+void
+rib_free(struct rib_head *rib)
+{
+	/* TODO */
+	RTE_SET_USED(rib);
+}
+
+int
+rib_lookup(const struct rib_head *rib, const uint8_t *address,
+	uint32_t *pnext_hop)
+{
+	/* TODO */
+	RTE_SET_USED(rib);
+	RTE_SET_USED(address);
+	RTE_SET_USED(pnext_hop);
+	return -1;
+}
+
+int
+rib_is_rule_present(const struct rib_head *rib, const uint8_t *address,
+	uint8_t depth, uint32_t *pnext_hop)
+{
+	/* TODO */
+	RTE_SET_USED(rib);
+	RTE_SET_USED(address);
+	RTE_SET_USED(depth);
+	RTE_SET_USED(pnext_hop);
+	return -1;
+}
+
+int
+rib_add(struct rib_head *rib, const uint8_t *address, uint8_t depth,
+	uint32_t next_hop)
+{
+	/* TODO */
+	RTE_SET_USED(rib);
+	RTE_SET_USED(address);
+	RTE_SET_USED(depth);
+	RTE_SET_USED(next_hop);
+	return -1;
+}
+
+int
+rib_delete(struct rib_head *rib, const uint8_t *address, uint8_t depth)
+{
+	/* TODO */
+	RTE_SET_USED(rib);
+	RTE_SET_USED(address);
+	RTE_SET_USED(depth);
+	return -1;
+}
+
+int
+rib_longer_iterator_state_init(struct rib_longer_iterator_state *state,
+	const struct rib_head *rib, const uint8_t *address, uint8_t depth)
+{
+	/* TODO */
+	RTE_SET_USED(state);
+	RTE_SET_USED(rib);
+	RTE_SET_USED(address);
+	RTE_SET_USED(depth);
+	return -1;
+}
+
+int
+rib_longer_iterator_next(struct rib_longer_iterator_state *state,
+	struct rib_iterator_rule *rule)
+{
+	/* TODO */
+	RTE_SET_USED(state);
+	RTE_SET_USED(rule);
+	return -1;
+}
+
+int
+rib_shorter_iterator_state_init(struct rib_shorter_iterator_state *state,
+	const struct rib_head *rib, const uint8_t *address, uint8_t depth)
+{
+	/* TODO */
+	RTE_SET_USED(state);
+	RTE_SET_USED(rib);
+	RTE_SET_USED(address);
+	RTE_SET_USED(depth);
+	return -1;
+}
+
+int
+rib_shorter_iterator_next(struct rib_shorter_iterator_state *state,
+	struct rib_iterator_rule *rule)
+{
+	/* TODO */
+	RTE_SET_USED(state);
+	RTE_SET_USED(rule);
+	return -1;
+}

--- a/lib/rib.c
+++ b/lib/rib.c
@@ -16,19 +16,156 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <rte_byteorder.h>
+#include <rte_errno.h>
+
+#if RTE_BYTE_ORDER == RTE_BIG_ENDIAN
+#include <rte_memcpy.h>
+#endif
+
+#include "gatekeeper_main.h"
 #include "gatekeeper_rib.h"
+
+static int
+__read_addr(uint8_t length, rib_address_t *cpu_addr, const uint8_t *address)
+{
+	if (unlikely(address == NULL)) {
+		*cpu_addr = 0;
+		return 0;
+	}
+
+	switch (length) {
+        case 32:
+		*cpu_addr = rte_be_to_cpu_32(*((uint32_t *)address));
+		break;
+
+	case 128: {
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+		uint64_t *dst = (uint64_t *)cpu_addr;
+		uint64_t *src = (uint64_t *)address;
+		dst[0] = rte_be_to_cpu_64(src[1]);
+		dst[1] = rte_be_to_cpu_64(src[0]);
+#else /* RTE_BIG_ENDIAN */
+		RTE_BUILD_BUG_ON(sizeof(*cpu_addr) != sizeof(uint128_t));
+		rte_mov128((uint8_t *)cpu_addr, address);
+#endif
+		break;
+	}
+
+	default:
+		G_LOG(ERR, "%s(): length=%u is not implemented\n",
+			__func__, length);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static inline int
+read_addr(const struct rib_head *rib, rib_address_t *cpu_addr,
+	const uint8_t *address)
+{
+	return __read_addr(rib->max_length, cpu_addr, address);
+}
+
+static int
+__write_addr(uint8_t length, uint8_t *address, rib_address_t cpu_addr)
+{
+	switch (length) {
+	case 32:
+		*((uint32_t *)address) = rte_cpu_to_be_32(cpu_addr);
+		break;
+
+	case 128: {
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+		uint64_t *dst = (uint64_t *)address;
+		uint64_t *src = (uint64_t *)&cpu_addr;
+		dst[0] = rte_cpu_to_be_64(src[1]);
+		dst[1] = rte_cpu_to_be_64(src[0]);
+#else /* RTE_BIG_ENDIAN */
+		RTE_BUILD_BUG_ON(sizeof(cpu_addr) != sizeof(uint128_t));
+		rte_mov128(address, (uint8_t *)&cpu_addr);
+#endif
+		break;
+	}
+
+	default:
+		G_LOG(ERR, "%s(): length=%u is not implemented\n",
+			__func__, length);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static inline int
+write_addr(const struct rib_head *rib, uint8_t *address, rib_address_t cpu_addr)
+{
+	return __write_addr(rib->max_length, address, cpu_addr);
+}
 
 int
 rib_create(struct rib_head *rib, const char *name, int socket_id,
 	uint8_t max_length, uint32_t max_rules)
 {
-	/* TODO */
-	RTE_SET_USED(rib);
-	RTE_SET_USED(name);
-	RTE_SET_USED(socket_id);
-	RTE_SET_USED(max_length);
-	RTE_SET_USED(max_rules);
-	return -1;
+	rib_address_t dummy;
+	int ret;
+	unsigned int n;
+
+	if (unlikely(max_length > RIB_MAX_ADDRESS_LENGTH)) {
+		G_LOG(ERR, "%s(): max_length=%u is greater than RIB_MAX_ADDRESS_LENGTH=%i\n",
+			__func__, max_length, RIB_MAX_ADDRESS_LENGTH);
+		return -EINVAL;
+	}
+
+	if (unlikely((max_length & 0x7) > 0)) {
+		G_LOG(ERR, "%s(): max_length=%u is not a multiple of 8\n",
+			__func__, max_length);
+		return -EINVAL;
+	}
+
+	ret = __read_addr(max_length, &dummy, (const uint8_t *)&dummy);
+	if (unlikely(ret < 0))
+		return ret;
+
+	ret = __write_addr(max_length, (uint8_t *)&dummy, 0);
+	if (unlikely(ret < 0))
+		return ret;
+
+	memset(rib, 0, sizeof(*rib));
+	rib->max_length = max_length;
+
+	/*
+	 * Number of nodes needed to store a max-length prefix.
+	 * Adding (RIB_MAX_PREFIX_BITS - 1) is equivalent to rouding up
+	 * the result since it's an integer division.
+	 */
+	n = (max_length + RIB_MAX_PREFIX_BITS - 1) / RIB_MAX_PREFIX_BITS;
+	/*
+	 * rib_add() needs at most a new internal node when adding
+	 * a prefix to the RIB.
+	 */
+	n++;
+	/*
+	 * Loose upper bound on the number of nodes needed to have
+	 * @max_rules rules.
+	 */
+	n *= max_rules;
+
+	rib->mp_nodes = rte_mempool_create(name, n, sizeof(struct rib_node),
+		0, 0, NULL, NULL, NULL, NULL, socket_id,
+		/* Save memory; struct rib_node is small. */
+		MEMPOOL_F_NO_SPREAD | MEMPOOL_F_NO_CACHE_ALIGN |
+		/* No synchronization; single writer. */
+		MEMPOOL_F_SP_PUT | MEMPOOL_F_SC_GET |
+		/* Nodes are not used for I/O. */
+		MEMPOOL_F_NO_IOVA_CONTIG);
+	if (unlikely(rib->mp_nodes == NULL)) {
+		ret = rte_errno;
+		G_LOG(ERR, "%s(): cannot create memory pool (errno=%i): %s\n",
+			__func__, ret, rte_strerror(ret));
+		return -ret;
+	}
+
+	return 0;
 }
 
 void


### PR DESCRIPTION
This pull request replaces the calls to the LPM iterator present in Gatekeeper's custom DPDK with a Routing Information Base (RIB). This is one step toward no longer having a custom DPDK for Gatekeeper. This work has been scheduled for Gatekeeper v1.2, but it is being brought to 1.1 due to issue #585.

This pull request closes #542.