### PR TITLE
gk: speed get_empty_fib_id() up

### DIFF
--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -219,6 +219,13 @@ struct gk_lpm {
 
 	/* The IPv6 FIB table that decides the actions on packets. */
 	struct gk_fib   *fib_tbl6;
+
+	/*
+	 * Indexes of the last FIB entries allocated at @fib_tbl and @fib_tbl6.
+	 * get_empty_fib_id() is the only function that uses these fields.
+	 */
+	uint32_t        last_ipv4_index;
+	uint32_t        last_ipv6_index;
 };
 
 struct ip_prefix {


### PR DESCRIPTION
The original `get_empty_fib_id()` prioritizes having all fib entries close together.  This strategy is too slow for large routing tables.  Having a speedy `get_empty_fib_id()` is critical to quickly populate the routing table when Gatekeeper boots up.

To compare performance, a production routing table with 891094 prefixes was loaded via the Dynamic Configuration block. With the original `get_empty_fib_id()`, the load took 26 minutes and 10 seconds.  With the speedy `get_empty_fib_id()`, the same load took 4 minutes and 26 seconds. That is almost 6 times faster!