### PR TITLE
gatekeeper: move from the LPM libraries to the FIB libraries

### DIFF
--- a/gk/fib.c
+++ b/gk/fib.c
@@ -1087,13 +1087,6 @@ check_prefix(const struct ip_prefix *prefix_info)
 {
 	if (unlikely(prefix_info->len < 0))
 		return -EINVAL;
-
-	if (unlikely(prefix_info->len == 0)) {
-		G_LOG(WARNING, "%s(%s): Gatekeeper currently does not support default routes\n",
-			__func__, prefix_info->str);
-		return -EPERM;
-	}
-
 	return 0;
 }
 

--- a/gt/lua_lpm.c
+++ b/gt/lua_lpm.c
@@ -253,20 +253,24 @@ l_ip_mask_addr(lua_State *l)
 
 	/* Second argument must be a Lua number. */
 	uint8_t depth = luaL_checknumber(l, 2);
-	if ((depth == 0) || (depth > RTE_FIB_MAXDEPTH))
-		luaL_error(l, "Expected a depth value between 1 and 32, however it is %d",
-			depth);
+	if (unlikely(depth > RTE_FIB_MAXDEPTH)) {
+		luaL_error(l, "%s(): expected a depth value between 0 and %d, however it is %d",
+			__func__, RTE_FIB_MAXDEPTH, depth);
+	}
 
-	if (lua_gettop(l) != 2)
-		luaL_error(l, "Expected two arguments, however it got %d arguments",
-			lua_gettop(l));
+	if (unlikely(lua_gettop(l) != 2)) {
+		luaL_error(l, "%s(): expected two arguments, however it got %d arguments",
+			__func__, lua_gettop(l));
+	}
 
 	ip4_prefix_mask(depth, &mask);
 	masked_ip = htonl(ntohl(ip) & rte_be_to_cpu_32(mask.s_addr));
 
-	if (inet_ntop(AF_INET, &masked_ip, buf, sizeof(buf)) == NULL)
-		luaL_error(l, "%s: failed to convert a number to an IPv4 address (%s)\n",
-			__func__, strerror(errno));
+	if (unlikely(inet_ntop(AF_INET, &masked_ip, buf, sizeof(buf))
+			== NULL)) {
+		luaL_error(l, "%s(): failed to convert a number to an IPv4 address (errno=%d): %s\n",
+			__func__, errno, strerror(errno));
+	}
 
 	lua_pushstring(l, buf);
 	return 1;
@@ -442,20 +446,24 @@ l_ip6_mask_addr(lua_State *l)
 
 	/* Second argument must be a Lua number. */
 	uint8_t depth = luaL_checknumber(l, 2);
-	if ((depth == 0) || (depth > RTE_FIB6_MAXDEPTH))
-		luaL_error(l, "Expected a depth value between 1 and 128, however it is %d",
-			depth);
+	if (unlikely(depth > RTE_FIB6_MAXDEPTH)) {
+		luaL_error(l, "%s(): expected a depth value between 0 and %d, however it is %d",
+			__func__, RTE_FIB6_MAXDEPTH, depth);
+	}
 
-	if (lua_gettop(l) != 2)
-		luaL_error(l, "Expected two arguments, however it got %d arguments",
-			lua_gettop(l));
+	if (unlikely(lua_gettop(l) != 2)) {
+		luaL_error(l, "%s(): expected two arguments, however it got %d arguments",
+			__func__, lua_gettop(l));
+	}
 
 	ip6_copy_addr(masked_ip, ipv6_addr->s6_addr);
 	ip6_mask_addr(masked_ip, depth);
 
-	if (inet_ntop(AF_INET6, masked_ip, buf, sizeof(buf)) == NULL)
-		luaL_error(l, "net: %s: failed to convert a number to an IPv6 address (%s)\n",
-			__func__, strerror(errno));
+	if (unlikely(inet_ntop(AF_INET6, masked_ip, buf, sizeof(buf))
+			== NULL)) {
+		luaL_error(l, "%s(): failed to convert a number to an IPv6 address (errno=%d): %s\n",
+			__func__, errno, strerror(errno));
+	}
 
 	lua_pushstring(l, buf);
 	return 1;

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -215,7 +215,7 @@ struct gk_lpm {
 	struct rib_head rib6;
 
 	/* The IPv6 FIB. */
-	struct rte_lpm6 *lpm6;
+	struct rte_fib6 *lpm6;
 
 	/* The IPv6 FIB table that decides the actions on packets. */
 	struct gk_fib   *fib_tbl6;

--- a/include/gatekeeper_fib.h
+++ b/include/gatekeeper_fib.h
@@ -206,7 +206,7 @@ struct gk_lpm {
 	struct rib_head rib;
 
 	/* The IPv4 FIB. */
-	struct rte_lpm  *lpm;
+	struct rte_fib  *lpm;
 
 	/* The IPv4 FIB table that decides the actions on packets. */
 	struct gk_fib   *fib_tbl;

--- a/include/gatekeeper_lpm.h
+++ b/include/gatekeeper_lpm.h
@@ -19,31 +19,68 @@
 #ifndef _GATEKEEPER_LPM_H_
 #define _GATEKEEPER_LPM_H_
 
-#include <rte_lpm.h>
 #include <rte_lpm6.h>
+#include <string.h>
+
+#include <rte_fib.h>
 #include <rte_byteorder.h>
+
+/*
+ * RTE_FIB_DIR24_8_4B allocates 4 bytes minus one bit for the next hop, so
+ * the maximum value is 31 bits. This is important because the rte_fib and
+ * rte_fib6 trucates the value of the default hop to this size.
+ */
+#define LPM_DEFAULT_NH (0x7FFFFFFF)
+
+static inline void
+set_ipv4_lpm_conf(struct rte_fib_conf *conf, uint32_t max_routes,
+	uint32_t num_tbl8)
+{
+	memset(conf, 0, sizeof(*conf));
+	conf->type = RTE_FIB_DIR24_8;
+	conf->default_nh = LPM_DEFAULT_NH;
+	conf->max_routes = max_routes;
+	conf->dir24_8.nh_sz = RTE_FIB_DIR24_8_4B;
+	conf->dir24_8.num_tbl8 = num_tbl8;
+}
 
 /*
  * The API here aims to be general and allow developers
  * to create more than one LPM table on a single lcore id.
  * @lcore and @identifier are only used to differentiate instances.
+ *
+ * The parameter lpm_conf is passed by copy because rte_fib_create(),
+ * which receives the parameter, does not have a const qualifier for it.
  */
-struct rte_lpm *init_ipv4_lpm(const char *tag,
-	const struct rte_lpm_config *lpm_conf,
+struct rte_fib *init_ipv4_lpm(const char *tag, struct rte_fib_conf lpm_conf,
 	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
-int lpm_lookup_ipv4(struct rte_lpm *lpm, uint32_t ip);
+int lpm_lookup_ipv4(struct rte_fib *lpm, uint32_t ip);
+
+/* @ip is in network order (i.e. big endian). */
+static inline int
+lpm_add(struct rte_fib *fib, uint32_t ip, uint8_t depth, uint64_t next_hop)
+{
+	return rte_fib_add(fib, rte_be_to_cpu_32(ip), depth, next_hop);
+}
+
+/* @ip is in network order (i.e. big endian). */
+static inline int
+lpm_delete(struct rte_fib *fib, uint32_t ip, uint8_t depth)
+{
+	return rte_fib_delete(fib, rte_be_to_cpu_32(ip), depth);
+}
+
+static inline void
+destroy_ipv4_lpm(struct rte_fib *lpm)
+{
+	rte_fib_free(lpm);
+}
 
 /* Similar to init_ipv4_lpm(), see above. */
 struct rte_lpm6 *init_ipv6_lpm(const char *tag,
 	const struct rte_lpm6_config *lpm6_conf,
 	unsigned int socket_id, unsigned int lcore, unsigned int identifier);
 int lpm_lookup_ipv6(struct rte_lpm6 *lpm, struct in6_addr *ip);
-
-static inline void
-destroy_ipv4_lpm(struct rte_lpm *lpm)
-{
-	rte_lpm_free(lpm);
-}
 
 static inline void
 destroy_ipv6_lpm(struct rte_lpm6 *lpm)

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -28,6 +28,7 @@
 #include <rte_jhash.h>
 #define DEFAULT_HASH_FUNC       rte_jhash
 #endif
+#include <rte_lcore.h>
 
 #include "gatekeeper_log_ratelimit.h"
 #include "list.h"


### PR DESCRIPTION
This pull request replaces library `rte_lpm` with `rte_fib`, and library `rte_lpm6` with `rte_fib6`. Although DPDK will eventually drop the LPM libraries in favor of the newest FIB libraries, the motivation for this pull request is that the library `rte_lpm6` has been misbehaving under production edit loads.

Thanks to the new libraries, this pull request enables the zero-length prefix on the routing table of Gatekeeper servers, and the LPM tables used on Lua policies.