### PR TITLE
lib/net: add support to the PMD i40e

### DIFF
--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -247,6 +247,25 @@ struct gatekeeper_if {
 	bool            guarantee_random_entropy;
 
 	/*
+	 * Some NICs do not support the RSS hash functions
+	 * ETH_RSS_IPV4 amd ETH_RSS_IPV6 (i.e. RSS hash for IPv4 or IPv6
+	 * non-fragmented packets).  But they may support the hash functions
+	 * ETH_RSS_NONFRAG_IPV4_TCP, ETH_RSS_NONFRAG_IPV4_UDP,
+	 * ETH_RSS_NONFRAG_IPV6_TCP, and ETH_RSS_NONFRAG_IPV6_UDP, and
+	 * setting the input set of the hash these hash functions.
+	 * An example of this behavior is the PMD i40e.
+	 *
+	 * Enabling the parameter below, Gatekeeper will try the alternative
+	 * RSS hash.
+	 *
+	 * Currently, this parameter only works for PMD i40e.
+	 *
+	 * If the interface is bonded, all ports in the bond must either
+	 * need this parameter disabled or enabled.
+	 */
+	bool            alternative_rss_hash;
+
+	/*
 	 * The fields below are for internal use.
 	 * Configuration files should not refer to them.
 	 */

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -284,6 +284,7 @@ struct gatekeeper_if {
 	bool     ipv6_hw_udp_cksum;
 	bool     ipv4_hw_cksum;
 	bool     guarantee_random_entropy;
+	bool     alternative_rss_hash;
 	/* This struct has hidden fields. */
 };
 

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -47,6 +47,8 @@ return function (gatekeeper_server)
 	local back_ipv6_hw_udp_cksum = true
 	local front_ipv4_hw_cksum = true
 	local back_ipv4_hw_cksum = true
+	local front_alternative_rss_hash = false
+	local back_alternative_rss_hash = false
 
 	--
 	-- End configuration of the network.
@@ -76,6 +78,7 @@ return function (gatekeeper_server)
 	front_iface.ipv6_hw_udp_cksum = front_ipv6_hw_udp_cksum
 	front_iface.ipv4_hw_cksum = front_ipv4_hw_cksum
 	front_iface.guarantee_random_entropy = guarantee_random_entropy
+	front_iface.alternative_rss_hash = front_alternative_rss_hash
 	local ret = staticlib.init_iface(front_iface, "front",
 		front_ports, front_ips, front_ipv4_vlan_tag,
 		front_ipv6_vlan_tag)
@@ -99,6 +102,7 @@ return function (gatekeeper_server)
 		back_iface.ipv6_hw_udp_cksum = back_ipv6_hw_udp_cksum
 		back_iface.ipv4_hw_cksum = back_ipv4_hw_cksum
 		back_iface.guarantee_random_entropy = guarantee_random_entropy
+		back_iface.alternative_rss_hash = back_alternative_rss_hash
 		ret = staticlib.init_iface(back_iface, "back",
 			back_ports, back_ips, back_ipv4_vlan_tag,
 			back_ipv6_vlan_tag)


### PR DESCRIPTION
The PMD i40e does not support the RSS hash functions `ETH_RSS_IPV4` and `ETH_RSS_IPV6` (i.e., RSS hash for IPv4 or IPv6 non-fragmented packets).  So Gatekeeper cannot work.

Nevertheless, i40e has an alternative way to set the needed RSS hash.  This patch adds the parameter `alternative_rss_hash` to `struct gatekeeper_if` to ask Gatekeeper to try this alternative hash.

The implemented solution is based on the reply to the question  [How to set up RSS hash fuction in XL710 to receive IPv4 flow type?](https://stackoverflow.com/questions/42342723/how-to-set-up-rss-hash-fuction-in-xl710-to-receive-ipv4-flow-type) on Stack Overflow.