### PR TITLE
log: add date and time to log entries

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -2551,45 +2551,11 @@ next_flow_index(struct gk_config *gk_conf, struct gk_instance *instance)
 	return instance->scan_cur_flow_idx;
 }
 
-static void
-log_stats(const struct gk_config *gk_conf,
-	const struct gk_instance *instance,
+static inline void
+log_stats(const struct gk_config *gk_conf, const struct gk_instance *instance,
 	const struct gk_measurement_metrics *stats)
 {
-	time_t now = time(NULL);
-	struct tm *p_tm, time_info;
-	char str_date_time[32];
-	int ret;
-
-	if (unlikely(now == ((time_t) -1))) {
-		G_LOG(ERR, "%s(): time() failed with errno=%i: %s\n",
-			__func__, errno, strerror(errno));
-		goto log_no_time;
-	}
-
-	p_tm = localtime_r(&now, &time_info);
-	if (unlikely(p_tm == NULL)) {
-		G_LOG(ERR, "%s(): localtime_r() failed with errno=%i: %s\n",
-			__func__, errno, strerror(errno));
-		goto log_no_time;
-	}
-	RTE_VERIFY(p_tm == &time_info);
-
-	ret = strftime(str_date_time, sizeof(str_date_time),
-		"%Y-%m-%d %H:%M:%S", &time_info);
-	if (unlikely(ret == 0)) {
-		G_LOG(ERR, "%s(): strftime() failed\n", __func__);
-		goto log_no_time;
-	}
-
-	goto log;
-
-log_no_time:
-	strcpy(str_date_time, "NO TIME");
-log:
-	G_LOG(NOTICE,
-		"Basic measurements at %s [tot_pkts_num = %"PRIu64", tot_pkts_size = %"PRIu64", pkts_num_granted = %"PRIu64", pkts_size_granted = %"PRIu64", pkts_num_request = %"PRIu64", pkts_size_request = %"PRIu64", pkts_num_declined = %"PRIu64", pkts_size_declined = %"PRIu64", tot_pkts_num_dropped = %"PRIu64", tot_pkts_size_dropped = %"PRIu64", tot_pkts_num_distributed = %"PRIu64", tot_pkts_size_distributed = %"PRIu64", flow_table_occupancy = %"PRIu32"/%u=%.1f%%]\n",
-		str_date_time,
+	G_LOG(NOTICE, "Basic measurements [tot_pkts_num = %"PRIu64", tot_pkts_size = %"PRIu64", pkts_num_granted = %"PRIu64", pkts_size_granted = %"PRIu64", pkts_num_request = %"PRIu64", pkts_size_request = %"PRIu64", pkts_num_declined = %"PRIu64", pkts_size_declined = %"PRIu64", tot_pkts_num_dropped = %"PRIu64", tot_pkts_size_dropped = %"PRIu64", tot_pkts_num_distributed = %"PRIu64", tot_pkts_size_distributed = %"PRIu64", flow_table_occupancy = %"PRIu32"/%u=%.1f%%]\n",
 		stats->tot_pkts_num,
 		stats->tot_pkts_size,
 		stats->pkts_num_granted,
@@ -2604,8 +2570,7 @@ log:
 		stats->tot_pkts_size_distributed,
 		instance->ip_flow_ht_num_items,
 		gk_conf->flow_ht_size,
-		100.0 * instance->ip_flow_ht_num_items /
-			gk_conf->flow_ht_size);
+		100.0 * instance->ip_flow_ht_num_items / gk_conf->flow_ht_size);
 }
 
 static int

--- a/include/gatekeeper_log_ratelimit.h
+++ b/include/gatekeeper_log_ratelimit.h
@@ -97,6 +97,8 @@ struct log_ratelimit_state {
 	uint64_t       end;
 	rte_atomic32_t log_level;
 	char           block_name[16];
+	char           str_date_time[32];
+	uint64_t       update_time_at;
 } __rte_cache_aligned;
 
 /* Only use these variables in file lib/log_ratelimit.c and in macro G_LOG(). */

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -54,8 +54,11 @@
 
 extern volatile int exiting;
 
+#define ONE_SEC_IN_NANO_SEC (1000000000L)
+
 extern uint64_t cycles_per_sec;
 extern uint64_t cycles_per_ms;
+extern double   cycles_per_ns;
 extern uint64_t picosec_per_cycle;
 
 extern FILE *log_file;

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -34,19 +34,21 @@
 #include "list.h"
 
 #define BLOCK_LOGTYPE RTE_LOGTYPE_USER1
-#define G_LOG_PREFIX "%s/%u: %s "
+#define G_LOG_PREFIX "%s/%u %s %s "
 
 #define G_LOG(level, fmt, ...)						\
 	do {								\
 		unsigned int __g_log_lcore_id = rte_lcore_id();		\
-		const char *__g_log_block_name =			\
-			likely(log_ratelimit_enabled)			\
-			? log_ratelimit_states[__g_log_lcore_id]	\
-				.block_name				\
-			: "Main";					\
+		const struct log_ratelimit_state *__g_log_lrs =		\
+			&log_ratelimit_states[__g_log_lcore_id];	\
 		rte_log_ratelimit(RTE_LOG_ ## level, BLOCK_LOGTYPE,	\
-			G_LOG_PREFIX fmt, __g_log_block_name,		\
-			__g_log_lcore_id, #level			\
+			G_LOG_PREFIX fmt,				\
+			likely(log_ratelimit_enabled)			\
+				? __g_log_lrs->block_name		\
+				: "Main",				\
+			__g_log_lcore_id,				\
+			__g_log_lrs->str_date_time,			\
+			#level						\
 			__VA_OPT__(,) __VA_ARGS__);			\
 	} while (0)
 

--- a/main/main.c
+++ b/main/main.c
@@ -50,6 +50,7 @@ volatile int exiting = false;
  */
 uint64_t cycles_per_sec;
 uint64_t cycles_per_ms;
+double   cycles_per_ns;
 uint64_t picosec_per_cycle;
 
 const char *log_file_name_format;
@@ -267,23 +268,24 @@ time_resolution_init(void)
 		if (ret < 0)
 			return ret;
 
-		diff_ns = (uint64_t)(tp_now.tv_sec - tp_start.tv_sec) * 1000000000UL 
-				+ (uint64_t)(tp_now.tv_nsec - tp_start.tv_nsec);
+		diff_ns = (uint64_t)(tp_now.tv_sec - tp_start.tv_sec) *
+				ONE_SEC_IN_NANO_SEC
+			+ (tp_now.tv_nsec - tp_start.tv_nsec);
 
-		if (diff_ns >= 1000000000UL) {
+		if (diff_ns >= ONE_SEC_IN_NANO_SEC) {
 			cycles = tsc_now - tsc_start;
 			break;
 		}
 	}
 
-	cycles_per_sec = cycles * 1000000000UL / diff_ns;
-	cycles_per_ms = cycles_per_sec / 1000UL;
-	picosec_per_cycle = 1000UL * diff_ns / cycles;
+	cycles_per_sec = cycles * ONE_SEC_IN_NANO_SEC / diff_ns;
+	cycles_per_ms = cycles_per_sec / 1000;
+	cycles_per_ns = (typeof(cycles_per_ns))cycles / diff_ns;
+	picosec_per_cycle = 1000 * diff_ns / cycles;
 
-	G_LOG(NOTICE,
-		"cycles/second = %" PRIu64 ", cycles/millisecond = %" PRIu64 ", picosec/cycle = %" PRIu64 "\n",
-		cycles_per_sec, cycles_per_ms, picosec_per_cycle);
-
+	G_LOG(NOTICE, "cycles/second = %" PRIu64 ", cycles/millisecond = %" PRIu64 ", cycles/nanoseconds = %f, picosec/cycle = %" PRIu64 "\n",
+		cycles_per_sec, cycles_per_ms, cycles_per_ns,
+		picosec_per_cycle);
 	return 0;
 }
 


### PR DESCRIPTION
Adding date and time to log entries helps one to investigate bugs during development and issues in production.

This commit closes #615