### PR TITLE
lls: drop lls_req()

### DIFF
--- a/lls/cache.c
+++ b/lls/cache.c
@@ -573,9 +573,6 @@ lls_req(enum lls_req_ty ty, void *req_arg)
 	req->ty = ty;
 
 	switch (ty) {
-	case LLS_REQ_HOLD:
-		req->u.hold = *(struct lls_hold_req *)req_arg;
-		break;
 	case LLS_REQ_PUT:
 		req->u.put = *(struct lls_put_req *)req_arg;
 		break;

--- a/lls/cache.c
+++ b/lls/cache.c
@@ -558,60 +558,6 @@ lls_process_reqs(struct lls_config *lls_conf)
 	return count;
 }
 
-int
-lls_req(enum lls_req_ty ty, void *req_arg)
-{
-	struct lls_config *lls_conf = get_lls_conf();
-	struct lls_request *req = mb_alloc_entry(&lls_conf->requests);
-	int ret;
-
-	if (req == NULL) {
-		G_LOG(ERR, "Allocation for request of type %d failed", ty);
-		return -1;
-	}
-
-	req->ty = ty;
-
-	switch (ty) {
-	case LLS_REQ_PUT:
-		req->u.put = *(struct lls_put_req *)req_arg;
-		break;
-	case LLS_REQ_ARP: {
-		struct lls_arp_req *arp_req = (struct lls_arp_req *)req_arg;
-		req->u.arp = *arp_req;
-		rte_memcpy(req->u.arp.pkts, arp_req->pkts,
-			sizeof(arp_req->pkts[0]) * arp_req->num_pkts);
-		break;
-	}
-	case LLS_REQ_ICMP: {
-		struct lls_icmp_req *icmp_req =
-			(struct lls_icmp_req *)req_arg;
-		req->u.icmp = *icmp_req;
-		rte_memcpy(req->u.icmp.pkts, icmp_req->pkts,
-			sizeof(icmp_req->pkts[0]) * icmp_req->num_pkts);
-		break;
-	}
-	case LLS_REQ_ICMP6: {
-		struct lls_icmp6_req *icmp6_req =
-			(struct lls_icmp6_req *)req_arg;
-		req->u.icmp6 = *icmp6_req;
-		rte_memcpy(req->u.icmp6.pkts, icmp6_req->pkts,
-			sizeof(icmp6_req->pkts[0]) * icmp6_req->num_pkts);
-		break;
-	}
-	default:
-		mb_free_entry(&lls_conf->requests, req);
-		G_LOG(ERR, "Unknown request type %d failed", ty);
-		return -1;
-	}
-
-	ret = mb_send_entry(&lls_conf->requests, req);
-	if (ret < 0)
-		return ret;
-
-	return 0;
-}
-
 struct lls_map *
 lls_cache_get(struct lls_cache *cache, const struct ipaddr *addr)
 {

--- a/lls/cache.h
+++ b/lls/cache.h
@@ -146,12 +146,6 @@ void lls_cache_destroy(struct lls_cache *cache);
 unsigned int lls_process_reqs(struct lls_config *lls_conf);
 
 /*
- * Submit a request to the LLS block, where @req_arg is one of the
- * the members of the union in struct lls_request that matches @ty.
- */
-int lls_req(enum lls_req_ty ty, void *req_arg);
-
-/*
  * Modify a cache entry without going through the mailbox.
  *
  * NOTE


### PR DESCRIPTION
This pull request addresses issue #288. `lls_req()` has no sister functions at the time of this pull request because they have been eliminated as the code evolved.

This pull request closes #288.