### PR TITLE
log: merge MAIN_LOG() into G_LOG()

### DIFF
--- a/include/gatekeeper_main.h
+++ b/include/gatekeeper_main.h
@@ -34,38 +34,17 @@
 #include "list.h"
 
 #define BLOCK_LOGTYPE RTE_LOGTYPE_USER1
-#define G_LOG_PREFIX "%s/%u %s %s "
-#define G_LOG_MAIN "Main"
+#define G_LOG_PREFIX "%s %s %s "
 
 #define G_LOG(level, fmt, ...)						\
-	do {								\
-		unsigned int __g_log_lcore_id = rte_lcore_id();		\
-		gatekeeper_log_ratelimit(RTE_LOG_ ## level,		\
-			BLOCK_LOGTYPE,	G_LOG_PREFIX fmt,		\
-			likely(log_ratelimit_enabled)			\
-				? log_ratelimit_states[__g_log_lcore_id]\
-					.block_name			\
-				: G_LOG_MAIN,				\
-			__g_log_lcore_id,				\
-			RTE_PER_LCORE(_log_thread_time).str_date_time,	\
-			#level						\
-			__VA_OPT__(,) __VA_ARGS__);			\
-	} while (0)
+	gatekeeper_log_ratelimit(RTE_LOG_ ## level, BLOCK_LOGTYPE,	\
+		G_LOG_PREFIX fmt,					\
+		RTE_PER_LCORE(_log_thread_info).thread_name,		\
+		RTE_PER_LCORE(_log_thread_info).str_date_time,		\
+		#level							\
+		__VA_OPT__(,) __VA_ARGS__)				\
 
 #define G_LOG_CHECK(level) check_log_allowed(RTE_LOG_ ## level)
-
-/*
- * This macro should only be called in contexts other than logical cores
- * because it is independent of functional blocks and is not rate limited.
- *
- * From logical cores, call G_LOG().
- */
-#define MAIN_LOG(level, fmt, ...)					\
-	gatekeeper_log_main(RTE_LOG_ ## level, BLOCK_LOGTYPE,		\
-		G_LOG_PREFIX fmt, G_LOG_MAIN, rte_gettid(),		\
-		RTE_PER_LCORE(_log_thread_time).str_date_time,		\
-		#level							\
-		__VA_OPT__(,) __VA_ARGS__)
 
 extern volatile int exiting;
 


### PR DESCRIPTION
This commit drops `MAIN_LOG()` and makes calling `G_LOG()` in non-lcore contexts safe because it is very error prone to identify when one should use `MAIN_LOG()` instead of `G_LOG()`. For example, `lib/net.c:lsc_event_callback()`, which runs in a non-lcore context, calls `log_if_name()`. But `log_if_name()` uses `G_LOG()` because it is also called in lcore contexts.