### PR TITLE
gk: improve log entries of the FIB

### DIFF
--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -319,20 +319,20 @@ void destroy_neigh_hash_table(struct neighbor_hash_table *neigh);
 
 int parse_ip_prefix(const char *ip_prefix, struct ipaddr *res);
 
-int add_fib_entry_numerical(struct ip_prefix *prefix_info,
+int add_fib_entry_numerical(const struct ip_prefix *prefix_info,
 	struct ipaddr *gt_addrs, struct ipaddr *gw_addrs,
 	unsigned int num_addrs, enum gk_fib_action action,
 	const struct route_properties *props, struct gk_config *gk_conf);
-int add_fib_entry_numerical_locked(struct ip_prefix *prefix_info,
+int add_fib_entry_numerical_locked(const struct ip_prefix *prefix_info,
 	struct ipaddr *gt_addrs, struct ipaddr *gw_addrs,
 	unsigned int num_addrs, enum gk_fib_action action,
 	const struct route_properties *props, struct gk_config *gk_conf);
 int add_fib_entry(const char *prefix, const char *gt_ip, const char *gw_ip,
 	enum gk_fib_action action, struct gk_config *gk_conf);
-int del_fib_entry_numerical(
-	struct ip_prefix *prefix_info, struct gk_config *gk_conf);
-int del_fib_entry_numerical_locked(
-	struct ip_prefix *prefix_info, struct gk_config *gk_conf);
+int del_fib_entry_numerical(const struct ip_prefix *prefix_info,
+	struct gk_config *gk_conf);
+int del_fib_entry_numerical_locked(const struct ip_prefix *prefix_info,
+	struct gk_config *gk_conf);
 int del_fib_entry(const char *ip_prefix, struct gk_config *gk_conf);
 
 int l_list_gk_fib4(lua_State *l);


### PR DESCRIPTION
The log entries of the FIB are part of the day-to-day interactions between network administrators and Gatekeeper servers. This commit improves these entries to bring them up to the new log format and adds information to these entries.

This commit also improves the strings of Lua errors associated with the FIB, reviews some error codes, and adds `const` to the parameter `struct ip_prefix` of many FIB functions.