### PR TITLE
fib: review lock requirements

### DIFF
--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -320,6 +320,8 @@ int add_fib_entry(const char *prefix, const char *gt_ip, const char *gw_ip,
 	enum gk_fib_action action, struct gk_config *gk_conf);
 int del_fib_entry_numerical(
 	struct ip_prefix *prefix_info, struct gk_config *gk_conf);
+int del_fib_entry_numerical_locked(
+	struct ip_prefix *prefix_info, struct gk_config *gk_conf);
 int del_fib_entry(const char *ip_prefix, struct gk_config *gk_conf);
 
 int l_list_gk_fib4(lua_State *l);

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -316,6 +316,10 @@ int add_fib_entry_numerical(struct ip_prefix *prefix_info,
 	struct ipaddr *gt_addrs, struct ipaddr *gw_addrs,
 	unsigned int num_addrs, enum gk_fib_action action,
 	const struct route_properties *props, struct gk_config *gk_conf);
+int add_fib_entry_numerical_locked(struct ip_prefix *prefix_info,
+	struct ipaddr *gt_addrs, struct ipaddr *gw_addrs,
+	unsigned int num_addrs, enum gk_fib_action action,
+	const struct route_properties *props, struct gk_config *gk_conf);
 int add_fib_entry(const char *prefix, const char *gt_ip, const char *gw_ip,
 	enum gk_fib_action action, struct gk_config *gk_conf);
 int del_fib_entry_numerical(

--- a/include/gatekeeper_rib.h
+++ b/include/gatekeeper_rib.h
@@ -142,6 +142,11 @@ int rib_delete(struct rib_head *rib, const uint8_t *address, uint8_t depth);
  * Look an address up on the RIB.
  * @address is in network order (big endian).
  * @address == NULL is equivalent to the all-zero address.
+ * RETURN
+ *	0 on lookup hit.
+ *	-ENOENT on lookup miss.
+ * 	A negative value on failure.
+ *
  */
 int rib_lookup(const struct rib_head *rib, const uint8_t *address,
 	uint32_t *pnext_hop);


### PR DESCRIPTION
The code around the FIB has tried to do some of the work related to adding and removing entries without holding a lock. The intention was to be faster, but the savings are small since there are way more readers than writers. Moreover, the risk of crashing Gatekeeper is too high. This pull request conservatively protects this code by acquiring the lock before it.

In addition, all FIB lookups that are not for incoming packets are rewritten to use the Routing Information Base added in pull request #594. This prepares Gatekeeper to eventually support NICs that can offload LPM lookups.