### PR TITLE
log: add log level to log entries

### DIFF
--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -34,7 +34,7 @@
 #include "list.h"
 
 #define BLOCK_LOGTYPE RTE_LOGTYPE_USER1
-#define G_LOG_PREFIX "%s/%u: "
+#define G_LOG_PREFIX "%s/%u: %s "
 
 #define G_LOG(level, fmt, ...)						\
 	do {								\
@@ -46,7 +46,8 @@
 			: "Main";					\
 		rte_log_ratelimit(RTE_LOG_ ## level, BLOCK_LOGTYPE,	\
 			G_LOG_PREFIX fmt, __g_log_block_name,		\
-			__g_log_lcore_id __VA_OPT__(,) __VA_ARGS__);	\
+			__g_log_lcore_id, #level			\
+			__VA_OPT__(,) __VA_ARGS__);			\
 	} while (0)
 
 #define G_LOG_CHECK(level) check_log_allowed(RTE_LOG_ ## level)

--- a/lib/log_ratelimit.c
+++ b/lib/log_ratelimit.c
@@ -50,7 +50,8 @@ log_ratelimit_reset(struct log_ratelimit_state *lrs, uint64_t now)
 	if (lrs->suppressed > 0) {
 		rte_log(RTE_LOG_NOTICE, BLOCK_LOGTYPE,
 			G_LOG_PREFIX "%u log entries were suppressed during the last ratelimit interval\n",
-			lrs->block_name, rte_lcore_id(), lrs->suppressed);
+			lrs->block_name, rte_lcore_id(), "NOTICE",
+			lrs->suppressed);
 	}
 	lrs->suppressed = 0;
 	lrs->end = now + lrs->interval_cycles;


### PR DESCRIPTION
Having the log level on each logged string enables network operators to quickly assess the gravity of log entries.

This commit closes #616.