### PR TITLE
gatekeeper: support variable sizes of RSS hash keys

### DIFF
--- a/ggu/main.c
+++ b/ggu/main.c
@@ -44,8 +44,9 @@ static struct ggu_config *ggu_conf;
 static void
 process_single_policy(struct ggu_policy *policy, void *arg)
 {
-	uint32_t flow_hash_val = rss_ip_flow_hf(&policy->flow, 0, 0);
 	const struct ggu_config *ggu_conf = arg;
+	uint32_t flow_hash_val = rss_flow_hash(&ggu_conf->net->front,
+		&policy->flow);
 	struct gk_cmd_entry *entry;
 	/*
 	 * Obtain mailbox of that GK block,

--- a/gk/main.c
+++ b/gk/main.c
@@ -846,7 +846,7 @@ gk_del_flow_entry_with_key(struct gk_instance *instance,
 		return gk_del_flow_entry_at_pos(instance, entry_idx);
 	}
 
-	if (likely(flow_key_eq(flow_key, &fe->flow)))
+	if (likely(flow_equal(flow_key, &fe->flow)))
 		return gk_del_flow_entry_at_pos(instance, entry_idx);
 
 	found_corruption_in_flow_table(instance);
@@ -884,6 +884,13 @@ rss_ip_flow_hf(const void *data,
 	 * get @front.
 	 */
 	return rss_flow_hash(&get_net_conf()->front, data);
+}
+
+static int
+ip_flow_cmp_eq(const void *key1, const void *key2,
+	__attribute__((unused)) size_t key_len)
+{
+	return flow_cmp(key1, key2);
 }
 
 static int
@@ -2507,7 +2514,7 @@ test_invalid_flow(__attribute__((unused)) void *arg,
 	const struct ip_flow *flow, struct flow_entry *fe)
 {
 	if (unlikely(!is_flow_valid(flow) || !is_flow_valid(&fe->flow) ||
-			!flow_key_eq(flow, &fe->flow) ||
+			!flow_equal(flow, &fe->flow) ||
 			!fe->in_use || fe->grantor_fib == NULL ||
 			fe->grantor_fib->action != GK_FWD_GRANTOR
 			))

--- a/include/gatekeeper_flow.h
+++ b/include/gatekeeper_flow.h
@@ -40,12 +40,12 @@ struct ip_flow {
 	} f;
 };
 
-int ip_flow_cmp_eq(const void *key1, const void *key2, size_t key_len);
+int flow_cmp(const struct ip_flow *flow1, const struct ip_flow *flow2);
 
 static inline bool
-flow_key_eq(const struct ip_flow *f1, const struct ip_flow *f2)
+flow_equal(const struct ip_flow *flow1, const struct ip_flow *flow2)
 {
-	return ip_flow_cmp_eq(f1, f2, sizeof(*f1)) == 0;
+	return flow_cmp(flow1, flow2) == 0;
 }
 
 void print_flow_err_msg(const struct ip_flow *flow, int32_t index,

--- a/include/gatekeeper_flow.h
+++ b/include/gatekeeper_flow.h
@@ -40,9 +40,6 @@ struct ip_flow {
 	} f;
 };
 
-uint32_t rss_ip_flow_hf(const void *data,
-	uint32_t data_len, uint32_t init_val);
-
 int ip_flow_cmp_eq(const void *key1, const void *key2, size_t key_len);
 
 static inline bool

--- a/lib/flow.c
+++ b/lib/flow.c
@@ -26,21 +26,16 @@
 #include "gatekeeper_main.h"
 #include "gatekeeper_flow.h"
 
-/* Type of function used to compare the hash key. */
 int
-ip_flow_cmp_eq(const void *key1, const void *key2,
-	__attribute__((unused)) size_t key_len)
+flow_cmp(const struct ip_flow *flow1, const struct ip_flow *flow2)
 {
-	const struct ip_flow *f1 = (const struct ip_flow *)key1;
-	const struct ip_flow *f2 = (const struct ip_flow *)key2;
+	if (flow1->proto != flow2->proto)
+		return flow1->proto == RTE_ETHER_TYPE_IPV4 ? -1 : 1;
 
-	if (f1->proto != f2->proto)
-		return f1->proto == RTE_ETHER_TYPE_IPV4 ? -1 : 1;
+	if (flow1->proto == RTE_ETHER_TYPE_IPV4)
+		return memcmp(&flow1->f.v4, &flow2->f.v4, sizeof(flow1->f.v4));
 
-	if (f1->proto == RTE_ETHER_TYPE_IPV4)
-		return memcmp(&f1->f.v4, &f2->f.v4, sizeof(f1->f.v4));
-	else
-		return memcmp(&f1->f.v6, &f2->f.v6, sizeof(f1->f.v6));
+	return memcmp(&flow1->f.v6, &flow2->f.v6, sizeof(flow1->f.v6));
 }
 
 static void

--- a/lib/net.c
+++ b/lib/net.c
@@ -1812,9 +1812,8 @@ start_iface(struct gatekeeper_if *iface, unsigned int num_attempts_link_get)
 	 */
 	ret = rte_eth_dev_set_mtu(iface->id, iface->mtu);
 	if (ret < 0) {
-		G_LOG(ERR,
-			"net: cannot set the MTU on the %s iface (error %d)\n",
-			iface->name, -ret);
+		G_LOG(ERR, "%s(%s): cannot set the MTU (errno=%i): %s\n",
+			__func__, iface->name, -ret, rte_strerror(-ret));
 		goto destroy_init;
 	}
 
@@ -1837,11 +1836,10 @@ start_iface(struct gatekeeper_if *iface, unsigned int num_attempts_link_get)
 		 * Only after the NICs start, we can check whether the RSS hash
 		 * is configured correctly or not.
 		 */
-		if (check_port_rss_key_update(iface, iface->ports[i])) {
-			G_LOG(ERR,
-				"net: port %hu (%s) on the %s interface does get the RSS hash key updated correctly\n",
-				iface->ports[i], iface->pci_addrs[i],
-				iface->name);
+		if (check_port_rss_key_update(iface, iface->ports[i]) != 0) {
+			G_LOG(ERR, "%s(%s): port %hu (%s) does not have the correct RSS hash key\n",
+				__func__, iface->name,
+				iface->ports[i], iface->pci_addrs[i]);
 			ret = -1;
 			goto stop_partial;
 		}

--- a/lib/net.c
+++ b/lib/net.c
@@ -21,8 +21,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
-#include <linux/random.h>
-#include <sys/syscall.h>
+#include <sys/random.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>
@@ -1146,10 +1145,8 @@ randomize_rss_key(struct gatekeeper_if *iface)
 		 * (i.e flags) is zero, getrandom() uses the /dev/urandom pool.
 		 */
 		do {
-			int ret = syscall(SYS_getrandom,
-				iface->rss_key + number_of_bytes,
-				iface->rss_key_len - number_of_bytes,
-				flags);
+			int ret = getrandom(iface->rss_key + number_of_bytes,
+				iface->rss_key_len - number_of_bytes, flags);
 			if (ret < 0)
 				return ret;
 			number_of_bytes += ret;

--- a/lib/net.c
+++ b/lib/net.c
@@ -41,58 +41,6 @@
 #include "gatekeeper_launch.h"
 
 static struct net_config config;
-/*
- * The secret key of the RSS hash (RSK) must be random in order
- * to prevent hackers from knowing it.
- */
-uint8_t default_rss_key[GATEKEEPER_RSS_KEY_LEN];
-
-static int
-randomize_rss_key(int guarantee_random_entropy)
-{
-	uint16_t final_set_count;
-	unsigned int flags = guarantee_random_entropy == 0 ? 0 : GRND_RANDOM;
-
-	/*
-	 * To validate if the key generated is reasonable, the
-	 * number of bits set to 1 in the key must be greater than 
-	 * 10% and less than 90% of the total bits in the key.
-	 * min_num_set_bits and max_num_set_bits represent the lower 
-	 * and upper bound for the key.
-	 */
-	const uint16_t min_num_set_bits = sizeof(default_rss_key) * 8 * 0.1;
-	const uint16_t max_num_set_bits = sizeof(default_rss_key) * 8 * 0.9;
-
-	do {	
-		int number_of_bytes = 0;
-		uint8_t i;
-
-		/* 
-		 * When the last parameter of the system call  getrandom()
-		 * (i.e flags) is zero, getrandom() uses the /dev/urandom pool.
-		 */	
-		do {
-			int ret = syscall(SYS_getrandom,
-				default_rss_key + number_of_bytes,
-				sizeof(default_rss_key) - number_of_bytes,
-				flags);
-			if (ret < 0)
-				return -1;
-			number_of_bytes += ret;	
-		} while (number_of_bytes < (int)sizeof(default_rss_key));
-
-		final_set_count = 0;
-		for (i = 0; i < RTE_DIM(default_rss_key); i++) {
-			final_set_count +=
-				__builtin_popcount(default_rss_key[i]);
-		}
-	} while (final_set_count < min_num_set_bits ||
-			final_set_count > max_num_set_bits);
-	return 0;
-}
-
-/* To support the optimized implementation of generic RSS hash function. */
-uint8_t rss_key_be[RTE_DIM(default_rss_key)];
 
 /*
  * Add a filter that steers packets to queues based on their EtherType.
@@ -981,49 +929,73 @@ check_port_rss(struct gatekeeper_if *iface, unsigned int port_idx,
 	const struct rte_eth_dev_info *dev_info,
 	struct rte_eth_conf *port_conf)
 {
-	uint8_t rss_hash_key[GATEKEEPER_RSS_KEY_LEN];
+	uint8_t rss_hash_key[GATEKEEPER_RSS_MAX_KEY_LEN];
 	struct rte_eth_rss_conf rss_conf = {
 		.rss_key = rss_hash_key,
-		.rss_key_len = GATEKEEPER_RSS_KEY_LEN,
+		.rss_key_len = sizeof(rss_hash_key),
 	};
 	uint64_t rss_off = dev_info->flow_type_rss_offloads;
 	int ret = rte_eth_dev_rss_hash_conf_get(
 		iface->ports[port_idx], &rss_conf);
 	if (ret == -ENOTSUP) {
-		G_LOG(NOTICE, "net: port %hu (%s) on the %s interface does not support to get RSS configuration, disable RSS\n",
-			iface->ports[port_idx], iface->pci_addrs[port_idx],
-			iface->name);
+		G_LOG(WARNING, "%s(%s): port %hu (%s) does not support to get RSS configuration, disable RSS\n",
+			__func__, iface->name,
+			iface->ports[port_idx], iface->pci_addrs[port_idx]);
 		goto disable_rss;
-	} else if (ret != 0) {
-		G_LOG(WARNING, "net: failed to get RSS hash configuration at port %hu (%s) on the %s interface - ret = %d\n",
+	}
+	if (ret < 0) {
+		G_LOG(ERR, "%s(%s): failed to get RSS hash configuration at port %hu (%s) (errno=%i): %s\n",
+			__func__, iface->name,
 			iface->ports[port_idx], iface->pci_addrs[port_idx],
-			iface->name, ret);
+			-ret, rte_strerror(-ret));
 		return ret;
 	}
+	RTE_VERIFY(ret == 0);
 
 	/* This port doesn't support RSS, so disable RSS. */
 	if (rss_off == 0) {
-		G_LOG(NOTICE, "net: port %hu (%s) on the %s interface does not support RSS\n",
-			iface->ports[port_idx], iface->pci_addrs[port_idx],
-			iface->name);
+		G_LOG(WARNING, "%s(%s): port %hu (%s) does not support RSS\n",
+			__func__, iface->name,
+			iface->ports[port_idx], iface->pci_addrs[port_idx]);
 		goto disable_rss;
 	}
 
-	if (dev_info->hash_key_size != sizeof(default_rss_key)) {
-		G_LOG(NOTICE, "net: port %hu (%s) on the %s interface does not provide a valid hash key size %hhu (%lu)\n",
+	/* Does Gatekeeper support the key length of @dev_info? */
+	if (dev_info->hash_key_size < GATEKEEPER_RSS_MIN_KEY_LEN ||
+			dev_info->hash_key_size > GATEKEEPER_RSS_MAX_KEY_LEN ||
+			dev_info->hash_key_size % 4 != 0) {
+		G_LOG(WARNING, "%s(%s): port %hu (%s) requires a RSS hash key of %i bytes; Gatekeeper only supports keys of [%i, %i] bytes long that are multiple of 4\n",
+			__func__, iface->name,
 			iface->ports[port_idx], iface->pci_addrs[port_idx],
-			iface->name, dev_info->hash_key_size,
-			sizeof(default_rss_key));
+			dev_info->hash_key_size, GATEKEEPER_RSS_MIN_KEY_LEN,
+			GATEKEEPER_RSS_MAX_KEY_LEN);
 		goto disable_rss;
 	}
+
+	/*
+	 * Check that all RSS keys have the same length.
+	 *
+	 * @iface->rss_key_len > GATEKEEPER_RSS_MAX_KEY_LEN when it is
+	 * the first time that check_port_rss() is being called.
+	 */
+	if (iface->rss_key_len <= GATEKEEPER_RSS_MAX_KEY_LEN &&
+			iface->rss_key_len != dev_info->hash_key_size) {
+		G_LOG(WARNING, "%s(%s): port %hu (%s) requires a RSS hash key of %i bytes, but another port requires a key of %i bytes; all ports of the same interface must have the same key length\n",
+			__func__, iface->name,
+			iface->ports[port_idx], iface->pci_addrs[port_idx],
+			dev_info->hash_key_size, iface->rss_key_len);
+		goto disable_rss;
+	}
+	iface->rss_key_len = dev_info->hash_key_size;
 
 	/* Check IPv4 RSS hashes. */
 	if (port_conf->rx_adv_conf.rss_conf.rss_hf & GATEKEEPER_IPV4_RSS_HF) {
 		/* No IPv4 hashes are supported, so disable RSS. */
 		if ((rss_off & GATEKEEPER_IPV4_RSS_HF) == 0) {
-			G_LOG(NOTICE, "net: port %hu (%s) on the %s interface does not support any IPv4 related RSS hashes\n",
-				iface->ports[port_idx], iface->pci_addrs[port_idx],
-				iface->name);
+			G_LOG(WARNING, "%s(%s): port %hu (%s) does not support any IPv4 related RSS hashes\n",
+				__func__, iface->name,
+				iface->ports[port_idx],
+				iface->pci_addrs[port_idx]);
 			goto disable_rss;
 		}
 
@@ -1032,10 +1004,10 @@ check_port_rss(struct gatekeeper_if *iface, unsigned int port_idx,
 		 * used is not supported, so warn the user.
 		 */
 		if ((rss_off & ETH_RSS_IPV4) == 0) {
-			G_LOG(WARNING, "net: port %hu (%s) on the %s interface does not support the ETH_RSS_IPV4 hash function; the device may not hash packets to the correct queues\n",
+			G_LOG(WARNING, "%s(%s): port %hu (%s) does not support the ETH_RSS_IPV4 hash function; the device may not hash packets to the correct queues\n",
+				__func__, iface->name,
 				iface->ports[port_idx],
-				iface->pci_addrs[port_idx],
-				iface->name);
+				iface->pci_addrs[port_idx]);
 		}
 	}
 
@@ -1043,9 +1015,10 @@ check_port_rss(struct gatekeeper_if *iface, unsigned int port_idx,
 	if (port_conf->rx_adv_conf.rss_conf.rss_hf & GATEKEEPER_IPV6_RSS_HF) {
 		/* No IPv6 hashes are supported, so disable RSS. */
 		if ((rss_off & GATEKEEPER_IPV6_RSS_HF) == 0) {
-			G_LOG(NOTICE, "net: port %hu (%s) on the %s interface does not support any IPv6 related RSS hashes\n",
-				iface->ports[port_idx], iface->pci_addrs[port_idx],
-				iface->name);
+			G_LOG(WARNING, "%s(%s): port %hu (%s) does not support any IPv6 related RSS hashes\n",
+				__func__, iface->name,
+				iface->ports[port_idx],
+				iface->pci_addrs[port_idx]);
 			goto disable_rss;
 		}
 
@@ -1054,10 +1027,10 @@ check_port_rss(struct gatekeeper_if *iface, unsigned int port_idx,
 		 * used is not supported, so warn the user.
 		 */
 		if ((rss_off & ETH_RSS_IPV6) == 0) {
-			G_LOG(WARNING, "net: port %hu (%s) on the %s interface does not support the ETH_RSS_IPV6 hash function; the device may not hash packets to the correct queues\n",
+			G_LOG(WARNING, "%s(%s): port %hu (%s) does not support the ETH_RSS_IPV6 hash function; the device may not hash packets to the correct queues\n",
+				__func__, iface->name,
 				iface->ports[port_idx],
-				iface->pci_addrs[port_idx],
-				iface->name);
+				iface->pci_addrs[port_idx]);
 		}
 	}
 
@@ -1069,11 +1042,10 @@ check_port_rss(struct gatekeeper_if *iface, unsigned int port_idx,
 	 */
 	if ((rss_off & port_conf->rx_adv_conf.rss_conf.rss_hf) !=
 			port_conf->rx_adv_conf.rss_conf.rss_hf) {
-		G_LOG(NOTICE,
-			"net: port %hu (%s) on the %s interface only supports RSS hash functions 0x%"PRIx64", but Gatekeeper asks for 0x%"PRIx64"\n",
+		G_LOG(WARNING, "%s(%s): port %hu (%s) only supports RSS hash functions 0x%"PRIx64", but Gatekeeper asks for 0x%"PRIx64"\n",
+			__func__, iface->name,
 			iface->ports[port_idx], iface->pci_addrs[port_idx],
-			iface->name, rss_off,
-			port_conf->rx_adv_conf.rss_conf.rss_hf);
+			rss_off, port_conf->rx_adv_conf.rss_conf.rss_hf);
 	}
 
 	port_conf->rx_adv_conf.rss_conf.rss_hf &= rss_off;
@@ -1150,10 +1122,55 @@ check_port_cksum(struct gatekeeper_if *iface, unsigned int port_idx,
 }
 
 static int
+randomize_rss_key(struct gatekeeper_if *iface)
+{
+	uint16_t final_set_count;
+	unsigned int flags = iface->guarantee_random_entropy ? GRND_RANDOM : 0;
+
+	/*
+	 * To validate if the key generated is reasonable, the
+	 * number of bits set to 1 in the key must be greater than
+	 * 10% and less than 90% of the total bits in the key.
+	 * min_num_set_bits and max_num_set_bits represent the lower
+	 * and upper bound for the key.
+	 */
+	const uint16_t min_num_set_bits = iface->rss_key_len * 8 * 0.1;
+	const uint16_t max_num_set_bits = iface->rss_key_len * 8 * 0.9;
+
+	do {
+		int number_of_bytes = 0;
+		uint8_t i;
+
+		/*
+		 * When the last parameter of the system call getrandom()
+		 * (i.e flags) is zero, getrandom() uses the /dev/urandom pool.
+		 */
+		do {
+			int ret = syscall(SYS_getrandom,
+				iface->rss_key + number_of_bytes,
+				iface->rss_key_len - number_of_bytes,
+				flags);
+			if (ret < 0)
+				return ret;
+			number_of_bytes += ret;
+		} while (number_of_bytes < iface->rss_key_len);
+
+		final_set_count = 0;
+		for (i = 0; i < iface->rss_key_len; i++) {
+			final_set_count +=
+				__builtin_popcount(iface->rss_key[i]);
+		}
+	} while (final_set_count < min_num_set_bits ||
+			final_set_count > max_num_set_bits);
+	return 0;
+}
+
+static int
 check_port_offloads(struct gatekeeper_if *iface,
 	struct rte_eth_conf *port_conf)
 {
 	unsigned int i;
+	int ret;
 
 	RTE_BUILD_BUG_ON((GATEKEEPER_IPV4_RSS_HF | GATEKEEPER_IPV6_RSS_HF) !=
 		ETH_RSS_IP);
@@ -1169,6 +1186,11 @@ check_port_offloads(struct gatekeeper_if *iface,
 	 * hash functions.
 	 */
 	iface->rss = true;
+	/*
+	 * The +1 makes @iface->rss_key_len invalid and helps check_port_rss()
+	 * to identify the first RSS key length.
+	 */
+	iface->rss_key_len = GATEKEEPER_RSS_MAX_KEY_LEN + 1;
 	port_conf->rx_adv_conf.rss_conf.rss_hf = 0;
 	if (ipv4_if_configured(iface)) {
 		port_conf->rx_adv_conf.rss_conf.rss_hf |=
@@ -1225,7 +1247,6 @@ check_port_offloads(struct gatekeeper_if *iface,
 	for (i = 0; i < iface->num_ports; i++) {
 		struct rte_eth_dev_info dev_info;
 		uint16_t port_id = iface->ports[i];
-		int ret;
 
 		rte_eth_dev_info_get(port_id, &dev_info);
 
@@ -1246,14 +1267,26 @@ check_port_offloads(struct gatekeeper_if *iface,
 	}
 
 	if (iface->rss) {
+		ret = randomize_rss_key(iface);
+		if (ret < 0) {
+			G_LOG(ERR, "%s(%s): failed to initialize RSS key (errno=%i): %s\n",
+				__func__, iface->name, -ret, strerror(-ret));
+			return ret;
+		}
+
+		/* Convert RSS key. */
+		RTE_VERIFY(iface->rss_key_len % 4 == 0);
+		rte_convert_rss_key((uint32_t *)iface->rss_key,
+			(uint32_t *)iface->rss_key_be, iface->rss_key_len);
+
 		port_conf->rxmode.mq_mode = ETH_MQ_RX_RSS;
-		port_conf->rx_adv_conf.rss_conf.rss_key = default_rss_key;
+		port_conf->rx_adv_conf.rss_conf.rss_key = iface->rss_key;
 		port_conf->rx_adv_conf.rss_conf.rss_key_len =
-			GATEKEEPER_RSS_KEY_LEN;
+			iface->rss_key_len;
 	} else {
 		/* Configured hash functions are not supported. */
-		G_LOG(WARNING, "net: the %s interface does not have RSS capabilities; the GK or GT block will receive all packets and send them to the other blocks as needed. Gatekeeper or Grantor should only be run with one lcore dedicated to GK or GT in this mode; restart with only one GK or GT lcore if necessary\n",
-			iface->name);
+		G_LOG(WARNING, "%s(%s): the interface does not have RSS capabilities; the GK or GT block will receive all packets and send them to the other blocks as needed. Gatekeeper or Grantor should only be run with one lcore dedicated to GK or GT in this mode; restart with only one GK or GT lcore if necessary\n",
+			__func__, iface->name);
 		iface->num_rx_queues = 1;
 	}
 
@@ -1450,10 +1483,10 @@ init_iface(struct gatekeeper_if *iface)
 	iface->ports = rte_calloc("ports", iface->num_ports,
 		sizeof(*iface->ports), 0);
 	if (iface->ports == NULL) {
-		G_LOG(ERR, "net: %s: out of memory for %s ports\n",
+		G_LOG(ERR, "%s(%s): out of memory for ports\n",
 			__func__, iface->name);
 		destroy_iface(iface, IFACE_DESTROY_LUA);
-		return -1;
+		return -ENOMEM;
 	}
 
 	/* Initialize all ports on this interface. */
@@ -1461,9 +1494,9 @@ init_iface(struct gatekeeper_if *iface)
 		ret = rte_eth_dev_get_port_by_name(iface->pci_addrs[i],
 			&iface->ports[i]);
 		if (ret < 0) {
-			G_LOG(ERR,
-				"net: failed to map PCI %s to a port on the %s interface (err=%d)\n",
-				iface->pci_addrs[i], iface->name, ret);
+			G_LOG(ERR, "%s(%s): failed to map PCI %s to a port (errno=%i): %s\n",
+				__func__, iface->name, iface->pci_addrs[i],
+				-ret, rte_strerror(-ret));
 			goto free_ports;
 		}
 	}
@@ -1471,9 +1504,8 @@ init_iface(struct gatekeeper_if *iface)
 	/* Make sure the ports support hardware offloads. */
 	ret = check_port_offloads(iface, &port_conf);
 	if (ret < 0) {
-		G_LOG(ERR,
-			"net: %s interface doesn't support a critical hardware capability\n",
-			iface->name);
+		G_LOG(ERR, "%s(%s): interface doesn't support a critical hardware capability\n",
+			__func__, iface->name);
 		goto free_ports;
 	}
 
@@ -1496,9 +1528,9 @@ init_iface(struct gatekeeper_if *iface)
 		RTE_VERIFY(ret > 0 && ret < (int)sizeof(dev_name));
 		ret = rte_eth_bond_create(dev_name, iface->bonding_mode, 0);
 		if (ret < 0) {
-			G_LOG(ERR,
-				"net: failed to create bonded port on the %s interface (err=%d)\n",
-				iface->name, ret);
+			G_LOG(ERR, "%s(%s): failed to create bonded port (errno=%i): %s\n",
+				__func__, iface->name,
+				-ret, rte_strerror(-ret));
 			goto close_partial;
 		}
 
@@ -1529,8 +1561,10 @@ init_iface(struct gatekeeper_if *iface)
 			ret = rte_eth_bond_slave_add(iface->id,
 				iface->ports[i]);
 			if (ret < 0) {
-				G_LOG(ERR, "net: failed to add slave port %hhu to bonded port %hhu (err=%d)\n",
-					iface->ports[i], iface->id, ret);
+				G_LOG(ERR, "%s(%s): failed to add slave port %hhu to bonded port %hhu (errno=%i): %s\n",
+					__func__, iface->name,
+					iface->ports[i], iface->id,
+					-ret, rte_strerror(-ret));
 				rm_slave_ports(iface, num_slaves_added);
 				goto close_ports;
 			}
@@ -1693,10 +1727,10 @@ setup_ipv6_addrs(struct gatekeeper_if *iface)
 static int
 check_port_rss_key_update(struct gatekeeper_if *iface, uint16_t port_id)
 {
-	uint8_t rss_hash_key[GATEKEEPER_RSS_KEY_LEN];
+	uint8_t rss_hash_key[GATEKEEPER_RSS_MAX_KEY_LEN];
 	struct rte_eth_rss_conf rss_conf = {
 		.rss_key = rss_hash_key,
-		.rss_key_len = GATEKEEPER_RSS_KEY_LEN,
+		.rss_key_len = sizeof(rss_hash_key),
 	};
 	int ret;
 
@@ -1708,35 +1742,29 @@ check_port_rss_key_update(struct gatekeeper_if *iface, uint16_t port_id)
 	case 0:
 		break;
 	case -ENODEV:
-		G_LOG(WARNING,
-			"net: failed to get RSS hash configuration at port %d on the %s interface - port identifier is invalid\n",
-			port_id, iface->name);
+		G_LOG(WARNING, "%s(%s): failed to get RSS hash configuration at port %d: port identifier is invalid\n",
+			__func__, iface->name, port_id);
 		return ret;
 	case -EIO:
-		G_LOG(WARNING,
-			"net: failed to get RSS hash configuration at port %d on the %s interface - device is removed\n",
-			port_id, iface->name);
+		G_LOG(WARNING, "%s(%s): failed to get RSS hash configuration at port %d: device is removed\n",
+			__func__, iface->name, port_id);
 		return ret;
 	case -ENOTSUP:
-		G_LOG(WARNING,
-			"net: failed to get RSS hash configuration at port %d on the %s interface - hardware doesn't support\n",
-			port_id, iface->name);
+		G_LOG(WARNING, "%s(%s): failed to get RSS hash configuration at port %d: hardware does not support RSS\n",
+			__func__, iface->name, port_id);
 		return ret;
 	default:
-		G_LOG(WARNING,
-			"net: failed to get RSS hash configuration at port %d on the %s interface - ret = %d\n",
-			port_id, iface->name, ret);
+		G_LOG(WARNING, "%s(%s): failed to get RSS hash configuration at port %d (errno=%i): %s\n",
+			__func__, iface->name, port_id,
+			-ret, rte_strerror(-ret));
 		return ret;
 	}
 
-	if ((rss_conf.rss_key_len !=
-			sizeof(default_rss_key) ||
-			memcmp(rss_conf.rss_key,
-				default_rss_key,
-				rss_conf.rss_key_len) != 0)) {
-		G_LOG(WARNING,
-			"net: the RSS hash configuration obtained at port %d on the %s interface doesn't match the expected RSS configuration\n",
-			port_id, iface->name);
+	if (unlikely(rss_conf.rss_key_len != iface->rss_key_len ||
+			memcmp(rss_conf.rss_key, iface->rss_key,
+				iface->rss_key_len) != 0)) {
+		G_LOG(WARNING, "%s(%s): the RSS hash configuration obtained at port %d does not match the expected RSS configuration\n",
+			__func__, iface->name, port_id);
 		return -EINVAL;
 	}
 
@@ -2296,18 +2324,6 @@ gatekeeper_init_network(struct net_config *net_conf)
 		return -1;
 	}
 
-	if (randomize_rss_key(net_conf->guarantee_random_entropy) < 0) {
-		G_LOG(ERR, "net: failed to initialize RSS key.\n");
-		ret = -1;
-		goto numa;
-	}
-
-	RTE_BUILD_BUG_ON(sizeof(default_rss_key) % 4 != 0);
-
-	/* Convert RSS key. */
-	rte_convert_rss_key((uint32_t *)default_rss_key,
-		(uint32_t *)rss_key_be, sizeof(default_rss_key));
-
 	/* Check port limits. */
 	num_ports = net_conf->front.num_ports +
 		(net_conf->back_iface_enabled ? net_conf->back.num_ports : 0);
@@ -2422,4 +2438,76 @@ send_pkts(uint8_t port, uint16_t tx_queue,
 		for (i = num_tx_succ; i < num_pkts; i++)
 			drop_packet(bufs[i]);
 	}
+}
+
+/*
+ * Optimized generic implementation of RSS hash function.
+ * If you want the calculated hash value matches NIC RSS value,
+ * you have to use special converted key with rte_convert_rss_key() fn.
+ * @param input_tuple
+ *   Pointer to input tuple with network order.
+ * @param input_len
+ *   Length of input_tuple in 4-bytes chunks.
+ * @param *rss_key
+ *   Pointer to RSS hash key.
+ * @return
+ *   Calculated hash value.
+ */
+static inline uint32_t
+gk_softrss_be(const uint32_t *input_tuple, uint32_t input_len,
+		const uint8_t *rss_key)
+{
+	uint32_t i;
+	uint32_t j;
+	uint32_t ret = 0;
+
+	for (j = 0; j < input_len; j++) {
+		/*
+		 * Need to use little endian,
+		 * since it takes ordering as little endian in both bytes and bits.
+		 */
+		uint32_t val = rte_be_to_cpu_32(input_tuple[j]);
+		for (i = 0; i < 32; i++)
+			if (val & (1 << (31 - i))) {
+				/*
+				 * The cast (uint64_t) is needed because when
+				 * @i == 0, the expression requires a 32-bit
+				 * shift of a 32-bit unsigned integer,
+				 * what is undefined.
+				 * The C standard only defines bit shifting
+				 * up to the bit-size of the integer minus one.
+				 * Finally, the cast (uint32_t) avoid promoting
+				 * the expression before the bit-or (i.e. `|`)
+				 * to uint64_t.
+				 */
+				ret ^= ((const uint32_t *)rss_key)[j] << i |
+					(uint32_t)((uint64_t)
+						(((const uint32_t *)rss_key)
+							[j + 1])
+						>> (32 - i));
+			}
+	}
+
+	return ret;
+}
+
+uint32_t
+rss_flow_hash(const struct gatekeeper_if *iface, const struct ip_flow *flow)
+{
+	if (flow->proto == RTE_ETHER_TYPE_IPV4) {
+		RTE_BUILD_BUG_ON(sizeof(flow->f.v4) % sizeof(uint32_t) != 0);
+		return gk_softrss_be((uint32_t *)&flow->f,
+			(sizeof(flow->f.v4)/sizeof(uint32_t)),
+			iface->rss_key_be);
+	}
+
+	if (likely(flow->proto == RTE_ETHER_TYPE_IPV6)) {
+		RTE_BUILD_BUG_ON(sizeof(flow->f.v6) % sizeof(uint32_t) != 0);
+		return gk_softrss_be((uint32_t *)&flow->f,
+			(sizeof(flow->f.v6)/sizeof(uint32_t)),
+			iface->rss_key_be);
+	}
+
+	rte_panic("%s(): unknown protocol: %i\n", __func__, flow->proto);
+	return 0;
 }

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -283,12 +283,12 @@ struct gatekeeper_if {
 	bool     ipv4_hw_udp_cksum;
 	bool     ipv6_hw_udp_cksum;
 	bool     ipv4_hw_cksum;
+	bool     guarantee_random_entropy;
 	/* This struct has hidden fields. */
 };
 
 struct net_config {
 	int          back_iface_enabled;
-	int          guarantee_random_entropy;
 	unsigned int num_attempts_link_get;
 	bool         *numa_used;
 	uint32_t     log_level;

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -36,7 +36,7 @@ return function (gatekeeper_server)
 	local back_num_tx_desc = 128
 
 	-- These variables are unlikely to need to be changed.
-	local guarantee_random_entropy = 0
+	local guarantee_random_entropy = false
 	local num_attempts_link_get = 5
 	local front_ipv6_default_hop_limits = 255
 	local back_ipv6_default_hop_limits = 255
@@ -53,7 +53,6 @@ return function (gatekeeper_server)
 	--
 
 	local net_conf = staticlib.c.get_net_conf()
-	net_conf.guarantee_random_entropy = guarantee_random_entropy
 	net_conf.num_attempts_link_get = num_attempts_link_get
 	net_conf.log_level = log_level
 	net_conf.rotate_log_interval_sec = rotate_log_interval_sec
@@ -76,8 +75,10 @@ return function (gatekeeper_server)
 	front_iface.ipv4_hw_udp_cksum = front_ipv4_hw_udp_cksum
 	front_iface.ipv6_hw_udp_cksum = front_ipv6_hw_udp_cksum
 	front_iface.ipv4_hw_cksum = front_ipv4_hw_cksum
+	front_iface.guarantee_random_entropy = guarantee_random_entropy
 	local ret = staticlib.init_iface(front_iface, "front",
-		front_ports, front_ips, front_ipv4_vlan_tag, front_ipv6_vlan_tag)
+		front_ports, front_ips, front_ipv4_vlan_tag,
+		front_ipv6_vlan_tag)
 	if ret < 0 then
 		error("Failed to initialize the front interface")
 	end
@@ -97,8 +98,10 @@ return function (gatekeeper_server)
 		back_iface.ipv4_hw_udp_cksum = back_ipv4_hw_udp_cksum
 		back_iface.ipv6_hw_udp_cksum = back_ipv6_hw_udp_cksum
 		back_iface.ipv4_hw_cksum = back_ipv4_hw_cksum
+		back_iface.guarantee_random_entropy = guarantee_random_entropy
 		ret = staticlib.init_iface(back_iface, "back",
-			back_ports, back_ips, back_ipv4_vlan_tag, back_ipv6_vlan_tag)
+			back_ports, back_ips, back_ipv4_vlan_tag,
+			back_ipv6_vlan_tag)
 		if ret < 0 then
 			error("Failed to initialize the back interface")
 		end


### PR DESCRIPTION
The original code assumes all RSS hash keys are 10 * 4 = 40 bytes. While this assumption has held well through the years, recent NICs have keys that are 13 * 4 = 52 bytes long. The length of RSS hash keys is always a multiple of 4 (i.e. `sizeof(uint32_t)`.

This pull request enables front and back interfaces to have different RSS hash keys of different lengths. However, if an interface is
bonded, all the keys of the ports must have the same length. Otherwise, there would not be a way to find the RSS hash of
a packet in software since there would be multiple values depending on where the packet arrived at the server.