### PR TITLE
gatekeeper: rewrite initialization of network interfaces

### DIFF
--- a/gk/main.c
+++ b/gk/main.c
@@ -2541,9 +2541,13 @@ gk_stage1(void *arg)
 
 	num_mbuf = calculate_mempool_config_para("gk", gk_conf->net,
 		gk_conf->front_max_pkt_burst + gk_conf->back_max_pkt_burst +
+		/*
+		 * One cannot divide the sum below per gk_conf->num_lcores
+		 * because, though unlikely, it might happen that
+		 * all packets go to a single instance.
+		 */
 		(gk_conf->net->front.total_pkt_burst +
-		gk_conf->net->back.total_pkt_burst + gk_conf->num_lcores - 1) /
-		gk_conf->num_lcores);
+		gk_conf->net->back.total_pkt_burst));
 
 	sol_conf = gk_conf->sol_conf;
 	for (i = 0; i < gk_conf->num_lcores; i++) {

--- a/gt/main.c
+++ b/gt/main.c
@@ -2067,8 +2067,12 @@ init_gt_instances(struct gt_config *gt_conf)
 		gt_conf->net, gt_conf->max_pkt_burst +
 		gt_conf->frag_max_entries + gt_conf->max_pkt_burst +
 		gt_conf->max_ggu_notify_pkts +
-		(gt_conf->net->front.total_pkt_burst +
-		gt_conf->num_lcores - 1) / gt_conf->num_lcores);
+		/*
+		 * One cannot divide the sum below per gt_conf->num_lcores
+		 * because, though unlikely, it might happen that
+		 * all packets go to a single instance.
+		 */
+		gt_conf->net->front.total_pkt_burst);
 
 	/* Set up queue identifiers now for RSS, before instances start. */
 	for (i = 0; i < gt_conf->num_lcores; i++) {

--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -35,24 +35,37 @@
 
 #define BLOCK_LOGTYPE RTE_LOGTYPE_USER1
 #define G_LOG_PREFIX "%s/%u %s %s "
+#define G_LOG_MAIN "Main"
 
 #define G_LOG(level, fmt, ...)						\
 	do {								\
 		unsigned int __g_log_lcore_id = rte_lcore_id();		\
-		const struct log_ratelimit_state *__g_log_lrs =		\
-			&log_ratelimit_states[__g_log_lcore_id];	\
-		rte_log_ratelimit(RTE_LOG_ ## level, BLOCK_LOGTYPE,	\
-			G_LOG_PREFIX fmt,				\
+		gatekeeper_log_ratelimit(RTE_LOG_ ## level,		\
+			BLOCK_LOGTYPE,	G_LOG_PREFIX fmt,		\
 			likely(log_ratelimit_enabled)			\
-				? __g_log_lrs->block_name		\
-				: "Main",				\
+				? log_ratelimit_states[__g_log_lcore_id]\
+					.block_name			\
+				: G_LOG_MAIN,				\
 			__g_log_lcore_id,				\
-			__g_log_lrs->str_date_time,			\
+			RTE_PER_LCORE(_log_thread_time).str_date_time,	\
 			#level						\
 			__VA_OPT__(,) __VA_ARGS__);			\
 	} while (0)
 
 #define G_LOG_CHECK(level) check_log_allowed(RTE_LOG_ ## level)
+
+/*
+ * This macro should only be called in contexts other than logical cores
+ * because it is independent of functional blocks and is not rate limited.
+ *
+ * From logical cores, call G_LOG().
+ */
+#define MAIN_LOG(level, fmt, ...)					\
+	gatekeeper_log_main(RTE_LOG_ ## level, BLOCK_LOGTYPE,		\
+		G_LOG_PREFIX fmt, G_LOG_MAIN, rte_gettid(),		\
+		RTE_PER_LCORE(_log_thread_time).str_date_time,		\
+		#level							\
+		__VA_OPT__(,) __VA_ARGS__)
 
 extern volatile int exiting;
 

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -481,7 +481,7 @@ struct net_config {
 
 /* Call lacp_enabled() instead this function wherever possible. */
 static inline int
-__lacp_enabled(struct gatekeeper_if *iface)
+__lacp_enabled(const struct gatekeeper_if *iface)
 {
 	return	iface->bonding_mode == BONDING_MODE_8023AD;
 }

--- a/include/gatekeeper_net.h
+++ b/include/gatekeeper_net.h
@@ -431,12 +431,6 @@ struct net_config {
 	int                  back_iface_enabled;
 
 	/*
-	 * Number of attempts to wait for Gatekeeper links to
-	 * come up during initialization.
-	 */
-	unsigned int         num_attempts_link_get;
-
-	/*
 	 * The NUMA nodes used in the host. Element i is true
 	 * if NUMA node i is being used; otherwise it is false.
 	 */

--- a/include/gatekeeper_sol.h
+++ b/include/gatekeeper_sol.h
@@ -102,13 +102,6 @@ struct sol_config {
 	/* Maximum number of requests to store in priority queue at once. */
 	unsigned int        pri_req_max_len;
 
-	/*
-	 * Bandwidth limit for the priority queue of requests,
-	 * as a percentage of the capacity of the link. Must
-	 * be > 0 and < 1.
-	 */
-	double              req_bw_rate;
-
 	/* Maximum request enqueue/dequeue size. */
 	unsigned int        enq_burst_size;
 	unsigned int        deq_burst_size;

--- a/include/list.h
+++ b/include/list.h
@@ -41,6 +41,12 @@ INIT_LIST_HEAD(struct list_head *list)
 	list->prev = list;
 }
 
+static inline int
+list_initiated(const struct list_head *head)
+{
+	return head->next != NULL && head->prev != NULL;
+}
+
 /**
  * list_entry - get the struct for this entry
  * @ptr:	the &struct list_head pointer.

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -414,7 +414,6 @@ struct dynamic_config {
 
 struct sol_config {
 	unsigned int pri_req_max_len;
-	double       req_bw_rate;
 	unsigned int enq_burst_size;
 	unsigned int deq_burst_size;
 	double       tb_rate_approx_err;

--- a/lua/gatekeeper/staticlib.lua
+++ b/lua/gatekeeper/staticlib.lua
@@ -290,7 +290,6 @@ struct gatekeeper_if {
 
 struct net_config {
 	int          back_iface_enabled;
-	unsigned int num_attempts_link_get;
 	bool         *numa_used;
 	uint32_t     log_level;
 	uint32_t     rotate_log_interval_sec;

--- a/lua/net.lua
+++ b/lua/net.lua
@@ -37,7 +37,6 @@ return function (gatekeeper_server)
 
 	-- These variables are unlikely to need to be changed.
 	local guarantee_random_entropy = false
-	local num_attempts_link_get = 5
 	local front_ipv6_default_hop_limits = 255
 	local back_ipv6_default_hop_limits = 255
 	local rotate_log_interval_sec = 60 * 60  -- (1 hour)
@@ -55,7 +54,6 @@ return function (gatekeeper_server)
 	--
 
 	local net_conf = staticlib.c.get_net_conf()
-	net_conf.num_attempts_link_get = num_attempts_link_get
 	net_conf.log_level = log_level
 	net_conf.rotate_log_interval_sec = rotate_log_interval_sec
 

--- a/lua/sol.lua
+++ b/lua/sol.lua
@@ -6,6 +6,7 @@ return function (net_conf, sol_lcores)
 
 	-- These parameters should likely be initially changed.
 	local log_level = staticlib.c.RTE_LOG_DEBUG
+	local destination_bw_gbps = 1
 
 	-- XXX #155 These parameters should only be changed for performance reasons.
 	local log_ratelimit_interval_ms = 5000
@@ -17,7 +18,6 @@ return function (net_conf, sol_lcores)
 
 	-- These variables are unlikely to need to be changed.
 	local tb_rate_approx_err = 1e-7
-	local req_channel_bw_mbps = 0.0
 
 	--
 	-- End configuration of SOL block.
@@ -35,12 +35,11 @@ return function (net_conf, sol_lcores)
 	sol_conf.log_ratelimit_interval_ms = log_ratelimit_interval_ms
 	sol_conf.log_ratelimit_burst = log_ratelimit_burst
 	sol_conf.pri_req_max_len = pri_req_max_len
-	sol_conf.req_bw_rate = req_bw_rate
 	sol_conf.enq_burst_size = enq_burst_size
 	sol_conf.deq_burst_size = deq_burst_size
 
 	sol_conf.tb_rate_approx_err = tb_rate_approx_err
-	sol_conf.req_channel_bw_mbps = req_channel_bw_mbps
+	sol_conf.req_channel_bw_mbps = destination_bw_gbps * 1000 * req_bw_rate
 
 	local ret = staticlib.c.run_sol(net_conf, sol_conf)
 	if ret < 0 then

--- a/sol/main.c
+++ b/sol/main.c
@@ -368,53 +368,12 @@ mbits_to_bytes(double mbps)
 }
 
 /*
- * Retrieve the link speed of a Gatekeeper interface. If it
- * is a bonded interface, the link speeds are summed.
- */
-static int
-iface_speed_bytes(struct gatekeeper_if *iface, uint64_t *link_speed_bytes)
-{
-	uint64_t link_speed_mbits = 0;
-	uint8_t i;
-	int ret;
-
-	RTE_VERIFY(link_speed_bytes != NULL);
-
-	for (i = 0; i < iface->num_ports; i++) {
-		struct rte_eth_link link;
-		ret = rte_eth_link_get(iface->ports[i], &link);
-		if (ret < 0) {
-			G_LOG(ERR, "net: querying port %hhu failed with err - %s\n",
-				iface->ports[i], rte_strerror(-ret));
-			goto err;
-		}
-
-		if (link.link_speed == RTE_ETH_SPEED_NUM_NONE ||
-				link.link_speed == RTE_ETH_SPEED_NUM_UNKNOWN) {
-			ret = -ENOTSUP;
-			goto err;
-		}
-
-		link_speed_mbits += link.link_speed;
-	}
-
-	/* Convert to bytes per second. */
-	*link_speed_bytes = mbits_to_bytes(link_speed_mbits);
-	return 0;
-
-err:
-	*link_speed_bytes = 0;
-	return ret;
-}
-
-/*
  * @sol_conf is allocated using rte_calloc_socket(), so initializations
  * to 0 are not strictly necessary in this function.
  */
 static int
 req_queue_init(struct sol_config *sol_conf)
 {
-	uint64_t link_speed_bytes;
 	double max_credit_bytes_precise;
 	double cycles_per_byte_precise;
 	uint64_t cycles_per_byte_floor;
@@ -422,24 +381,9 @@ req_queue_init(struct sol_config *sol_conf)
 	uint32_t a, b;
 	int ret, i;
 
-	/* Find link speed in bytes, even for a bonded interface. */
-	ret = iface_speed_bytes(&sol_conf->net->back, &link_speed_bytes);
-	if (ret == 0) {
-		G_LOG(NOTICE,
-			"Back interface link speed: %"PRIu64" bytes per second\n",
-			link_speed_bytes);
-		/* Keep max number of bytes a float for later calculations. */
-		max_credit_bytes_precise =
-			sol_conf->req_bw_rate * link_speed_bytes;
-	} else {
-		G_LOG(NOTICE, "Back interface link speed: undefined\n");
-		if (sol_conf->req_channel_bw_mbps <= 0) {
-			G_LOG(ERR, "When link speed on back interface is undefined, parameter req_channel_bw_mbps must be calculated and defined\n");
-			return -1;
-		}
-		max_credit_bytes_precise =
-			mbits_to_bytes(sol_conf->req_channel_bw_mbps);
-	}
+	/* Convert to bytes per second. */
+	max_credit_bytes_precise =
+		mbits_to_bytes(sol_conf->req_channel_bw_mbps);
 
 	max_credit_bytes_precise /= sol_conf->num_lcores;
 
@@ -459,15 +403,16 @@ req_queue_init(struct sol_config *sol_conf)
 		cycles_per_byte_precise - cycles_per_byte_floor,
 		sol_conf->tb_rate_approx_err, &a, &b);
 	if (ret < 0) {
-		G_LOG(ERR, "Could not approximate the request queue's allocated bandwidth\n");
+		G_LOG(ERR, "%s(): could not approximate the request queue's allocated bandwidth\n",
+			__func__);
 		return ret;
 	}
 
 	/* Add integer number of cycles per byte to numerator. */
 	a += cycles_per_byte_floor * b;
 
-	G_LOG(NOTICE, "Cycles per byte (%f) represented as a rational: %u / %u\n",
-		cycles_per_byte_precise, a, b);
+	G_LOG(NOTICE, "%s(): cycles per byte (%f) represented as a rational: %u / %u\n",
+		__func__, cycles_per_byte_precise, a, b);
 
 	now = rte_rdtsc();
 
@@ -665,8 +610,10 @@ run_sol(struct net_config *net_conf, struct sol_config *sol_conf)
 	int ret, i;
 	uint16_t front_inc;
 
-	if (net_conf == NULL || sol_conf == NULL) {
-		ret = -1;
+	if (unlikely(net_conf == NULL || sol_conf == NULL)) {
+		G_LOG(ERR, "%s(): net_conf = %p or sol_conf = %p cannot be NULL\n",
+			__func__, net_conf, sol_conf);
+		ret = -EINVAL;
 		goto out;
 	}
 
@@ -677,50 +624,50 @@ run_sol(struct net_config *net_conf, struct sol_config *sol_conf)
 			sol_conf->log_level, "SOL");
 	}
 
-	if (!net_conf->back_iface_enabled) {
-		G_LOG(ERR, "Back interface is required\n");
-		ret = -1;
+	if (unlikely(!net_conf->back_iface_enabled)) {
+		G_LOG(ERR, "%s(): back interface is required\n", __func__);
+		ret = -EINVAL;
 		goto out;
 	}
 
-	if (sol_conf->pri_req_max_len == 0) {
-		G_LOG(ERR,
-			"Priority queue max len must be greater than 0\n");
-		ret = -1;
+	if (unlikely(sol_conf->pri_req_max_len == 0)) {
+		G_LOG(ERR, "%s(): the parameter pri_req_max_len = %u must be greater than 0\n",
+			__func__, sol_conf->pri_req_max_len);
+		ret = -EINVAL;
 		goto out;
 	}
 
-	if (sol_conf->enq_burst_size == 0 || sol_conf->deq_burst_size == 0) {
-		G_LOG(ERR, "Priority queue enqueue and dequeue sizes must both be greater than 0\n");
-		ret = -1;
+	if (unlikely(sol_conf->enq_burst_size == 0 ||
+			sol_conf->deq_burst_size == 0)) {
+		G_LOG(ERR, "%s(): the paramters enq_burst_size = %u and deq_burst_size = %u must both be greater than 0\n",
+			__func__, sol_conf->enq_burst_size,
+			sol_conf->deq_burst_size);
+		ret = -EINVAL;
 		goto out;
 	}
 
-	if (sol_conf->deq_burst_size > sol_conf->pri_req_max_len ||
-			sol_conf->enq_burst_size > sol_conf->pri_req_max_len) {
-		G_LOG(ERR, "Request queue enqueue and dequeue sizes must be less than the max length of the request queue\n");
-		ret = -1;
+	if (unlikely(sol_conf->enq_burst_size > sol_conf->pri_req_max_len ||
+			sol_conf->deq_burst_size > sol_conf->pri_req_max_len)) {
+		G_LOG(ERR, "%s(): the paramters enq_burst_size = %u and deq_burst_size = %u must both be less than or equal to the parameter pri_req_max_len = %u\n",
+			__func__, sol_conf->enq_burst_size,
+			sol_conf->deq_burst_size, sol_conf->pri_req_max_len);
+		ret = -EINVAL;
 		goto out;
 	}
 
-	if (sol_conf->req_bw_rate <= 0 || sol_conf->req_bw_rate >= 1) {
-		G_LOG(ERR,
-			"Request queue bandwidth must be in range (0, 1), but it has been specified as %f\n",
-			sol_conf->req_bw_rate);
-		ret = -1;
+	if (unlikely(sol_conf->req_channel_bw_mbps <= 0)) {
+		G_LOG(ERR, "%s(): the parameter req_channel_bw_mbps = %f must be greater than 0\n",
+			__func__, sol_conf->req_channel_bw_mbps);
+		ret = -EINVAL;
 		goto out;
 	}
 
-	if (sol_conf->req_channel_bw_mbps < 0) {
-		G_LOG(ERR,
-			"Request channel bandwidth in Mbps must be greater than 0 when the NIC doesn't supply guaranteed bandwidth, but is %f\n",
-			sol_conf->req_channel_bw_mbps);
-		ret = -1;
+	if (unlikely(sol_conf->num_lcores <= 0)) {
+		G_LOG(ERR, "%s(): the parameter num_lcores = %i must be greater than 0\n",
+			__func__, sol_conf->num_lcores);
+		ret = -EINVAL;
 		goto out;
 	}
-
-	if (sol_conf->num_lcores <= 0)
-		goto success;
 
 	/*
 	 * Need to account for the packets in the following scenarios:
@@ -758,8 +705,8 @@ run_sol(struct net_config *net_conf, struct sol_config *sol_conf)
 	}
 
 	sol_conf->net = net_conf;
-
-	goto success;
+	rte_atomic32_init(&sol_conf->ref_cnt);
+	return 0;
 
 stage2:
 	pop_n_at_stage2(1);
@@ -769,10 +716,6 @@ burst:
 	net_conf->front.total_pkt_burst -= front_inc;
 out:
 	return ret;
-
-success:
-	rte_atomic32_init(&sol_conf->ref_cnt);
-	return 0;
 }
 
 /*


### PR DESCRIPTION
The original version of the bonding driver required applications to set many parameters of the members of a bonded interface directly. This is no longer the case, and this pull request reviews the initialization code of network interfaces to accomplish the following:
1. Simplifying the initialization code by leveraging the current bonding driver;
2. Fixing a LACP bug when a bonded interface has two or more physical interfaces and all support multicast;
3. Improving transmission capacity of bonded interfaces by adding IPv4 and IPv6 addresses into the balancing hash;
4. Reporting MAC addresses of the interfaces to enable diagnoses;
5. Monitoring the state of the links through interruptions;
6. Updating the calculation of the bandwidth of the request channel;
7. Fixing miscalculations in the size of mbuf pools.