### PR TITLE
dpdk: update branch for Gatekeeper v1.2

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -27,7 +27,8 @@ jobs:
         libhugetlbfs-bin build-essential gcc-multilib linux-headers-`uname -r`
         libmnl0 libmnl-dev libkmod2 libkmod-dev libnuma-dev libelf1 libelf-dev
         libc6-dev-i386 autoconf flex bison libncurses5-dev libreadline-dev
-        python libcap-dev libcap2 meson ninja-build pkg-config
+        python python3-pyelftools libcap-dev libcap2 meson ninja-build
+        pkg-config
 
     - name: Setup Gatekeeper
       run: sudo ./setup.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dependencies/dpdk"]
 	path = dependencies/dpdk
 	url = https://github.com/cjdoucette/dpdk
-	branch = gkv1.2
+	branch = gkv1.2b
 [submodule "dependencies/luajit-2.0"]
 	path = dependencies/luajit-2.0
 	url = https://github.com/AltraMayor/luajit.git

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ the folder `bpf/`.
 The `autoconf`, `flex`, `bison`, `libncurses5-dev`, and
 `libreadline-dev` packages are for BIRD. The `devscripts` package is used to
 build Gatekeeper Debian packages.
-`python` is needed to be able to run the `dpdk-devbind.py` script.
+The packages `python` and `python3-pyelftools` are needed to build DPDK and to
+run Python scripts such as `dpdk-devbind.py`.
 `libcap-dev` is needed to compile Gatekeeper, but only `libcap2` is needed
 to run Gatekeeper.
 `meson` and `ninja-build` are needed for building DPDK.


### PR DESCRIPTION
This new branch for Gatekeeper v1.2 is based on DPDK v21.05. The motivation for this new branch is to solve the LACP disconnect bug (see [the DPDK commit](https://github.com/DPDK/dpdk/commit/fad80ab3698e7f7d3e9c2a28c371da6a17fbc477)).
DPDK v21.05 is the first DPDK release to include the referred commit.

This commit also adds the package `python3-pyelftools` as a dependency.