### PR TITLE
gt: fix l_lpm_lookup() and l_lpm6_lookup()

### DIFF
--- a/gt/lua_lpm.c
+++ b/gt/lua_lpm.c
@@ -252,9 +252,7 @@ l_lpm_lookup(lua_State *l)
 	}
 
 	ret = fib_lookup(&lpm_ud->fib, (uint8_t *)&ip, &label);
-	if (ret < 0)
-		lua_pushinteger(l, ret);
-	lua_pushinteger(l, label);
+	lua_pushinteger(l, ret >= 0 ? (lua_Integer)label : ret);
 	return 1;
 }
 
@@ -505,9 +503,7 @@ l_lpm6_lookup(lua_State *l)
 	}
 
 	ret = fib_lookup(&lpm6_ud->fib, ipv6_addr->s6_addr, &label);
-	if (ret < 0)
-		lua_pushinteger(l, ret);
-	lua_pushinteger(l, label);
+	lua_pushinteger(l, ret >= 0 ? (lua_Integer)label : ret);
 	return 1;
 }
 


### PR DESCRIPTION
This commit makes `l_lpm_lookup()` and `l_lpm6_lookup()` report error codes.

This commit closes #632.