### PR TITLE
dpdk: update branch for Gatekeeper v1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dependencies/dpdk"]
 	path = dependencies/dpdk
 	url = https://github.com/cjdoucette/dpdk
-	branch = gatekeeper-dpdk
+	branch = gkv1.2
 [submodule "dependencies/luajit-2.0"]
 	path = dependencies/luajit-2.0
 	url = https://github.com/AltraMayor/luajit.git


### PR DESCRIPTION
This new branch for Gatekeeper v1.2 drops patches that are no longer needed, and adds a fix for the ICE driver. More information on the ICE driver is available on issue #634.